### PR TITLE
fix: remove vscode settings file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-    "cSpell.words": [
-        "closebrackets",
-        "codemirror",
-        "csstype",
-        "Keymap",
-        "matchbrackets"
-    ]
-}


### PR DESCRIPTION
This PR removes the `.vscode/settings.json` file as this file shouldn't be tracked. It's very specific to the developer which IDE and also which vscode extensions are used.

If this file is tracked it will accumulate settings from different vscode extensions which are not relevant.