### PR TITLE
feat(shared-package): rename color utilities

### DIFF
--- a/packages/checklist-block/src/ChecklistBlock.spec.tsx
+++ b/packages/checklist-block/src/ChecklistBlock.spec.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { mount } from '@cypress/react';
-import { mapRgbaToString, Padding, paddingStyleMap, withAppBridgeStubs } from '@frontify/guideline-blocks-shared';
+import { Padding, paddingStyleMap, toRgbaString, withAppBridgeStubs } from '@frontify/guideline-blocks-shared';
 import ChecklistBlock from '.';
 import { createItem } from './helpers';
 import {
@@ -367,16 +367,16 @@ it('Correctly renders styles provided by settings', () => {
         const fill = $item.css('background-color');
         const checked = $item.data('checked');
         if (checked) {
-            expect(border).to.equal(mapRgbaToString(testSettings.completeCheckboxColor));
-            expect(fill).to.equal(mapRgbaToString(testSettings.completeCheckboxColor));
+            expect(border).to.equal(toRgbaString(testSettings.completeCheckboxColor));
+            expect(fill).to.equal(toRgbaString(testSettings.completeCheckboxColor));
         } else {
-            expect(border).to.equal(mapRgbaToString(testSettings.incompleteCheckboxColor));
+            expect(border).to.equal(toRgbaString(testSettings.incompleteCheckboxColor));
             expect(fill).to.equal('rgb(255, 255, 255)');
         }
     });
     cy.get(TEXT_EDITOR).each(($editor) => {
         const color = $editor.css('color');
-        expect(color).to.equal(mapRgbaToString(testSettings.incompleteTextColor));
+        expect(color).to.equal(toRgbaString(testSettings.incompleteTextColor));
     });
     cy.get(CHECKBOX_LABEL)
         .find('span')
@@ -387,18 +387,14 @@ it('Correctly renders styles provided by settings', () => {
             const strikethroughThickness = $labelSection.css('text-decoration-thickness');
             const strikethroughColor = $labelSection.css('text-decoration-color');
             const [lineStyle, lineThickness, lineColor] = testSettings.strikethroughMultiInput;
-            expect(color).to.equal(mapRgbaToString(testSettings.completeTextColor));
+            expect(color).to.equal(toRgbaString(testSettings.completeTextColor));
             expect(textDecoration).to.equal('line-through');
             expect(strikethroughStyle).to.equal(StrikethroughStyleType[lineStyle]);
             expect(strikethroughThickness).to.equal(lineThickness);
-            expect(strikethroughColor).to.equal(mapRgbaToString(lineColor));
+            expect(strikethroughColor).to.equal(toRgbaString(lineColor));
         });
-    cy.get(PROGRESS_BAR).should('have.css', 'background-color', mapRgbaToString(testSettings.progressBarTrackColor));
-    cy.get(PROGRESS_BAR_FILL).should(
-        'have.css',
-        'background-color',
-        mapRgbaToString(testSettings.progressBarFillColor)
-    );
+    cy.get(PROGRESS_BAR).should('have.css', 'background-color', toRgbaString(testSettings.progressBarTrackColor));
+    cy.get(PROGRESS_BAR_FILL).should('have.css', 'background-color', toRgbaString(testSettings.progressBarFillColor));
     cy.get(CHECKLIST_BLOCK_SELECTOR).should('have.css', 'padding', paddingStyleMap[testSettings.paddingBasic]);
     cy.get(CHECKBOX_DATE).should('have.length', 5);
 });
@@ -438,5 +434,5 @@ it('Correctly displays highlight color', () => {
         },
     });
     mount(<ChecklistBlockWithStubs />);
-    cy.get(CHECKBOX_LABEL).find('span').should('have.css', 'background-color', mapRgbaToString(highlightColor));
+    cy.get(CHECKBOX_LABEL).find('span').should('have.css', 'background-color', toRgbaString(highlightColor));
 });

