### PR TITLE
fix(BlockSettings): remove label from LinkChooserBlock type

### DIFF
--- a/packages/block-settings/types/blocks/linkChooser.ts
+++ b/packages/block-settings/types/blocks/linkChooser.ts
@@ -6,7 +6,6 @@ import { BaseBlock } from './base';
 export type LinkChooserBlock = {
     type: 'linkChooser';
     placeholder?: string;
-    label?: string;
     openInNewTab?: boolean;
     disabled?: boolean;
     clearable?: boolean;


### PR DESCRIPTION
`label` is already declared inside the `BaseBlock` type, no need for it in the `LinkChooserBlock`.