### PR TITLE
fix: remove fondue style from checklist block

### DIFF
--- a/packages/checklist-block/src/ChecklistBlock.tsx
+++ b/packages/checklist-block/src/ChecklistBlock.tsx
@@ -14,7 +14,6 @@ import {
     OrderableListItem,
 } from '@frontify/fondue';
 import '@frontify/fondue-tokens/styles';
-import '@frontify/fondue/style';
 import {
     generatePaddingString,
     joinClassNames,


### PR DESCRIPTION
Remove Fondue style import to prevent the issue below occuring on all block when a checklist is loaded:

https://user-images.githubusercontent.com/93908356/187639666-d86a6397-6995-42ea-b174-0fe46d62032c.mov