--- a/packages/checklist-block/src/ChecklistBlock.tsx
+++ b/packages/checklist-block/src/ChecklistBlock.tsx
@@ -4,43 +4,43 @@ import { useBlockSettings, useEditorState } from '@frontify/app-bridge';
 import {
     Button,
     ButtonSize,
+    ButtonStyle,
+    DragProperties,
     IconSize,
     IconView,
     IconViewSlash,
-    OrderableList,
     ItemDragState,
-    DragProperties,
+    OrderableList,
     OrderableListItem,
-    ButtonStyle,
 } from '@frontify/arcade';
-import { ItemDropTarget } from '@react-types/shared';
-import { useHover } from '@react-aria/interactions';
-import { useState, FC } from 'react';
-import { ChecklistItem } from './components/ChecklistItem';
-import { ProgressBar } from './components/ProgressBar';
-import { GridNode } from '@react-types/grid';
-import { ProgressHeader } from './components/ProgressHeader';
-import { ChecklistContent, ChecklistItemMode, ChecklistProps, DefaultValues, ProgressBarType, Settings } from './types';
+import '@frontify/arcade/style';
 import {
-    colorToHexAlpha,
     generatePaddingString,
     joinClassNames,
     paddingStyleMap,
+    toHex8String,
 } from '@frontify/guideline-blocks-shared';
-import { SettingsContext } from './SettingsContext';
-import { reorderList } from './utilities';
+import { useHover } from '@react-aria/interactions';
+import { GridNode } from '@react-types/grid';
+import { ItemDropTarget } from '@react-types/shared';
+import { FC, useState } from 'react';
+import 'tailwindcss/tailwind.css';
+import { ChecklistItem } from './components/ChecklistItem';
+import { ProgressBar } from './components/ProgressBar';
+import { ProgressHeader } from './components/ProgressHeader';
 import {
-    createItem,
     calculateFraction,
     calculatePercentage,
+    createItem,
+    filterCompleteItems,
     findIndexById,
     findIndexesForMove,
-    updateItemById,
     provideDefaults,
-    filterCompleteItems,
+    updateItemById,
 } from './helpers';
