### PR TITLE
feat(BlockSettingsType): allow legacy color format for colorInput

### DIFF
--- a/packages/block-settings/types/blocks/colorInput.ts
+++ b/packages/block-settings/types/blocks/colorInput.ts
@@ -1,8 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { Color } from '@frontify/fondue';
+import { Color, ColorRgb } from '@frontify/fondue';
 import { BaseBlock } from './base';
+
+type ColorFormats = Color | ColorRgb;
 
 export type ColorInputBlock = {
     type: 'colorInput';
-} & BaseBlock<Color>;
+} & BaseBlock<ColorFormats>;


### PR DESCRIPTION
This PR adjusts the colorInput type to still allow the legacy color format as value. This is needed for the fondue v11 update in clarify: https://github.com/Frontify/clarify/pull/10668