### PR TITLE
feat: add function possibility for choices

### DIFF
--- a/packages/block-settings/types/blocks/checklist.ts
+++ b/packages/block-settings/types/blocks/checklist.ts
@@ -5,7 +5,7 @@ import { Checkbox } from './checkbox';
 
 export type ChecklistBlock = {
     type: 'checklist';
-    choices: Checkbox[];
+    choices: Checkbox[] | (() => Checkbox[]) | (() => Promise<Checkbox[]>);
     showClearAndSelectAllButtons?: boolean;
     columns?: 1 | 2;
 } & BaseBlock<string[] | null>;

--- a/packages/block-settings/types/blocks/checklist.ts
+++ b/packages/block-settings/types/blocks/checklist.ts
@@ -1,11 +1,14 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { BaseBlock } from './base';
-import { Checkbox } from './checkbox';
+import type { BaseBlock } from './base';
+import type { Checkbox } from './checkbox';
+import type { AppBridgeBlock } from '@frontify/app-bridge';
+
+type ChoicesFn = (props: { appBridge: AppBridgeBlock }) => Promise<Checkbox[]>;
 
 export type ChecklistBlock = {
     type: 'checklist';
-    choices: Checkbox[] | (() => Checkbox[]) | (() => Promise<Checkbox[]>);
+    choices: Checkbox[] | ChoicesFn;
     showClearAndSelectAllButtons?: boolean;
     columns?: 1 | 2;
 } & BaseBlock<string[] | null>;


### PR DESCRIPTION
Allows function in `choices` with or without `Promise` return
```
{
	id: 'test',
	type: 'checklist',
	choices: () =>
		new Promise((resolve) => setTimeout(() => resolve([{ id: 'test-1', label: 'test 1' }]), 2000)),
},
```