### PR TITLE
feat(BlockSettings): add new type Setting

### DIFF
--- a/packages/block-settings/types/blocks/base.ts
+++ b/packages/block-settings/types/blocks/base.ts
@@ -2,12 +2,14 @@
 
 import { Bundle } from '../bundle';
 
+type Setting<T> = T | ((bundle: Bundle) => T);
+
 export type BaseBlock<T = undefined> = {
     id: string;
-    label?: string;
-    info?: string;
+    label?: Setting<string>;
+    info?: Setting<string>;
     value?: T;
-    defaultValue?: T;
+    defaultValue?: Setting<T>;
     showForTranslations?: boolean;
     show?: (bundle: Bundle) => boolean;
     onChange?: (bundle: Bundle) => void;


### PR DESCRIPTION
This PR adds a new type `Setting` to allow arrow functions on the `label`, `info` and `defaultValue` properties.