### PR TITLE
fix(Divider block): Show alignment when custom width is selected

### DIFF
--- a/packages/divider-block/src/settings.ts
+++ b/packages/divider-block/src/settings.ts
@@ -42,7 +42,8 @@ export const COLOR_DEFAULT_RGBA_VALUE = {
 
 const solidStyleIsSelected = (bundle: ApiBundle): boolean => bundle.getBlock(IS_LINE_ID)?.value === DividerStyle.Solid;
 const limitedWidthIsSelected = (bundle: ApiBundle): boolean =>
-    bundle.getBlock(WIDTH_SIMPLE_ID)?.value !== DividerWidth['100%'];
+    bundle.getBlock(WIDTH_SIMPLE_ID)?.value !== DividerWidth['100%'] &&
+    bundle.getBlock(WIDTH_CUSTOM_ID)?.value !== '100%';
 
 const Settings: ApiSettings = {
     main: [


### PR DESCRIPTION
Show alignment settings also when custom width is anything else than `100%`