### PR TITLE
fix: do not allow functions in defaultValue

### DIFF
--- a/packages/block-settings/types/blocks/base.ts
+++ b/packages/block-settings/types/blocks/base.ts
@@ -12,7 +12,7 @@ export type BaseBlock<T = undefined> = {
     label?: ValueOrPromisedValue<string>;
     info?: ValueOrPromisedValue<string>;
     value?: T;
-    defaultValue?: ValueOrPromisedValue<T>;
+    defaultValue?: T;
     showForTranslations?: boolean;
     show?: (bundle: Bundle) => boolean;
     onChange?: (bundle: Bundle) => void;


### PR DESCRIPTION
since defaultValues are immediately applied in clarify, it doesn't make sense to define it as a function