### PR TITLE
fix: Divider block settings

### DIFF
--- a/packages/divider-block/src/settings.ts
+++ b/packages/divider-block/src/settings.ts
@@ -146,7 +146,7 @@ const Settings: ApiSettings = {
                 const dividerHeightKey = (Object.keys(dividerHeight) as Array<DividerHeight>).find(
                     (key) => dividerHeight[key] === customValue
                 );
-                if (sliderValue && dividerHeightKey) {
+                if ((sliderValue && dividerHeightKey) || (sliderValue && !customValue)) {
                     bundle.setBlockValue(HEIGHT_CUSTOM_ID, dividerHeight[sliderValue]);
                 }
             },


### PR DESCRIPTION
This PR fixes the (hopefully) last two issues on the Divider block: https://app.clickup.com/t/ndbnnb

- Alignment setting doesn't need to be there when 100% width is selected
- Vertical line position/alignment changes undesirably when user selects Custom for height