### PR TITLE
feat(AssetInputBlock): add isLegacyApi prop

### DIFF
--- a/packages/block-settings/types/blocks/assetInput.ts
+++ b/packages/block-settings/types/blocks/assetInput.ts
@@ -19,6 +19,11 @@ export type AssetInputValue = {
     value: number;
 };
 
+export enum ApiType {
+    FileUpload = 'FileUpload',
+    BlockAssets = 'BlockAssets',
+}
+
 export type AssetInputBlock = {
     type: 'assetInput';
     multiSelection?: boolean;
@@ -26,5 +31,5 @@ export type AssetInputBlock = {
     projectTypes?: AssetChooserProjectType[];
     objectTypes?: AssetChooserObjectType[];
     mode?: AssetInputMode;
-    isLegacyApi?: boolean;
+    api?: ApiType;
 } & BaseBlock<AssetInputValue | AssetInputValue['value']>;


### PR DESCRIPTION
in the scope of this ticket: https://app.clickup.com/t/28z1fnn
needed to be able to differentiate between legacy blocks and new blocks