### PR TITLE
feat: add icon bool to NotificationBlock type

### DIFF
--- a/packages/block-settings/package.json
+++ b/packages/block-settings/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@frontify/guideline-blocks-settings",
-    "version": "0.5.1",
+    "version": "0.5.0",
     "description": "Provides the types for the block settings",
     "sideEffects": false,
     "module": "dist/index.js",


### PR DESCRIPTION
Allows the notification block (settings) to be used without an icon
![Settings panel Accordion (3)](https://user-images.githubusercontent.com/11270687/152820510-497ca79a-9632-468a-baa4-7ce729f3f01d.jpg)
