### PR TITLE
refactor: use new asset input type

### DIFF
--- a/packages/callout-block/src/CalloutBlock.tsx
+++ b/packages/callout-block/src/CalloutBlock.tsx
@@ -87,7 +87,7 @@ export const CalloutBlock: FC<CalloutBlockProps> = ({ appBridge }) => {
         setCustomCornerRadiusStyle(cornerRadiusStyle);
 
         if (iconSwitch && icon) {
-            appBridge.getAssetById(icon).then((iconAsset) => {
+            appBridge.getAssetById(icon.value).then((iconAsset) => {
                 setIconUrl(iconAsset.generic_url);
                 setIconAltText(`Callout Block Icon: ${iconAsset.title}`);
             });

--- a/packages/callout-block/src/types.ts
+++ b/packages/callout-block/src/types.ts
@@ -1,6 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { AppBridgeNative } from '@frontify/app-bridge';
+import { AssetInputValue } from '@frontify/guideline-blocks-settings';
 
 export enum Type {
     Warning = 'warning',
@@ -72,7 +73,7 @@ export type BlockSettings = {
     customPaddingSwitch: boolean;
     customCornerRadiusSwitch: boolean;
     textValue?: string;
-    icon?: number;
+    icon?: AssetInputValue;
     padding?: Padding;
     customPadding?: string[];
     cornerRadius?: CornerRadius;


### PR DESCRIPTION
TODO:
~~- Merge https://github.com/Frontify/guideline-components/pull/143~~
~~- Update the dependencies in clarify~~

The `assetInput` block settings now emits `{ source: AssetInputSource, value: number }` instead of `number`