-import 'tailwindcss/tailwind.css';
-import '@frontify/arcade/style';
+import { SettingsContext } from './SettingsContext';
+import { ChecklistContent, ChecklistItemMode, ChecklistProps, DefaultValues, ProgressBarType, Settings } from './types';
+import { reorderList } from './utilities';
 
 export const ChecklistBlock: FC<ChecklistProps> = ({ appBridge }: ChecklistProps) => {
     const isEditing = useEditorState(appBridge);
@@ -138,8 +138,8 @@ export const ChecklistBlock: FC<ChecklistProps> = ({ appBridge }: ChecklistProps
                 <div className="tw-relative" {...hoverProps}>
                     {shouldShowProgress && progressBarType === ProgressBarType.Bar && (
                         <ProgressBar
-                            fillColor={colorToHexAlpha(progressBarFillColor)}
-                            trackColor={colorToHexAlpha(progressBarTrackColor)}
+                            fillColor={toHex8String(progressBarFillColor)}
+                            trackColor={toHex8String(progressBarTrackColor)}
                             percentage={calculatePercentage(content)}
                         />
                     )}

--- a/packages/checklist-block/src/components/Checkbox.spec.tsx
+++ b/packages/checklist-block/src/components/Checkbox.spec.tsx
@@ -1,8 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { Checkbox } from './Checkbox';
 import { mount } from '@cypress/react';
 import { CheckboxProps } from '../types';
+import { Checkbox } from './Checkbox';
 
 const CHECKBOX_DISPLAY = '[data-test-id="checkbox"]';
 const CHECKBOX_LABEL = '[data-test-id="checkbox-label"]';

--- a/packages/checklist-block/src/components/Checkbox.tsx
+++ b/packages/checklist-block/src/components/Checkbox.tsx
@@ -1,15 +1,15 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { IconCheck, FOCUS_STYLE } from '@frontify/arcade';
+import { FOCUS_STYLE, IconCheck } from '@frontify/arcade';
+import { joinClassNames, toHex8String } from '@frontify/guideline-blocks-shared';
 import { useCheckbox } from '@react-aria/checkbox';
 import { useFocusRing } from '@react-aria/focus';
 import { mergeProps } from '@react-aria/utils';
 import { useToggleState } from '@react-stately/toggle';
-import { useContext, useRef, FC, MouseEvent } from 'react';
+import { FC, MouseEvent, useContext, useRef } from 'react';
+import { SettingsContext } from '../SettingsContext';
 import { CheckboxProps } from '../types';
 import { CheckboxLabel } from './CheckboxLabel';
-import { colorToHexAlpha, joinClassNames } from '@frontify/guideline-blocks-shared';
-import { SettingsContext } from '../SettingsContext';
 
 export const Checkbox: FC<CheckboxProps> = ({
     id,
@@ -43,8 +43,8 @@ export const Checkbox: FC<CheckboxProps> = ({
     const { completeCheckboxColor, incompleteCheckboxColor } = useContext(SettingsContext);
 
     const checkboxStyles = {
-        background: checked ? colorToHexAlpha(completeCheckboxColor) : '',
-        borderColor: checked ? colorToHexAlpha(completeCheckboxColor) : colorToHexAlpha(incompleteCheckboxColor),
+        background: checked ? toHex8String(completeCheckboxColor) : '',
+        borderColor: checked ? toHex8String(completeCheckboxColor) : toHex8String(incompleteCheckboxColor),
     };
 
     const handleLabelClick = (event: MouseEvent<HTMLLabelElement>) => {

--- a/packages/checklist-block/src/components/CheckboxLabel.spec.tsx
+++ b/packages/checklist-block/src/components/CheckboxLabel.spec.tsx
@@ -1,8 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { CheckboxLabel } from './CheckboxLabel';
 import { mount } from '@cypress/react';
 import { CheckboxLabelProps } from '../types';
+import { CheckboxLabel } from './CheckboxLabel';
 
 const CHECKBOX_LABEL = '[data-test-id="checkbox-label"]';
 const CHECKBOX_DATE = '[data-test-id="checkbox-date"]';

--- a/packages/checklist-block/src/components/CheckboxLabel.tsx
+++ b/packages/checklist-block/src/components/CheckboxLabel.tsx
@@ -1,6 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { Color } from '@frontify/arcade';
+import { joinClassNames, toHex8String } from '@frontify/guideline-blocks-shared';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
 import { CSSProperties, FC, useContext } from 'react';
+import { SettingsContext } from '../SettingsContext';
 import {
     CheckboxLabelProps,
     ChecklistDecoration,
@@ -8,11 +13,6 @@ import {
     StrikethroughStyleType,
     StrikethroughType,
 } from '../types';
-import { colorToHexAlpha, joinClassNames } from '@frontify/guideline-blocks-shared';
-import dayjs from 'dayjs';
-import relativeTime from 'dayjs/plugin/relativeTime';
-import { SettingsContext } from '../SettingsContext';
-import { Color } from '@frontify/arcade';
 
 dayjs.extend(relativeTime);
 
@@ -26,11 +26,11 @@ const getLabelDecorationStylesMap = (
         textDecoration: 'line-through',
         textDecorationStyle: StrikethroughStyleType[style],
         textDecorationThickness: thickness,
-        textDecorationColor: colorToHexAlpha(color),
+        textDecorationColor: toHex8String(color),
         fontWeight: '500',
     },
     [ChecklistDecoration.Highlight]: {
-        backgroundColor: colorToHexAlpha(highlightColor),
+        backgroundColor: toHex8String(highlightColor),
     },
     [ChecklistDecoration.Checkbox]: {
         fontWeight: '500',
@@ -63,7 +63,7 @@ export const CheckboxLabel: FC<CheckboxLabelProps> = ({ children = '', htmlFor, 
 
     const decorationStyles = getLabelDecorationStylesMap(type, thickness, color, highlightColor)[completedDecoration];
 
-    const labelStyles = { color: colorToHexAlpha(completeTextColor), ...decorationStyles };
+    const labelStyles = { color: toHex8String(completeTextColor), ...decorationStyles };
 
     const decoratedChildren = decorateLabelChildren(children, labelStyles);
 

--- a/packages/checklist-block/src/components/ChecklistButton.tsx
+++ b/packages/checklist-block/src/components/ChecklistButton.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { FC } from 'react';
 import { Button, ButtonStyle } from '@frontify/arcade';
+import { FC } from 'react';
 import { ChecklistButtonProps } from '../types';
 
 export const ChecklistButton: FC<ChecklistButtonProps> = ({ onClick, icon, disabled, size }) => (

--- a/packages/checklist-block/src/components/ChecklistItem.tsx
+++ b/packages/checklist-block/src/components/ChecklistItem.tsx
@@ -1,22 +1,21 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { useState, FC } from 'react';
 import {
     ButtonGroup,
     ButtonSize,
-    ItemDragState,
-    IconCaretUp,
-    IconCaretDown,
-    IconReject,
     FocusController,
+    IconCaretDown,
+    IconCaretUp,
+    IconReject,
+    ItemDragState,
 } from '@frontify/arcade';
-import { TextEditor } from './TextEditor';
-import { getInteractionModality, useHover } from '@react-aria/interactions';
-import { useFocusWithin } from '@react-aria/interactions';
+import { joinClassNames } from '@frontify/guideline-blocks-shared';
+import { getInteractionModality, useFocusWithin, useHover } from '@react-aria/interactions';
+import { FC, useState } from 'react';
+import { ChecklistItemMode, ChecklistItemProps } from '../types';
 import { Checkbox } from './Checkbox';
 import { ChecklistButton } from './ChecklistButton';
-import { ChecklistItemMode, ChecklistItemProps } from '../types';
-import { joinClassNames } from '@frontify/guideline-blocks-shared';
+import { TextEditor } from './TextEditor';
 
 const DefaultChecklistItem = {
     text: '',

--- a/packages/checklist-block/src/components/TextEditor.spec.tsx
+++ b/packages/checklist-block/src/components/TextEditor.spec.tsx
@@ -1,8 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { TextEditor } from './TextEditor';
 import { mount } from '@cypress/react';
 import { TextEditorProps } from '../types';
+import { TextEditor } from './TextEditor';
 
 const TEXT_EDITOR = '[data-test-id="text-editor"]';
 const TEXT_VALUE = 'TEXT';

--- a/packages/checklist-block/src/components/TextEditor.tsx
+++ b/packages/checklist-block/src/components/TextEditor.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { colorToHexAlpha } from '@frontify/guideline-blocks-shared';
-import { useContext, useRef, KeyboardEvent, FocusEvent, forwardRef, useImperativeHandle } from 'react';
+import { toHex8String } from '@frontify/guideline-blocks-shared';
+import { FocusEvent, forwardRef, KeyboardEvent, useContext, useImperativeHandle, useRef } from 'react';
 import { SettingsContext } from '../SettingsContext';
 import { ImperativeFocusHandle, TextEditorProps } from '../types';
 
@@ -43,7 +43,7 @@ export const TextEditor = forwardRef<ImperativeFocusHandle, TextEditorProps>(
                     contentEditable={!readonly}
                     className="tw-block tw-max-w-full tw-flex-initial [word-break:break-word] empty:before:tw-content-[attr(data-placeholder)] empty:before:tw-text-black-60 empty:before:tw-inline-block tw-bg-transparent tw-border-none tw-text-s tw-outline-none hover:tw-cursor-text tw-whitespace-pre-wrap tw-px-0.5"
                     data-placeholder={placeholder}
-                    style={{ color: colorToHexAlpha(incompleteTextColor) }}
+                    style={{ color: toHex8String(incompleteTextColor) }}
                     onKeyDown={handleKeyPress}
                     onBlur={handleChange}
                     ref={editorRef}

--- a/packages/checklist-block/src/settings.ts
+++ b/packages/checklist-block/src/settings.ts
@@ -1,14 +1,14 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { Bundle, BlockSettings } from '@frontify/guideline-blocks-settings';
-import { ChecklistDecoration, DefaultValues, ProgressBarType, StrikethroughType } from './types';
-import { IconEnum, MultiInputLayout, DropdownSize } from '@frontify/arcade';
+import { DropdownSize, IconEnum, MultiInputLayout } from '@frontify/arcade';
+import { BlockSettings, Bundle } from '@frontify/guideline-blocks-settings';
 import {
-    minimumNumericalOrPixelOrAutoRule,
-    numericalOrPixelRule,
     appendUnit,
     getPaddingExtendedSettings,
+    minimumNumericalOrPixelOrAutoRule,
+    numericalOrPixelRule,
 } from '@frontify/guideline-blocks-shared';
+import { ChecklistDecoration, DefaultValues, ProgressBarType, StrikethroughType } from './types';
 
 const COMPLETED_DECORATION = 'completedDecoration';
 const STRIKETHROUGH_WIDTH = 'strikethroughWidth';

--- a/packages/checklist-block/src/types.ts
+++ b/packages/checklist-block/src/types.ts
@@ -2,8 +2,8 @@
 
 import { AppBridgeNative } from '@frontify/app-bridge';
 import { ButtonSize, Color, ItemDragState } from '@frontify/arcade';
-import { ReactElement, MouseEvent } from 'react';
-import { Padding, paddingStyleMap, PaddingSettings } from '@frontify/guideline-blocks-shared';
+import { Padding, PaddingSettings, paddingStyleMap } from '@frontify/guideline-blocks-shared';
+import { MouseEvent, ReactElement } from 'react';
 
 export type ChecklistProps = {
     appBridge: AppBridgeNative;

--- a/packages/divider-block/src/DividerBlock.tsx
+++ b/packages/divider-block/src/DividerBlock.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { useBlockSettings } from '@frontify/app-bridge';
-import { joinClassNames, mapRgbaToString } from '@frontify/guideline-blocks-shared';
+import { joinClassNames, toRgbaString } from '@frontify/guideline-blocks-shared';
 import { FC } from 'react';
 import 'tailwindcss/tailwind.css';
 import {
@@ -64,7 +64,7 @@ export const DividerBlock: FC<Props> = ({ appBridge }) => {
                     ])}
                     style={{
                         borderTopWidth: isThicknessCustom ? thicknessCustom : dividerThicknessValues[thicknessSimple],
-                        borderTopColor: color ? mapRgbaToString(color) : mapRgbaToString(COLOR_DEFAULT_RGBA_VALUE),
+                        borderTopColor: color ? toRgbaString(color) : toRgbaString(COLOR_DEFAULT_RGBA_VALUE),
                     }}
                 />
             </div>

--- a/packages/dos-donts-block/src/DoDontItem.tsx
+++ b/packages/dos-donts-block/src/DoDontItem.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { IconApprove, IconRejectCircle, IconSize, RichTextEditor } from '@frontify/arcade';
-import { joinClassNames, mapRgbaToString } from '@frontify/guideline-blocks-shared';
+import { joinClassNames, toRgbaString } from '@frontify/guideline-blocks-shared';
 import { CSSProperties, FC, useMemo } from 'react';
 import { DoDontItemProps, DoDontStyle, DoDontType, EditorChild, EditorElement } from './types';
 
@@ -16,8 +16,8 @@ export const DoDontItem: FC<DoDontItemProps> = ({
     body = '',
     editing = false,
 }) => {
-    const doColorString = mapRgbaToString(doColor);
-    const dontColorString = mapRgbaToString(dontColor);
+    const doColorString = toRgbaString(doColor);
+    const dontColorString = toRgbaString(dontColor);
 
     const headingStyles: Record<DoDontType, CSSProperties> = {
         [DoDontType.Do]: { color: doColorString },

--- a/packages/personal-note-block/src/PersonalNoteBlock.tsx
+++ b/packages/personal-note-block/src/PersonalNoteBlock.tsx
@@ -2,7 +2,7 @@
 
 import { useBlockSettings, useEditorState } from '@frontify/app-bridge';
 import { Color, RichTextEditor } from '@frontify/arcade';
-import { isDark, joinClassNames, mapRgbaToString } from '@frontify/guideline-blocks-shared';
+import { isDark, joinClassNames, toRgbaString } from '@frontify/guideline-blocks-shared';
 import { CSSProperties, FC, useEffect, useState } from 'react';
 import 'tailwindcss/tailwind.css';
 import { NoteHeader } from './components/NoteHeader';
@@ -28,7 +28,7 @@ const getBorderStyles = (borderSelection: BorderSelectionType): CSSProperties =>
     return {
         borderStyle: borderStyles[style],
         borderWidth: width,
-        borderColor: mapRgbaToString(rgba),
+        borderColor: toRgbaString(rgba),
     };
 };
 
@@ -37,7 +37,7 @@ const getRadiusStyles = (borderRadius: string): CSSProperties => ({
 });
 
 const getBackgroundStyles = (backgroundColor: Color): CSSProperties =>
-    backgroundColor ? { backgroundColor: mapRgbaToString(backgroundColor) } : {};
+    backgroundColor ? { backgroundColor: toRgbaString(backgroundColor) } : {};
 
 const getPaddingStyles = (padding: string): CSSProperties => ({
     padding,

--- a/packages/personal-note-block/src/settings.ts
+++ b/packages/personal-note-block/src/settings.ts
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { IconEnum, DropdownSize } from '@frontify/arcade';
-import { Bundle, BlockSettings } from '@frontify/guideline-blocks-settings';
+import { DropdownSize, IconEnum } from '@frontify/arcade';
+import { BlockSettings, Bundle } from '@frontify/guideline-blocks-settings';
 import {
     appendUnit,
     getBorderSettings,

--- a/packages/quote-block/src/QuoteBlock.tsx
+++ b/packages/quote-block/src/QuoteBlock.tsx
@@ -2,7 +2,7 @@
 
 import { useBlockSettings, useEditorState } from '@frontify/app-bridge';
 import { RichTextEditor } from '@frontify/arcade';
-import { mapRgbaToString } from '@frontify/guideline-blocks-shared';
+import { toRgbaString } from '@frontify/guideline-blocks-shared';
 import { FC } from 'react';
 import 'tailwindcss/tailwind.css';
 import { DEFAULT_AUTHOR_NAME, DEFAULT_COLOR_VALUE } from './settings';
@@ -52,8 +52,8 @@ export const QuoteBlock: FC<Props> = ({ appBridge }) => {
 
     const placeholder = 'Add your quote text here';
     const size = isCustomSize ? sizeValue : quoteSizeMap[sizeChoice];
-    const quotesRgba = mapRgbaToString(quotesColor);
-    const borderRgba = mapRgbaToString(accentLinecolor);
+    const quotesRgba = toRgbaString(quotesColor);
+    const borderRgba = toRgbaString(accentLinecolor);
     const borderStyles = showAccentLine
         ? {
               borderLeftStyle: lineType,

--- a/packages/shared/src/utilities/color/index.ts
+++ b/packages/shared/src/utilities/color/index.ts
@@ -1,5 +1,5 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 export * from './isDark';
-export * from './mapRgbaToString';
-export * from './colorToHexAlpha';
+export * from './toRgbaString';
+export * from './toHex8String';

--- a/packages/shared/src/utilities/color/isDark.ts
+++ b/packages/shared/src/utilities/color/isDark.ts
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import tinycolor from 'tinycolor2';
 import { Color } from '@frontify/arcade';
+import tinycolor from 'tinycolor2';
 
 /**
  * Calculates if text should be in a light color depending on color (e.g. background-color)

--- a/packages/shared/src/utilities/color/toHex8String.spec.ts
+++ b/packages/shared/src/utilities/color/toHex8String.spec.ts
@@ -1,8 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { colorToHexAlpha } from '.';
+import { toHex8String } from './toHex8String';
 
-describe('colorToHexAlpha', () => {
+describe('toHex8String', () => {
     const data = [
         { color: { r: 255, g: 255, b: 255 }, expected: '#ffffffff' },
         { color: { r: 255, g: 221, b: 255, a: 1 }, expected: '#ffddffff' },
@@ -11,6 +11,6 @@ describe('colorToHexAlpha', () => {
     ];
 
     it.each(data)('validates against expected values', ({ color, expected }) => {
-        expect(colorToHexAlpha(color)).toBe(expected);
+        expect(toHex8String(color)).toBe(expected);
     });
 });

--- a/packages/shared/src/utilities/color/toHex8String.ts
+++ b/packages/shared/src/utilities/color/toHex8String.ts
@@ -1,13 +1,13 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import tinycolor from 'tinycolor2';
 import { Color } from '@frontify/arcade';
+import tinycolor from 'tinycolor2';
 
 /**
- * Maps color object of rgba values to rgba string.
+ * Maps color object of rgba values to hex alpha string.
  *
  * @param {Object} Color object
  * @returns {String} To be used as css value.
  */
 
-export const mapRgbaToString = (color: Color): string => tinycolor(color).toRgbString();
+export const toHex8String = (color: Color): string => tinycolor(color).toHex8String();

--- a/packages/shared/src/utilities/color/toRgbaString.spec.ts
+++ b/packages/shared/src/utilities/color/toRgbaString.spec.ts
@@ -1,11 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { mapRgbaToString } from './mapRgbaToString';
+import { toRgbaString } from './toRgbaString';
 
-describe('mapRgbaToString', () => {
+describe('toRgbaString', () => {
     const data = [{ color: { r: 1, g: 2, b: 3, a: 0.5 }, expected: 'rgba(1, 2, 3, 0.5)' }];
 
     it.each(data)('validates against expected values', ({ color, expected }) => {
-        expect(mapRgbaToString(color)).toBe(expected);
+        expect(toRgbaString(color)).toBe(expected);
     });
 });

--- a/packages/shared/src/utilities/color/toRgbaString.ts
+++ b/packages/shared/src/utilities/color/toRgbaString.ts
@@ -1,13 +1,13 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import tinycolor from 'tinycolor2';
 import { Color } from '@frontify/arcade';
+import tinycolor from 'tinycolor2';
 
 /**
- * Maps color object of rgba values to hex alpha string.
+ * Maps color object of rgba values to rgba string.
  *
  * @param {Object} Color object
  * @returns {String} To be used as css value.
  */
 
-export const colorToHexAlpha = (color: Color): string => tinycolor(color).toHex8String();
+export const toRgbaString = (color: Color): string => tinycolor(color).toRgbString();

--- a/packages/storybook-block/src/StorybookBlock.tsx
+++ b/packages/storybook-block/src/StorybookBlock.tsx
@@ -2,7 +2,7 @@
 
 import { useBlockSettings, useEditorState } from '@frontify/app-bridge';
 import { Button, IconSize, IconStorybook, TextInput } from '@frontify/arcade';
-import { joinClassNames, mapRgbaToString } from '@frontify/guideline-blocks-shared';
+import { joinClassNames, toRgbaString } from '@frontify/guideline-blocks-shared';
 import { useHover } from '@react-aria/interactions';
 import { CSSProperties, FC, useEffect, useState } from 'react';
 import 'tailwindcss/tailwind.css';
@@ -32,7 +32,7 @@ const getIframeStyles = (borderSelection: BorderSelectionType, borderRadius: str
     return {
         borderStyle: borderStyles[style],
         borderWidth: width,
-        borderColor: mapRgbaToString(rgba),
+        borderColor: toRgbaString(rgba),
         borderRadius,
     };
 };

--- a/packages/storybook-block/src/settings.ts
+++ b/packages/storybook-block/src/settings.ts
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { IconEnum, DropdownSize } from '@frontify/arcade';
-import { Bundle, BlockSettings } from '@frontify/guideline-blocks-settings';
+import { DropdownSize, IconEnum } from '@frontify/arcade';
+import { BlockSettings, Bundle } from '@frontify/guideline-blocks-settings';
 import {
     appendUnit,
     getBorderRadiusSettings,


### PR DESCRIPTION
Renamed `mapRgbaToString` to `toRgbaString`, because we are using the tinycolor-library, which can handle [many different input formats](https://github.com/bgrins/TinyColor#accepted-string-input) (not only a rgba object as before). You can get a rgba-string from the utility from many different inputs now, hence the new name fits better IMO.

For consistency I've renamed also `colorToHexAlpha` to `toHex8String`.