### PR TITLE
chore(Settings): rename section from content to basics

### DIFF
--- a/packages/block-settings/types/index.ts
+++ b/packages/block-settings/types/index.ts
@@ -9,7 +9,7 @@ export type { Rule } from './validation';
 
 export enum Sections {
     Main = 'main',
-    Content = 'content',
+    Basics = 'basics',
     Layout = 'layout',
     Style = 'style',
     Security = 'security',
@@ -18,7 +18,7 @@ export enum Sections {
 
 export type BlockSettings = {
     [Sections.Main]?: SettingBlock[];
-    [Sections.Content]?: SettingBlock[];
+    [Sections.Basics]?: SettingBlock[];
     [Sections.Layout]?: SettingBlock[];
     [Sections.Style]?: SettingBlock[];
     [Sections.Security]?: SettingBlock[];

--- a/packages/callout-block/src/settings.ts
+++ b/packages/callout-block/src/settings.ts
@@ -50,7 +50,7 @@ export const settings: BlockSettings = {
             ],
         },
     ],
-    content: [
+    basics: [
         {
             id: 'iconSwitch',
             type: 'switch',

--- a/packages/figma-block/src/settings.ts
+++ b/packages/figma-block/src/settings.ts
@@ -41,7 +41,7 @@ export const settings: BlockSettings = {
             ],
         },
     ],
-    content: [
+    basics: [
         {
             id: ASSET_ID,
             type: 'assetInput',

--- a/packages/quote-block/src/settings.ts
+++ b/packages/quote-block/src/settings.ts
@@ -77,7 +77,7 @@ export const settings: BlockSettings = {
             ],
         },
     ],
-    content: [
+    basics: [
         {
             id: 'quotationMarksContentSection',
             type: 'sectionHeading',

--- a/packages/sketchfab-block/src/settings.ts
+++ b/packages/sketchfab-block/src/settings.ts
@@ -43,7 +43,7 @@ export const settings: BlockSettings & {
             ],
         },
     ],
-    content: [
+    basics: [
         {
             id: SketchfabSettings.URL,
             label: '3D Model URL',

--- a/packages/storybook-block/src/settings.ts
+++ b/packages/storybook-block/src/settings.ts
@@ -47,7 +47,7 @@ export const settings: BlockSettings = {
             ],
         },
     ],
-    content: [
+    basics: [
         {
             id: 'url',
             label: 'Link',


### PR DESCRIPTION
This PR renames all sections from "content" to "basics".

Ticket: https://app.clickup.com/t/2chb53h