### PR TITLE
feat(StorybookBlock): add 'iframe.html' to path when without addons

### DIFF
--- a/packages/storybook-block/src/StorybookBlock.tsx
+++ b/packages/storybook-block/src/StorybookBlock.tsx
@@ -67,19 +67,21 @@ export const StorybookBlock: FC<BlockProps> = ({ appBridge }) => {
             const newIframeUrl = new URL(url);
             newIframeUrl.searchParams.set('nav', 'false');
 
-            let panelValue = 'bottom';
-            let shouldAddIframeToUrl = false;
-            if (style === StorybookStyle.WithoutAddons) {
-                panelValue = 'false';
-                shouldAddIframeToUrl = true;
-            } else if (positioning === StorybookPosition.Horizontal) {
-                panelValue = 'right';
-            }
+            const hasAddons = style === StorybookStyle.Default;
+            const shouldAddIframeToUrl = !hasAddons;
+            const includesIframe = newIframeUrl.pathname.toString().includes('iframe.html');
+            const positionValue = positioning === StorybookPosition.Horizontal ? 'right' : 'bottom';
+            const panelValue = !hasAddons ? 'false' : positionValue;
 
             newIframeUrl.searchParams.set('panel', panelValue);
 
-            if (!newIframeUrl.pathname.toString().includes('iframe.html') && shouldAddIframeToUrl) {
-                newIframeUrl.pathname = '/iframe.html';
+            if (shouldAddIframeToUrl && !includesIframe) {
+                newIframeUrl.pathname = `${newIframeUrl.pathname}iframe.html`;
+            }
+
+            if (!shouldAddIframeToUrl && includesIframe) {
+                const pathname = newIframeUrl.pathname.toString().replace('iframe.html', '');
+                newIframeUrl.pathname = pathname;
             }
 
             setIframeUrl(newIframeUrl);


### PR DESCRIPTION
This PR adds `iframe.html` to the storybook-url, when the styletype without addons is selected. Which is actually the same behaviour as in the old block.