### PR TITLE
fix(ColorKitBlock): remove responsive styles

### DIFF
--- a/packages/color-kit-block/src/Color.tsx
+++ b/packages/color-kit-block/src/Color.tsx
@@ -56,7 +56,7 @@ export const Color = ({ isEditing, color }: ColorProps): ReactElement => {
                 withArrow
                 key={color.id}
                 position={TooltipPosition.Right}
-                content={<TooltipContent colorValue={color.hex} status={status} />}
+                content={<TooltipContent colorName={color.name} colorValue={color.hex} status={status} />}
                 triggerElement={
                     <div>
                         <ColorBox />

--- a/packages/color-kit-block/src/ColorKitBlock.tsx
+++ b/packages/color-kit-block/src/ColorKitBlock.tsx
@@ -24,12 +24,12 @@ export const ColorKitBlock = ({ appBridge }: ColorKitBlockProps): ReactElement =
     return (
         <div data-test-id="color-kit-block" className="tw-p-8 tw-pt-7 tw-border tw-border-line tw-rounded">
             <div className="tw-flex tw-justify-between">
-                <div className="tw-flex tw-flex-wrap tw-items-start sm:tw-flex-nowrap">
+                <div className="tw-flex tw-items-start">
                     <Text as="p" size="large" weight="x-strong">
                         Color Kit
                     </Text>
 
-                    <div className="tw-w-full tw-space-x-1 tw-mt-1 tw-ml-0 sm:tw-w-auto sm:tw-mt-0 sm:tw-ml-3">
+                    <div className="tw-w-full tw-space-x-1 tw-mt-0 tw-ml-3 sm:tw-w-auto">
                         <Badge size="small">ASE</Badge>
                         <Badge size="small">LESS</Badge>
                         <Badge size="small">OCO</Badge>

--- a/packages/color-kit-block/src/TooltipContent.spec.ct.tsx
+++ b/packages/color-kit-block/src/TooltipContent.spec.ct.tsx
@@ -4,17 +4,19 @@ import { mount } from 'cypress/react';
 
 import { TooltipContent } from './TooltipContent';
 
-const ColorKitTooltipContentSelector = '[data-test-id="color-hash"]';
+const ColorKitTooltipContentSelector = '[data-test-id="tooltip-content"]';
 
+const dummyColorName = 'Color Name';
 const dummyColorValue = '27f006';
 
 describe('TooltipContent', () => {
     beforeEach(() => {
-        mount(<TooltipContent colorValue={dummyColorValue} status="idle" />);
+        mount(<TooltipContent colorName={dummyColorName} colorValue={dummyColorValue} status="idle" />);
     });
 
     it('renders color hex', () => {
         cy.get(ColorKitTooltipContentSelector).should('exist');
-        cy.get(ColorKitTooltipContentSelector).should('have.text', `#${dummyColorValue}`);
+        cy.get(ColorKitTooltipContentSelector).find('span').contains(dummyColorName);
+        cy.get(ColorKitTooltipContentSelector).find('span').contains(`#${dummyColorValue}`);
     });
 });

--- a/packages/color-kit-block/src/TooltipContent.tsx
+++ b/packages/color-kit-block/src/TooltipContent.tsx
@@ -2,13 +2,11 @@
 
 import { TooltipContentProps } from './types';
 
-export const TooltipContent = ({ colorValue, status }: TooltipContentProps) => {
+export const TooltipContent = ({ colorName, colorValue, status }: TooltipContentProps) => {
     return (
         <span data-test-id="tooltip-content">
-            <span className="tw-block">Color Name</span>
-            <span data-test-id="color-hash" className="tw-block">
-                #{colorValue}
-            </span>
+            <span className="tw-block">{colorName}</span>
+            <span className="tw-block">#{colorValue}</span>
             <span className="tw-text-black-50">
                 {status === 'error' && 'Error copying. Try again.'}
                 {status === 'idle' && 'Click to copy.'}

--- a/packages/color-kit-block/src/types.ts
+++ b/packages/color-kit-block/src/types.ts
@@ -11,6 +11,7 @@ export type ColorKitBlockProps = {
 };
 
 export type TooltipContentProps = {
+    colorName: string;
     colorValue: string;
     status: 'error' | 'success' | 'idle';
 };


### PR DESCRIPTION
Removing `:sm` helpers for now until we find a fix.

Also fix the color name in tooltip.