### PR TITLE
feat: added switch size to type

### DIFF
--- a/packages/block-settings/types/blocks/switch.ts
+++ b/packages/block-settings/types/blocks/switch.ts
@@ -1,5 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { SwitchSize } from '@frontify/fondue';
 import { BaseBlock } from './base';
 import { SettingBlock } from './index';
 
@@ -8,4 +9,5 @@ export type SwitchBlock = {
     switchLabel?: string;
     on?: SettingBlock[];
     off?: SettingBlock[];
+    size?: SwitchSize;
 } & BaseBlock<boolean>;

--- a/packages/sketchfab-block/src/settings.ts
+++ b/packages/sketchfab-block/src/settings.ts
@@ -35,7 +35,6 @@ export const settings: BlockSettings & {
             id: SketchfabSettings.ACCOUNT_TYPE,
             type: 'dropdown',
             size: 'Large' as DropdownSize.Large,
-            clearable: false,
             defaultValue: SketchfabAccount.Basic,
             choices: [
                 { value: SketchfabAccount.Basic, label: SketchfabAccount.Basic },


### PR DESCRIPTION
Linked PR: https://github.com/Frontify/clarify/pull/10354

Since we now have multiple switch sizes, it would be useful to have the ability to control the size of the switch from the settings. This [Figma file](https://www.figma.com/file/SvZmrz3XSrRHqr8ZHHeunF/3D-Blocks?node-id=305%3A308418) is s demonstration of where we need switch sizes to be settable