### PR TITLE
fix(dos-donts): fix column slider accessibility

### DIFF
--- a/packages/dos-donts-block/src/DosDontsBlock.tsx
+++ b/packages/dos-donts-block/src/DosDontsBlock.tsx
@@ -24,7 +24,7 @@ export const DosDontsBlock: FC<DosDontsBlockProps> = ({ appBridge }) => {
 
     const {
         items = [],
-        columns = 2,
+        columns = '2',
         isCustomSpacing = false,
         spacingValue = '',
         doColor = DO_COLOR_DEFAULT_VALUE,
@@ -59,7 +59,7 @@ export const DosDontsBlock: FC<DosDontsBlockProps> = ({ appBridge }) => {
         });
     };
 
-    useEffect(() => setItems(layout === DoDontLayout.Stacked ? columns * 2 : 2), [layout, columns]);
+    useEffect(() => setItems(layout === DoDontLayout.Stacked ? +columns * 2 : 2), [layout, columns]);
 
     return (
         <div

--- a/packages/dos-donts-block/src/settings.ts
+++ b/packages/dos-donts-block/src/settings.ts
@@ -59,22 +59,22 @@ const settings: ApiSettings = {
             label: 'Columns',
             type: 'slider',
             show: (bundle: ApiBundle) => bundle.getBlock('layout')?.value === DoDontLayout.Stacked,
-            defaultValue: 2,
+            defaultValue: '2',
             choices: [
                 {
-                    value: 1,
+                    value: '1',
                     label: '1',
                 },
                 {
-                    value: 2,
+                    value: '2',
                     label: '2',
                 },
                 {
-                    value: 3,
+                    value: '3',
                     label: '3',
                 },
                 {
-                    value: 4,
+                    value: '4',
                     label: '4',
                 },
             ],


### PR DESCRIPTION
Fix for issue: https://app.clickup.com/t/1vhxc2y
- Converted column ID's to strings to align with documentation. The value was not displaying since the choice ID's were all numbers but the value saves as a string.