### PR TITLE
chore: update fondue in all blocks/packages

### DIFF
--- a/examples/asset-upload/package.json
+++ b/examples/asset-upload/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "@frontify/fondue-tokens": "3.1.0",
         "react": "17.0.2",
         "react-dom": "17.0.2"

--- a/examples/asset-upload/package.json
+++ b/examples/asset-upload/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.11",
+        "@frontify/fondue": "12.0.0-beta.24",
         "@frontify/fondue-tokens": "3.1.0",
         "react": "17.0.2",
         "react-dom": "17.0.2"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "vitest": "0.25.0"
     },
     "dependencies": {
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "glob": "8.0.3",
         "react": "17.0.2",
         "react-dom": "17.0.2"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "vitest": "0.25.0"
     },
     "dependencies": {
-        "@frontify/fondue": "12.0.0-beta.11",
+        "@frontify/fondue": "12.0.0-beta.24",
         "glob": "8.0.3",
         "react": "17.0.2",
         "react-dom": "17.0.2"

--- a/packages/callout-block/package.json
+++ b/packages/callout-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/callout-block/package.json
+++ b/packages/callout-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.11",
+        "@frontify/fondue": "12.0.0-beta.24",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/checklist-block/package.json
+++ b/packages/checklist-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/checklist-block/package.json
+++ b/packages/checklist-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.11",
+        "@frontify/fondue": "12.0.0-beta.24",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/code-snippet-block/package.json
+++ b/packages/code-snippet-block/package.json
@@ -33,7 +33,7 @@
         "@codemirror/state": "^6.1.4",
         "@codemirror/view": "^6.5.1",
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/code-snippet-block/package.json
+++ b/packages/code-snippet-block/package.json
@@ -33,7 +33,7 @@
         "@codemirror/state": "^6.1.4",
         "@codemirror/view": "^6.5.1",
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.11",
+        "@frontify/fondue": "12.0.0-beta.24",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-block/package.json
+++ b/packages/color-block/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "@frontify/fondue-tokens": "3.2.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-block/package.json
+++ b/packages/color-block/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.13",
+        "@frontify/fondue": "12.0.0-beta.24",
         "@frontify/fondue-tokens": "3.2.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-kit-block/package.json
+++ b/packages/color-kit-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-kit-block/package.json
+++ b/packages/color-kit-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.11",
+        "@frontify/fondue": "12.0.0-beta.24",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-scale-block/package.json
+++ b/packages/color-scale-block/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-scale-block/package.json
+++ b/packages/color-scale-block/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.2",
+        "@frontify/fondue": "12.0.0-beta.24",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/divider-block/package.json
+++ b/packages/divider-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/divider-block/package.json
+++ b/packages/divider-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.11",
+        "@frontify/fondue": "12.0.0-beta.24",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/dos-donts-block/package.json
+++ b/packages/dos-donts-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/dos-donts-block/package.json
+++ b/packages/dos-donts-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.11",
+        "@frontify/fondue": "12.0.0-beta.24",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "@frontify/fondue-tokens": "3.2.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.20",
+        "@frontify/fondue": "12.0.0-beta.24",
         "@frontify/fondue-tokens": "3.2.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/figma-block/package.json
+++ b/packages/figma-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/figma-block/package.json
+++ b/packages/figma-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.11",
+        "@frontify/fondue": "12.0.0-beta.24",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/personal-note-block/package.json
+++ b/packages/personal-note-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/personal-note-block/package.json
+++ b/packages/personal-note-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.11",
+        "@frontify/fondue": "12.0.0-beta.24",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/quote-block/package.json
+++ b/packages/quote-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/quote-block/package.json
+++ b/packages/quote-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.11",
+        "@frontify/fondue": "12.0.0-beta.24",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/quote-block/src/QuoteBlock.tsx
+++ b/packages/quote-block/src/QuoteBlock.tsx
@@ -1,7 +1,17 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { useBlockAssets, useBlockSettings, useEditorState } from '@frontify/app-bridge';
-import { EditorActions, RichTextEditor, merge } from '@frontify/fondue';
+import {
+    BoldPlugin,
+    InitPlugin,
+    ItalicPlugin,
+    PluginComposer,
+    RichTextEditor,
+    StrikethroughPlugin,
+    TextStylePlugin,
+    UnderlinePlugin,
+    merge,
+} from '@frontify/fondue';
 import '@frontify/fondue-tokens/styles';
 import { toRgbaString, useGuidelineDesignTokens } from '@frontify/guideline-blocks-shared';
 import { FC } from 'react';
@@ -20,10 +30,10 @@ import {
 } from './types';
 import { flexBoxAlignmentClassNames, textAlignmentClassNames } from './utilities';
 
-const ACTIONS = [
-    [EditorActions.TEXT_STYLES],
-    [EditorActions.BOLD, EditorActions.ITALIC, EditorActions.UNDERLINE, EditorActions.STRIKETHROUGH],
-];
+const customPlugins = new PluginComposer();
+customPlugins
+    .setPlugin([new InitPlugin(), new TextStylePlugin()])
+    .setPlugin([new BoldPlugin(), new ItalicPlugin(), new UnderlinePlugin(), new StrikethroughPlugin()]);
 
 const DEFAULT_CONTENT_VALUE = '[{"type":"quote","children":[{"text":""}]}]';
 
@@ -107,7 +117,7 @@ export const QuoteBlock: FC<Props> = ({ appBridge }) => {
                             placeholder={isEditing ? 'Add your quote text here' : undefined}
                             value={blockSettings.content ?? DEFAULT_CONTENT_VALUE}
                             onTextChange={onChangeContent}
-                            actions={ACTIONS}
+                            plugins={customPlugins}
                             readonly={!isEditing}
                         />
                     </div>

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,7 +42,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "tinycolor2": "1.4.2"
     },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,7 +42,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.11",
+        "@frontify/fondue": "12.0.0-beta.24",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "tinycolor2": "1.4.2"
     },

--- a/packages/sketchfab-block/package.json
+++ b/packages/sketchfab-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/sketchfab-block/package.json
+++ b/packages/sketchfab-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.11",
+        "@frontify/fondue": "12.0.0-beta.24",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/storybook-block/package.json
+++ b/packages/storybook-block/package.json
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.11",
+        "@frontify/fondue": "12.0.0-beta.24",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/storybook-block/package.json
+++ b/packages/storybook-block/package.json
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/text-block/package.json
+++ b/packages/text-block/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.11",
+        "@frontify/fondue": "12.0.0-beta.24",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/text-block/package.json
+++ b/packages/text-block/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.27",
-        "@frontify/fondue": "12.0.0-beta.24",
+        "@frontify/fondue": "12.0.0-beta.25",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "workspace:*",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
       '@4tw/cypress-drag-drop': 2.2.1
       '@babel/core': 7.20.2
       '@cypress/vite-dev-server': 4.0.1
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@testing-library/react-hooks': 8.0.1
       '@types/node': 18.7.21
       '@types/react': 17.0.50
@@ -27,7 +27,7 @@ importers:
       vite: 3.2.3
       vitest: 0.25.0
     dependencies:
-      '@frontify/fondue': 12.0.0-beta.24_rv2t7de65xq26o5frb4lun64yi
+      '@frontify/fondue': 12.0.0-beta.25_rv2t7de65xq26o5frb4lun64yi
       glob: 8.0.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -56,7 +56,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -75,7 +75,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.25_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -156,7 +156,7 @@ importers:
       vite-plugin-dts: 1.7.0
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.29_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_sfoxds7t5ydpegc3knd667wn6m
+      '@frontify/fondue': 12.0.0-beta.25_sfoxds7t5ydpegc3knd667wn6m
     devDependencies:
       '@frontify/eslint-config-typescript': 0.15.5_pcit6nykmxit3vv6c7deq76n7y
       eslint: 8.27.0
@@ -173,7 +173,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -192,7 +192,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.25_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -218,7 +218,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -245,7 +245,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.25_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -282,7 +282,7 @@ importers:
       '@codemirror/view': ^6.5.1
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -307,7 +307,7 @@ importers:
       '@codemirror/state': 6.1.4
       '@codemirror/view': 6.5.1
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.25_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -336,7 +336,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@frontify/fondue-tokens': 3.2.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -358,7 +358,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.25_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.2.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -387,7 +387,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -406,7 +406,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.25_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -433,7 +433,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -454,7 +454,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.25_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -483,7 +483,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -502,7 +502,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.25_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -528,7 +528,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -547,7 +547,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.25_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -573,7 +573,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@frontify/fondue-tokens': 3.2.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -592,7 +592,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.25_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.2.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -618,7 +618,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -637,7 +637,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.25_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -663,7 +663,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -683,7 +683,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.25_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -710,7 +710,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -729,7 +729,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.25_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -755,7 +755,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-typescript': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@frontify/guideline-blocks-settings': workspace:*
       '@testing-library/react-hooks': 8.0.1
       '@types/node': 18.7.21
@@ -779,7 +779,7 @@ importers:
       vitest: 0.25.0
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_rv2t7de65xq26o5frb4lun64yi
+      '@frontify/fondue': 12.0.0-beta.25_rv2t7de65xq26o5frb4lun64yi
       '@frontify/guideline-blocks-settings': link:../block-settings
       tinycolor2: 1.4.2
     devDependencies:
@@ -810,7 +810,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -829,7 +829,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.25_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -855,7 +855,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -875,7 +875,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.25_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -902,7 +902,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.24
+      '@frontify/fondue': 12.0.0-beta.25
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -923,7 +923,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.25_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -1844,35 +1844,35 @@ packages:
       - ts-node
     dev: false
 
-  /@frontify/fondue/12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m:
-    resolution: {integrity: sha512-oNfBM9Gj2aJZ2Z0ApcBh6jU+Kj2xt/5KHCLKT8uyi69jYFb0DDRDFehBhU37YIU85SLtk3btGur8LCH8gxAuUQ==}
-    engines: {node: ~16}
+  /@frontify/fondue/12.0.0-beta.25_angvksxlvvfhyjj3xhcshgfg2m:
+    resolution: {integrity: sha512-KDl+1Frhu+M11ca16I9Krj6i2kg8PndcxZHcLhGApQgIVMlRx61x4v3vYNgmBG33No3DNgtauZBX6wzgzdhTZw==}
+    engines: {node: '>=16'}
     peerDependencies:
-      react: ^17.0.2
-      react-dom: ^17.0.2
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
     dependencies:
       '@frontify/fondue-tokens': 3.2.0
       '@popperjs/core': 2.11.6
-      '@react-aria/accordion': 3.0.0-alpha.9_react@17.0.2
-      '@react-aria/aria-modal-polyfill': 3.6.0_react@17.0.2
-      '@react-aria/breadcrumbs': 3.1.10_react@17.0.2
-      '@react-aria/button': 3.6.2_react@17.0.2
-      '@react-aria/checkbox': 3.6.0_react@17.0.2
-      '@react-aria/combobox': 3.4.2_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/dialog': 3.4.0_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/focus': 3.9.0_react@17.0.2
-      '@react-aria/interactions': 3.12.0_react@17.0.2
-      '@react-aria/link': 3.3.4_react@17.0.2
-      '@react-aria/listbox': 3.7.0_react@17.0.2
-      '@react-aria/menu': 3.6.2_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/overlays': 3.8.1_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/radio': 3.4.0_react@17.0.2
-      '@react-aria/select': 3.8.2_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/selection': 3.11.0_react@17.0.2
-      '@react-aria/table': 3.5.0_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/tooltip': 3.3.2_react@17.0.2
-      '@react-aria/utils': 3.14.0_react@17.0.2
-      '@react-aria/visually-hidden': 3.5.0_react@17.0.2
+      '@react-aria/accordion': 3.0.0-alpha.13_react@17.0.2
+      '@react-aria/aria-modal-polyfill': 3.6.1_react@17.0.2
+      '@react-aria/breadcrumbs': 3.4.0_react@17.0.2
+      '@react-aria/button': 3.6.3_react@17.0.2
+      '@react-aria/checkbox': 3.7.0_react@17.0.2
+      '@react-aria/combobox': 3.4.3_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/dialog': 3.4.1_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/link': 3.3.5_react@17.0.2
+      '@react-aria/listbox': 3.7.1_react@17.0.2
+      '@react-aria/menu': 3.7.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/overlays': 3.12.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/radio': 3.4.1_react@17.0.2
+      '@react-aria/select': 3.8.3_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/selection': 3.12.0_react@17.0.2
+      '@react-aria/table': 3.6.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/tooltip': 3.3.3_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-aria/visually-hidden': 3.6.0_react@17.0.2
       '@react-stately/checkbox': 3.3.0_react@17.0.2
       '@react-stately/collections': 3.4.4_react@17.0.2
       '@react-stately/combobox': 3.2.2_react@17.0.2
@@ -1885,7 +1885,6 @@ packages:
       '@react-stately/toggle': 3.4.2_react@17.0.2
       '@react-stately/tooltip': 3.2.2_react@17.0.2
       '@react-stately/tree': 3.3.4_react@17.0.2
-      '@storybook/addon-a11y': 6.5.13_sfoxds7t5ydpegc3knd667wn6m
       '@udecode/plate': 18.9.0_lq7qkw3fyxdfk55wtvczfr7dqi
       '@xstate/immer': 0.3.1_immer@9.0.12+xstate@4.28.1
       '@xstate/react': 1.6.3_gcyz5mxmyrgibkcjljkbjmosn4
@@ -1930,35 +1929,35 @@ packages:
       - wonka
     dev: false
 
-  /@frontify/fondue/12.0.0-beta.24_rv2t7de65xq26o5frb4lun64yi:
-    resolution: {integrity: sha512-oNfBM9Gj2aJZ2Z0ApcBh6jU+Kj2xt/5KHCLKT8uyi69jYFb0DDRDFehBhU37YIU85SLtk3btGur8LCH8gxAuUQ==}
-    engines: {node: ~16}
+  /@frontify/fondue/12.0.0-beta.25_rv2t7de65xq26o5frb4lun64yi:
+    resolution: {integrity: sha512-KDl+1Frhu+M11ca16I9Krj6i2kg8PndcxZHcLhGApQgIVMlRx61x4v3vYNgmBG33No3DNgtauZBX6wzgzdhTZw==}
+    engines: {node: '>=16'}
     peerDependencies:
-      react: ^17.0.2
-      react-dom: ^17.0.2
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
     dependencies:
       '@frontify/fondue-tokens': 3.2.0_ts-node@10.9.1
       '@popperjs/core': 2.11.6
-      '@react-aria/accordion': 3.0.0-alpha.9_react@17.0.2
-      '@react-aria/aria-modal-polyfill': 3.6.0_react@17.0.2
-      '@react-aria/breadcrumbs': 3.1.10_react@17.0.2
-      '@react-aria/button': 3.6.2_react@17.0.2
-      '@react-aria/checkbox': 3.6.0_react@17.0.2
-      '@react-aria/combobox': 3.4.2_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/dialog': 3.4.0_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/focus': 3.9.0_react@17.0.2
-      '@react-aria/interactions': 3.12.0_react@17.0.2
-      '@react-aria/link': 3.3.4_react@17.0.2
-      '@react-aria/listbox': 3.7.0_react@17.0.2
-      '@react-aria/menu': 3.6.2_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/overlays': 3.8.1_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/radio': 3.4.0_react@17.0.2
-      '@react-aria/select': 3.8.2_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/selection': 3.11.0_react@17.0.2
-      '@react-aria/table': 3.5.0_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/tooltip': 3.3.2_react@17.0.2
-      '@react-aria/utils': 3.14.0_react@17.0.2
-      '@react-aria/visually-hidden': 3.5.0_react@17.0.2
+      '@react-aria/accordion': 3.0.0-alpha.13_react@17.0.2
+      '@react-aria/aria-modal-polyfill': 3.6.1_react@17.0.2
+      '@react-aria/breadcrumbs': 3.4.0_react@17.0.2
+      '@react-aria/button': 3.6.3_react@17.0.2
+      '@react-aria/checkbox': 3.7.0_react@17.0.2
+      '@react-aria/combobox': 3.4.3_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/dialog': 3.4.1_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/link': 3.3.5_react@17.0.2
+      '@react-aria/listbox': 3.7.1_react@17.0.2
+      '@react-aria/menu': 3.7.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/overlays': 3.12.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/radio': 3.4.1_react@17.0.2
+      '@react-aria/select': 3.8.3_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/selection': 3.12.0_react@17.0.2
+      '@react-aria/table': 3.6.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/tooltip': 3.3.3_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-aria/visually-hidden': 3.6.0_react@17.0.2
       '@react-stately/checkbox': 3.3.0_react@17.0.2
       '@react-stately/collections': 3.4.4_react@17.0.2
       '@react-stately/combobox': 3.2.2_react@17.0.2
@@ -1971,7 +1970,6 @@ packages:
       '@react-stately/toggle': 3.4.2_react@17.0.2
       '@react-stately/tooltip': 3.2.2_react@17.0.2
       '@react-stately/tree': 3.3.4_react@17.0.2
-      '@storybook/addon-a11y': 6.5.13_sfoxds7t5ydpegc3knd667wn6m
       '@udecode/plate': 18.9.0_lq7qkw3fyxdfk55wtvczfr7dqi
       '@xstate/immer': 0.3.1_immer@9.0.12+xstate@4.28.1
       '@xstate/react': 1.6.3_gcyz5mxmyrgibkcjljkbjmosn4
@@ -2016,35 +2014,35 @@ packages:
       - wonka
     dev: false
 
-  /@frontify/fondue/12.0.0-beta.24_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-oNfBM9Gj2aJZ2Z0ApcBh6jU+Kj2xt/5KHCLKT8uyi69jYFb0DDRDFehBhU37YIU85SLtk3btGur8LCH8gxAuUQ==}
-    engines: {node: ~16}
+  /@frontify/fondue/12.0.0-beta.25_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-KDl+1Frhu+M11ca16I9Krj6i2kg8PndcxZHcLhGApQgIVMlRx61x4v3vYNgmBG33No3DNgtauZBX6wzgzdhTZw==}
+    engines: {node: '>=16'}
     peerDependencies:
-      react: ^17.0.2
-      react-dom: ^17.0.2
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
     dependencies:
       '@frontify/fondue-tokens': 3.2.0
       '@popperjs/core': 2.11.6
-      '@react-aria/accordion': 3.0.0-alpha.9_react@17.0.2
-      '@react-aria/aria-modal-polyfill': 3.6.0_react@17.0.2
-      '@react-aria/breadcrumbs': 3.1.10_react@17.0.2
-      '@react-aria/button': 3.6.2_react@17.0.2
-      '@react-aria/checkbox': 3.6.0_react@17.0.2
-      '@react-aria/combobox': 3.4.2_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/dialog': 3.4.0_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/focus': 3.9.0_react@17.0.2
-      '@react-aria/interactions': 3.12.0_react@17.0.2
-      '@react-aria/link': 3.3.4_react@17.0.2
-      '@react-aria/listbox': 3.7.0_react@17.0.2
-      '@react-aria/menu': 3.6.2_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/overlays': 3.8.1_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/radio': 3.4.0_react@17.0.2
-      '@react-aria/select': 3.8.2_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/selection': 3.11.0_react@17.0.2
-      '@react-aria/table': 3.5.0_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/tooltip': 3.3.2_react@17.0.2
-      '@react-aria/utils': 3.14.0_react@17.0.2
-      '@react-aria/visually-hidden': 3.5.0_react@17.0.2
+      '@react-aria/accordion': 3.0.0-alpha.13_react@17.0.2
+      '@react-aria/aria-modal-polyfill': 3.6.1_react@17.0.2
+      '@react-aria/breadcrumbs': 3.4.0_react@17.0.2
+      '@react-aria/button': 3.6.3_react@17.0.2
+      '@react-aria/checkbox': 3.7.0_react@17.0.2
+      '@react-aria/combobox': 3.4.3_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/dialog': 3.4.1_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/link': 3.3.5_react@17.0.2
+      '@react-aria/listbox': 3.7.1_react@17.0.2
+      '@react-aria/menu': 3.7.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/overlays': 3.12.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/radio': 3.4.1_react@17.0.2
+      '@react-aria/select': 3.8.3_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/selection': 3.12.0_react@17.0.2
+      '@react-aria/table': 3.6.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/tooltip': 3.3.3_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-aria/visually-hidden': 3.6.0_react@17.0.2
       '@react-stately/checkbox': 3.3.0_react@17.0.2
       '@react-stately/collections': 3.4.4_react@17.0.2
       '@react-stately/combobox': 3.2.2_react@17.0.2
@@ -2057,7 +2055,6 @@ packages:
       '@react-stately/toggle': 3.4.2_react@17.0.2
       '@react-stately/tooltip': 3.2.2_react@17.0.2
       '@react-stately/tree': 3.3.4_react@17.0.2
-      '@storybook/addon-a11y': 6.5.13_sfoxds7t5ydpegc3knd667wn6m
       '@udecode/plate': 18.9.0_ynovzzal4ukqjumbrzchvba2hi
       '@xstate/immer': 0.3.1_immer@9.0.12+xstate@4.28.1
       '@xstate/react': 1.6.3_react@17.0.2+xstate@4.28.1
@@ -2465,25 +2462,25 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-aria/accordion/3.0.0-alpha.9_react@17.0.2:
-    resolution: {integrity: sha512-3n55HzOKu9/JWdbASSdNE0KI4vKH1zsWVeoLgE9M5MXfgHYsOb/c7KkHIrBkC1oD03KdKioDlNENEXzBoOiI4w==}
+  /@react-aria/accordion/3.0.0-alpha.13_react@17.0.2:
+    resolution: {integrity: sha512-xq9R6Op9UeKRG/dUcA64SXPJ71+sS3GTtaccsl0BYpMn1wEwmpEazMMOFJw2piPdWEllMDa51Twked77CEYMnA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.20.1
-      '@react-aria/button': 3.6.2_react@17.0.2
+      '@react-aria/button': 3.6.3_react@17.0.2
       '@react-aria/interactions': 3.13.0_react@17.0.2
       '@react-aria/selection': 3.12.0_react@17.0.2
       '@react-aria/utils': 3.14.1_react@17.0.2
-      '@react-stately/tree': 3.3.4_react@17.0.2
-      '@react-types/accordion': 3.0.0-alpha.7_react@17.0.2
+      '@react-stately/tree': 3.4.0_react@17.0.2
+      '@react-types/accordion': 3.0.0-alpha.11_react@17.0.2
       '@react-types/button': 3.7.0_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
-  /@react-aria/aria-modal-polyfill/3.6.0_react@17.0.2:
-    resolution: {integrity: sha512-coWVSX/esVk2z8f8aXbaT4HzIjv6V7tYy+3gbOTACkI96QtXbtzWawq2gNpssNnT6zEh/4Ox2iwKYQEU6xSdEQ==}
+  /@react-aria/aria-modal-polyfill/3.6.1_react@17.0.2:
+    resolution: {integrity: sha512-Tbcrd+ec7ygELIJuqd6w7D7xtCVw4dnp/b9rey2/7xjJ+5W92tgb5/ntIM0/jlBWesDZjVj977rPRJY/+MnBgQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
@@ -2493,23 +2490,23 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-aria/breadcrumbs/3.1.10_react@17.0.2:
-    resolution: {integrity: sha512-kuUVQYDSrA5799icfuG9oIw/+zSECZ9J1QiABUsiOdM64TYeDeULfGLV2RV376SB44V8bK8maoZtJ7ewU5gcHg==}
+  /@react-aria/breadcrumbs/3.4.0_react@17.0.2:
+    resolution: {integrity: sha512-zQzDu8yO4DInw14FfuZVkIqsoQ9xJ+nbRjJug1iag+FBJCb598DnBZVpFvZdsOsRKbCtImhHhjK/CcImq1rTpA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.20.1
       '@react-aria/i18n': 3.6.2_react@17.0.2
       '@react-aria/interactions': 3.13.0_react@17.0.2
-      '@react-aria/link': 3.3.4_react@17.0.2
+      '@react-aria/link': 3.3.5_react@17.0.2
       '@react-aria/utils': 3.14.1_react@17.0.2
-      '@react-types/breadcrumbs': 3.3.0_react@17.0.2
+      '@react-types/breadcrumbs': 3.4.5_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
-  /@react-aria/button/3.6.2_react@17.0.2:
-    resolution: {integrity: sha512-8XRcPR5qXKNmnBO6u9FSY8vYa7P1FIgVix07EHBCTZiJYHYxcUsFYRWG9qf2aShGotJs4957unqGH1L1ncRYKQ==}
+  /@react-aria/button/3.6.3_react@17.0.2:
+    resolution: {integrity: sha512-t6UHFPFMlAQW0yefjhqwyQya6RYlUtMRtMKZjnRANbK6JskazkkLvu//qULs+vsiM21PLhspKVLcGdS+t2khsA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
@@ -2539,8 +2536,8 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-aria/checkbox/3.6.0_react@17.0.2:
-    resolution: {integrity: sha512-E2MZoMZhtHtlS1mYjxTI29JRq4s3Y6d92KHj7tzvcC308d4Bzz0IHJd0bMz/8whoNteU02pQyZ3rDAcGf92bHQ==}
+  /@react-aria/checkbox/3.7.0_react@17.0.2:
+    resolution: {integrity: sha512-CGVfBcCK3e8YwjPSgIMTQbMxbjTtsDy9xGkw/7iCMVIsHC7MfzO8Ny5qJJbQ2dVkNnSfIgQdtWikYGJN2QjeDw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
@@ -2548,15 +2545,15 @@ packages:
       '@react-aria/label': 3.4.3_react@17.0.2
       '@react-aria/toggle': 3.4.1_react@17.0.2
       '@react-aria/utils': 3.14.1_react@17.0.2
-      '@react-stately/checkbox': 3.3.0_react@17.0.2
+      '@react-stately/checkbox': 3.3.1_react@17.0.2
       '@react-stately/toggle': 3.4.3_react@17.0.2
       '@react-types/checkbox': 3.4.1_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
-  /@react-aria/combobox/3.4.2_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-LFB0L2WLR7hc5J2c36jdgekHigLv4PwZfNRlh+B4VX474pS9Zt33F0FIrCKsYZA8xXzvM+lXr4POjwsoBhmnJw==}
+  /@react-aria/combobox/3.4.3_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-MrpxrpJOOIRKMKkFDxTzQFu6y31eL15IsMbTRttO0NsrnQiJl19ojz6MpnhIJjnaC/Wz2EEWqnUawQsJjAVxyQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
@@ -2564,15 +2561,15 @@ packages:
       '@babel/runtime': 7.20.1
       '@react-aria/i18n': 3.6.2_react@17.0.2
       '@react-aria/interactions': 3.13.0_react@17.0.2
-      '@react-aria/listbox': 3.7.0_react@17.0.2
+      '@react-aria/listbox': 3.7.1_react@17.0.2
       '@react-aria/live-announcer': 3.1.1
-      '@react-aria/menu': 3.6.2_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/menu': 3.7.0_sfoxds7t5ydpegc3knd667wn6m
       '@react-aria/overlays': 3.12.0_sfoxds7t5ydpegc3knd667wn6m
       '@react-aria/selection': 3.12.0_react@17.0.2
       '@react-aria/textfield': 3.8.0_react@17.0.2
       '@react-aria/utils': 3.14.1_react@17.0.2
       '@react-stately/collections': 3.5.0_react@17.0.2
-      '@react-stately/combobox': 3.2.2_react@17.0.2
+      '@react-stately/combobox': 3.3.0_react@17.0.2
       '@react-stately/layout': 3.9.0_react@17.0.2
       '@react-types/button': 3.7.0_react@17.0.2
       '@react-types/combobox': 3.5.5_react@17.0.2
@@ -2581,8 +2578,8 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@react-aria/dialog/3.4.0_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-h1D7OOe20PhSb4DD40ABVgHMbSA2Y9rSU5lrGf9zuNSYkQIwDz6pTSXp/9roy7SEvf5KAN6zPa1inSVBOTzf3w==}
+  /@react-aria/dialog/3.4.1_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-1P6zCn78OP9nv7/1i4QsysOKQ6gxHy9JUyOj0ixrR1jwYI/psCM2MwT9cfPjuj7pGQys6lsu4glSmZ82zARURQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
@@ -2620,19 +2617,6 @@ packages:
       '@react-aria/interactions': 3.11.0_react@17.0.2
       '@react-aria/utils': 3.13.3_react@17.0.2
       '@react-types/shared': 3.14.1_react@17.0.2
-      clsx: 1.1.1
-      react: 17.0.2
-    dev: false
-
-  /@react-aria/focus/3.9.0_react@17.0.2:
-    resolution: {integrity: sha512-DwesjEjWjFfwAwzv9qeqkyKZNPAYmPa3UrygxzmXeKEg2JpaACGZPxRcmT2EFJFEDbX8daQDEeRGyLO49o5agg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.20.1
-      '@react-aria/interactions': 3.13.0_react@17.0.2
-      '@react-aria/utils': 3.14.1_react@17.0.2
-      '@react-types/shared': 3.16.0_react@17.0.2
       clsx: 1.1.1
       react: 17.0.2
     dev: false
@@ -2687,17 +2671,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-aria/interactions/3.12.0_react@17.0.2:
-    resolution: {integrity: sha512-KcKurjPZwme9ggvGQjbjqZtZtuyXipTBVMHUah9a3+Dz7vXxhRg5vFaEdM79oQnNsrGFW5xS6SKBehl/JG6BMw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.20.1
-      '@react-aria/utils': 3.14.1_react@17.0.2
-      '@react-types/shared': 3.16.0_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-aria/interactions/3.13.0_react@17.0.2:
     resolution: {integrity: sha512-gbZL+qs+6FPitR/abAramth4lqz/drEzXwzIDF6p6WyajF805mjyAgZin1/3mQygSE5BwJNDU7jMUSGRvgFyTw==}
     peerDependencies:
@@ -2744,8 +2717,8 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-aria/link/3.3.4_react@17.0.2:
-    resolution: {integrity: sha512-Op0usCd5SAg5OHkCl1+TYbsvT/wWhqadd/3Pi0VD0kKmaSy4GhUNJkTo8n0hS2k3vIq+qRq7zwnON2h5eLVkHA==}
+  /@react-aria/link/3.3.5_react@17.0.2:
+    resolution: {integrity: sha512-BbyoJ73IAQcQMYWFxhV/zJWYFlx4Edprm6xfBZKMEBrEpUcvBwe/X3QsCQmRXZ8fJodMjQ9SdQPyue1yi8Ksrw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
@@ -2758,8 +2731,8 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-aria/listbox/3.7.0_react@17.0.2:
-    resolution: {integrity: sha512-XUWg+ll9LmzJB3WzAklwJY5A/YuRTWd5UM/WSL34aV1O6P/IdLW697Xvr6fpHWMPtkIUeNB6teAAT2M98iWx5Q==}
+  /@react-aria/listbox/3.7.1_react@17.0.2:
+    resolution: {integrity: sha512-vKovd+u8F7jdcogZeDPtm89gn390cR0xpMbOoyPzbACOdST43SYexDXWV4Ww/M2YWkdJxT3jZ576NeifcfO2MA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
@@ -2770,7 +2743,7 @@ packages:
       '@react-aria/selection': 3.12.0_react@17.0.2
       '@react-aria/utils': 3.14.1_react@17.0.2
       '@react-stately/collections': 3.5.0_react@17.0.2
-      '@react-stately/list': 3.5.4_react@17.0.2
+      '@react-stately/list': 3.6.0_react@17.0.2
       '@react-types/listbox': 3.3.5_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
@@ -2782,8 +2755,8 @@ packages:
       '@babel/runtime': 7.20.1
     dev: false
 
-  /@react-aria/menu/3.6.2_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-uBZHGuFAtOdoocBVZzoBpZQFJmkt5axlEUKjBgh2BuR5JX8aZiSxyKnfgAeb3aDEi9PZpOp6RWxHzOMBRg4TsA==}
+  /@react-aria/menu/3.7.0_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-dCSg67G3vEXOovZyaojZXvcq19MLqual6oTSJC9WhNS/SR0AuNPbwMbD34a/b1Je73ro5bzjIbmQPyt/i3XaCA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
@@ -2795,8 +2768,8 @@ packages:
       '@react-aria/selection': 3.12.0_react@17.0.2
       '@react-aria/utils': 3.14.1_react@17.0.2
       '@react-stately/collections': 3.5.0_react@17.0.2
-      '@react-stately/menu': 3.4.2_react@17.0.2
-      '@react-stately/tree': 3.3.4_react@17.0.2
+      '@react-stately/menu': 3.4.3_react@17.0.2
+      '@react-stately/tree': 3.4.0_react@17.0.2
       '@react-types/button': 3.7.0_react@17.0.2
       '@react-types/menu': 3.7.3_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
@@ -2825,28 +2798,8 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@react-aria/overlays/3.8.1_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-6r86wO7DlcYXOwufzxuYWkh/lwgwpKYAhKHL8z8DcErX7mbauoeh2Z3wX+6a27rSrkqRksmsWYJR3nsg55u1DA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.20.1
-      '@react-aria/i18n': 3.6.2_react@17.0.2
-      '@react-aria/interactions': 3.13.0_react@17.0.2
-      '@react-aria/utils': 3.14.1_react@17.0.2
-      '@react-aria/visually-hidden': 3.6.0_react@17.0.2
-      '@react-stately/overlays': 3.4.3_react@17.0.2
-      '@react-types/button': 3.7.0_react@17.0.2
-      '@react-types/overlays': 3.6.5_react@17.0.2
-      '@react-types/shared': 3.16.0_react@17.0.2
-      dom-helpers: 3.4.0
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-    dev: false
-
-  /@react-aria/radio/3.4.0_react@17.0.2:
-    resolution: {integrity: sha512-DUccHQxfI0PikXXQKarh/hLS/G+ZzfdQ00/sd57jzWsuRyukb+WywQhud29p5uO3wT33/MH9LZgSmb9dlvfabQ==}
+  /@react-aria/radio/3.4.1_react@17.0.2:
+    resolution: {integrity: sha512-a1JFxFOiExX1ZRGBE31LW4dgc3VmW2v3upJ5snGQldC83o0XxqNavmOef+fMsIRV0AQA/mcxAJVNQ0n9SfIiUQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
@@ -2856,14 +2809,14 @@ packages:
       '@react-aria/interactions': 3.13.0_react@17.0.2
       '@react-aria/label': 3.4.3_react@17.0.2
       '@react-aria/utils': 3.14.1_react@17.0.2
-      '@react-stately/radio': 3.6.0_react@17.0.2
+      '@react-stately/radio': 3.6.1_react@17.0.2
       '@react-types/radio': 3.3.1_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
-  /@react-aria/select/3.8.2_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-a2lUvB9k54sfoiqyTcl+rq9GKqwcF8RMapaYxaE0VQmUVUl/hk31mTMo5y3giDCpMlrVO0jxve3nZe9YyUOOvg==}
+  /@react-aria/select/3.8.3_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-EkbzbpSEkq0oSmFSeOJskjPzopqmKQ2VxsEaJHL8RebVdJiNxp5kSaBOaH1KxZI9DgrzHQNSRKYJaSJ1pUTfbw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
@@ -2872,33 +2825,17 @@ packages:
       '@react-aria/i18n': 3.6.2_react@17.0.2
       '@react-aria/interactions': 3.13.0_react@17.0.2
       '@react-aria/label': 3.4.3_react@17.0.2
-      '@react-aria/listbox': 3.7.0_react@17.0.2
-      '@react-aria/menu': 3.6.2_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/listbox': 3.7.1_react@17.0.2
+      '@react-aria/menu': 3.7.0_sfoxds7t5ydpegc3knd667wn6m
       '@react-aria/selection': 3.12.0_react@17.0.2
       '@react-aria/utils': 3.14.1_react@17.0.2
       '@react-aria/visually-hidden': 3.6.0_react@17.0.2
-      '@react-stately/select': 3.3.2_react@17.0.2
+      '@react-stately/select': 3.3.3_react@17.0.2
       '@react-types/button': 3.7.0_react@17.0.2
       '@react-types/select': 3.6.5_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-    dev: false
-
-  /@react-aria/selection/3.11.0_react@17.0.2:
-    resolution: {integrity: sha512-2Qcv0PxXqOrYYT1oL+TOaB+lE/jhIPzVEPHVmf8HYzEMP5WBYP8Q+R9no5s8x++b1W0DsbUVwmk9szY48O9Bmw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.20.1
-      '@react-aria/focus': 3.10.0_react@17.0.2
-      '@react-aria/i18n': 3.6.2_react@17.0.2
-      '@react-aria/interactions': 3.13.0_react@17.0.2
-      '@react-aria/utils': 3.14.1_react@17.0.2
-      '@react-stately/collections': 3.5.0_react@17.0.2
-      '@react-stately/selection': 3.11.1_react@17.0.2
-      '@react-types/shared': 3.16.0_react@17.0.2
-      react: 17.0.2
     dev: false
 
   /@react-aria/selection/3.12.0_react@17.0.2:
@@ -2935,8 +2872,8 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-aria/table/3.5.0_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-oYcsIEYbbjAzojRWUsAdtfxPzlEKBmk6o4svDHnGqC9HSj8/yExn8b8RB0veDP7E+5IdO62pUwUy48jBwWu2uw==}
+  /@react-aria/table/3.6.0_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-hwq+5iwXVSirmi9Lr0v5wDOv7uz7UD+BUNFXP5d9nknrAKzVYDfpuNpz/Bbhpczp9R89VRBcFvcKJ3cWhESYnw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
@@ -2949,7 +2886,7 @@ packages:
       '@react-aria/live-announcer': 3.1.1
       '@react-aria/selection': 3.12.0_react@17.0.2
       '@react-aria/utils': 3.14.1_react@17.0.2
-      '@react-stately/table': 3.5.0_react@17.0.2
+      '@react-stately/table': 3.6.0_react@17.0.2
       '@react-stately/virtualizer': 3.4.0_react@17.0.2
       '@react-types/checkbox': 3.4.1_react@17.0.2
       '@react-types/grid': 3.1.5_react@17.0.2
@@ -3005,8 +2942,8 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-aria/tooltip/3.3.2_react@17.0.2:
-    resolution: {integrity: sha512-k/0/1/bfGp3gZ6JK8giJPgz2bkt+eJigzD5oY4d908KavyJ3nKAZe7hR+0ahT0lj0Z2Xb7M5SZepisk8Kj8LbA==}
+  /@react-aria/tooltip/3.3.3_react@17.0.2:
+    resolution: {integrity: sha512-EF58SQ70KEfGJQErsELJh1dk3KUDrBFmCEHo6kD1fVEHCqUgdWLkz+TCfkiP8VgFoj4WoE8zSpl3MpgGOQr/Gg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
@@ -3014,7 +2951,7 @@ packages:
       '@react-aria/focus': 3.10.0_react@17.0.2
       '@react-aria/interactions': 3.13.0_react@17.0.2
       '@react-aria/utils': 3.14.1_react@17.0.2
-      '@react-stately/tooltip': 3.2.2_react@17.0.2
+      '@react-stately/tooltip': 3.2.3_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       '@react-types/tooltip': 3.2.5_react@17.0.2
       react: 17.0.2
@@ -3046,19 +2983,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-aria/utils/3.14.0_react@17.0.2:
-    resolution: {integrity: sha512-DHgmwNBNEhnb6DEYYAfbt99wprBqJJOBBeIpQ2g3+pxwlw4BZ+v4Qr+rDD0ZibWV0mYzt8zOhZ9StpId7iTF0Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.20.1
-      '@react-aria/ssr': 3.4.0_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
-      '@react-types/shared': 3.16.0_react@17.0.2
-      clsx: 1.1.1
-      react: 17.0.2
-    dev: false
-
   /@react-aria/utils/3.14.1_react@17.0.2:
     resolution: {integrity: sha512-+ynP0YlxN02MHVEBaeuTrIhBsfBYpfJn36pZm2t7ZEFbafH8DPaMGZ70ffYZXAESkWzRULXL3e79DheWOFI1qA==}
     peerDependencies:
@@ -3067,19 +2991,6 @@ packages:
       '@babel/runtime': 7.20.1
       '@react-aria/ssr': 3.4.0_react@17.0.2
       '@react-stately/utils': 3.5.1_react@17.0.2
-      '@react-types/shared': 3.16.0_react@17.0.2
-      clsx: 1.1.1
-      react: 17.0.2
-    dev: false
-
-  /@react-aria/visually-hidden/3.5.0_react@17.0.2:
-    resolution: {integrity: sha512-tF/kCZCGv1yebwgH21cKbhjSV5CmB5/SAHOUM5YkO5V/lIFjaPtywcamIPI8F0JSfrwGF/Z9EqvqBxvIYGRlCA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.20.1
-      '@react-aria/interactions': 3.13.0_react@17.0.2
-      '@react-aria/utils': 3.14.1_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       clsx: 1.1.1
       react: 17.0.2
@@ -3151,6 +3062,19 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-stately/checkbox/3.3.1_react@17.0.2:
+    resolution: {integrity: sha512-r2hL11GF9r2ztUFEhpiVgiXgE+W99tyL1Kt7rOiTZ8/aMBGWwBxOHAdHeqcWFeBgOztXuJsKiDu82necEG4xhA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/toggle': 3.4.3_react@17.0.2
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/checkbox': 3.4.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-stately/collections/3.4.4_react@17.0.2:
     resolution: {integrity: sha512-gryUYCe6uzqE0ea5frTwOxOPpx/6Z42PRk7KetOh3ddN3Ts0j8XQP08jP1IB/7BC1QidrkHWvDCqGHxRiEjiIg==}
     peerDependencies:
@@ -3177,9 +3101,24 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.20.1
-      '@react-stately/list': 3.5.4_react@17.0.2
-      '@react-stately/menu': 3.4.2_react@17.0.2
+      '@react-stately/list': 3.6.0_react@17.0.2
+      '@react-stately/menu': 3.4.3_react@17.0.2
       '@react-stately/select': 3.3.2_react@17.0.2
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/combobox': 3.5.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-stately/combobox/3.3.0_react@17.0.2:
+    resolution: {integrity: sha512-+9xQW6C4nMcx7M72P4vZdQECa9CqzALTM3HTNAXgdCmfEezhns/m4xGmn4hoN8iw39yYvU8Ffs80rgTFQ+/oFg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/list': 3.6.0_react@17.0.2
+      '@react-stately/menu': 3.4.3_react@17.0.2
+      '@react-stately/select': 3.3.3_react@17.0.2
       '@react-stately/utils': 3.5.1_react@17.0.2
       '@react-types/combobox': 3.5.5_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
@@ -3224,8 +3163,34 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-stately/list/3.6.0_react@17.0.2:
+    resolution: {integrity: sha512-sah2JAiqlSZhg1tQBSv9866LeAJISmosOFsOsVZPfyfAewuCksA+8OHrFtbKmMyzU5MbrmpbR8v2zZH7c1CLdg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/collections': 3.5.0_react@17.0.2
+      '@react-stately/selection': 3.11.1_react@17.0.2
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-stately/menu/3.4.2_react@17.0.2:
     resolution: {integrity: sha512-vFC8EloVEcqf6sgiP6ABIkC41ytjoJiGtj7Ws5OS7PvZNyxxDgJr4V0O3Pxd1T0AjlHCloBbojnvoTRwZiSr/A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/overlays': 3.4.3_react@17.0.2
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/menu': 3.7.3_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-stately/menu/3.4.3_react@17.0.2:
+    resolution: {integrity: sha512-ZWym6XQSLaC5uFUTZl6+mreEgzc8EUG6ElcnvdXYcH4DWUfswhLxCi3IdnG0lusWEi4NcHbZ2prEUxpT8VKqrg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
@@ -3271,6 +3236,18 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-stately/radio/3.6.1_react@17.0.2:
+    resolution: {integrity: sha512-Hcg2qgvR7ekKMzVKeGby1FgMk3Sw4iDcEY/K1Y6j7UmGjM2HtQOq614tWQSQeGB25pp5I2jAWlparJeX0vY/oA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/radio': 3.3.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-stately/select/3.3.2_react@17.0.2:
     resolution: {integrity: sha512-/C9fW7HT+V9XnmSTiZZqH5cn+ifY9vdXvIKDbUyna98lFHtDgn7i/UvD5edunOGY0qqSMIO3kJ6/BiNg+gpn6Q==}
     peerDependencies:
@@ -3278,8 +3255,24 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.1
       '@react-stately/collections': 3.5.0_react@17.0.2
-      '@react-stately/list': 3.5.4_react@17.0.2
-      '@react-stately/menu': 3.4.2_react@17.0.2
+      '@react-stately/list': 3.6.0_react@17.0.2
+      '@react-stately/menu': 3.4.3_react@17.0.2
+      '@react-stately/selection': 3.11.1_react@17.0.2
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/select': 3.6.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-stately/select/3.3.3_react@17.0.2:
+    resolution: {integrity: sha512-HTKKwx5tq21G2r3Q0CVC5v2Amftj1+DvBlFSRIC9ZqWyxeQg//HotX0GpYHzEEyj5hB1GjBklKJ4UVejqNbb0w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/collections': 3.5.0_react@17.0.2
+      '@react-stately/list': 3.6.0_react@17.0.2
+      '@react-stately/menu': 3.4.3_react@17.0.2
       '@react-stately/selection': 3.11.1_react@17.0.2
       '@react-stately/utils': 3.5.1_react@17.0.2
       '@react-types/select': 3.6.5_react@17.0.2
@@ -3301,6 +3294,21 @@ packages:
 
   /@react-stately/table/3.5.0_react@17.0.2:
     resolution: {integrity: sha512-C0HFfKMCOomqPtRCPs85AtoJGPnGu9mzFfwksFxAssdIatw3t66h5SJS0vSSql7Ku9h70scmvJR+nIOckx0IeA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/collections': 3.5.0_react@17.0.2
+      '@react-stately/grid': 3.4.1_react@17.0.2
+      '@react-stately/selection': 3.11.1_react@17.0.2
+      '@react-types/grid': 3.1.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      '@react-types/table': 3.3.3_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-stately/table/3.6.0_react@17.0.2:
+    resolution: {integrity: sha512-B6zamfI06j3+kxlMm1mgn+JaQv5CdXgYsMLo96nrU+XRbn2WzAikc2w+XHmfnqlKAcm+PtcDjrshDOCMioP2QA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
@@ -3362,8 +3370,33 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-stately/tooltip/3.2.3_react@17.0.2:
+    resolution: {integrity: sha512-RWCcqn6iz1IcOXX+TiXBql2kI5hgDlf49DiGZJqSGmNQujX1FVZ1uqn9yHpdh+/TZPZ7JeMvQu3S5lA+x4ehPw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/overlays': 3.4.3_react@17.0.2
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/tooltip': 3.2.5_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-stately/tree/3.3.4_react@17.0.2:
     resolution: {integrity: sha512-CBgXvwa9qYBsJuxrAiVgGnm48eSxLe/6OjPMwH1pWf4s383Mx73MbbN4fS0oWDeXBVgdqz5/Xg/p8nvPIvl3WQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/collections': 3.5.0_react@17.0.2
+      '@react-stately/selection': 3.11.1_react@17.0.2
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-stately/tree/3.4.0_react@17.0.2:
+    resolution: {integrity: sha512-MqxSABMzykwI6Wj1B7+jBcCoYc0b05CueRTQDyoL+PfVhnV0SzOH6P84UPD+FHlz8x3RG/2hTTmLr4A8McO2nQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
@@ -3395,8 +3428,8 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-types/accordion/3.0.0-alpha.7_react@17.0.2:
-    resolution: {integrity: sha512-h5Nvf/+O+Cl/Vw6m3RNGD3hv7VwKX0ilJe1a473iJgjruzMQybSgpcCdWES31QZdEE+rkjpqTGoG22MusEOE+Q==}
+  /@react-types/accordion/3.0.0-alpha.11_react@17.0.2:
+    resolution: {integrity: sha512-7TAvvMnfSWtX4gkmRg3pE31y/E/oTWfUAIi9WT4hPJBbE/8zItjD2P5cQ5tLizXT87fnm+4s8jvci7gZcN2/pw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
@@ -3404,10 +3437,10 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-types/breadcrumbs/3.3.0_react@17.0.2:
-    resolution: {integrity: sha512-pqYtDkbyHwWVq9eB4pwYtd8e5S2PCcdTy263hEwcW4XhDc9bmWR/iWu6/sBUoY3qwpMrWP+mEzdmfBILWhDqpw==}
+  /@react-types/breadcrumbs/3.4.5_react@17.0.2:
+    resolution: {integrity: sha512-5DXV6qW6Orronu1D9Op903m+lGzPajzJnsW6ygEiv6kjRutY33gIl1ePoQKoBQzNimtFs3uE4YLOw7nLzry1qg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-types/link': 3.3.5_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
@@ -3697,168 +3730,6 @@ packages:
     resolution: {integrity: sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==}
     dev: false
 
-  /@storybook/addon-a11y/6.5.13_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-+Tcl/4LWRh3ygLUZFGvkjT42CF/tJcP+kgsIho7i2MxpgZyD6+BUhL9srPZusjbR+uHcHXJ/yxw/vxFQ+UCTLA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-    dependencies:
-      '@storybook/addons': 6.5.13_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/api': 6.5.13_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/channels': 6.5.13
-      '@storybook/client-logger': 6.5.13
-      '@storybook/components': 6.5.13_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/core-events': 6.5.13
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/theming': 6.5.13_sfoxds7t5ydpegc3knd667wn6m
-      axe-core: 4.4.2
-      core-js: 3.23.1
-      global: 4.4.0
-      lodash: 4.17.21
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      react-sizeme: 3.0.2
-      regenerator-runtime: 0.13.10
-      ts-dedent: 2.2.0
-      util-deprecate: 1.0.2
-    dev: false
-
-  /@storybook/addons/6.5.13_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-18CqzNnrGMfeZtiKz+R/3rHtSNnfNwz6y6prIQIbWseK16jY8ELTfIFGviwO5V2OqpbHDQi5+xQQ63QAIb89YA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@storybook/api': 6.5.13_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/channels': 6.5.13
-      '@storybook/client-logger': 6.5.13
-      '@storybook/core-events': 6.5.13
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/router': 6.5.13_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/theming': 6.5.13_sfoxds7t5ydpegc3knd667wn6m
-      '@types/webpack-env': 1.17.0
-      core-js: 3.23.1
-      global: 4.4.0
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      regenerator-runtime: 0.13.10
-    dev: false
-
-  /@storybook/api/6.5.13_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-xVSmB7/IuFd6G7eiJjbI2MuS7SZunoUM6d+YCWpjiehfMeX47MXt1gZtOwFrgJC1ShZlefXFahq/dvxwtmWs+w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@storybook/channels': 6.5.13
-      '@storybook/client-logger': 6.5.13
-      '@storybook/core-events': 6.5.13
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/router': 6.5.13_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/semver': 7.3.2
-      '@storybook/theming': 6.5.13_sfoxds7t5ydpegc3knd667wn6m
-      core-js: 3.23.1
-      fast-deep-equal: 3.1.3
-      global: 4.4.0
-      lodash: 4.17.21
-      memoizerific: 1.11.3
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      regenerator-runtime: 0.13.10
-      store2: 2.13.2
-      telejson: 6.0.8
-      ts-dedent: 2.2.0
-      util-deprecate: 1.0.2
-    dev: false
-
-  /@storybook/channels/6.5.13:
-    resolution: {integrity: sha512-sGYSilE30bz0jG+HdHnkv0B4XkAv2hP+KRZr4xmnv+MOOQpRnZpJ5Z3HVU16s17cj/83NWihKj6BuKcEVzyilg==}
-    dependencies:
-      core-js: 3.23.1
-      ts-dedent: 2.2.0
-      util-deprecate: 1.0.2
-    dev: false
-
-  /@storybook/client-logger/6.5.13:
-    resolution: {integrity: sha512-F2SMW3LWFGXLm2ENTwTitrLWJgmMXRf3CWQXdN2EbkNCIBHy5Zcbt+91K4OX8e2e5h9gjGfrdYbyYDYOoUCEfA==}
-    dependencies:
-      core-js: 3.23.1
-      global: 4.4.0
-    dev: false
-
-  /@storybook/components/6.5.13_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-6Hhx70JK5pGfKCkqMU4yq/BBH+vRTmzj7tZKfPwba+f8VmTMoOr/2ysTQFRtXryiHB6Z15xBYgfq5x2pIwQzLQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@storybook/client-logger': 6.5.13
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/theming': 6.5.13_sfoxds7t5ydpegc3knd667wn6m
-      core-js: 3.23.1
-      memoizerific: 1.11.3
-      qs: 6.10.5
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      regenerator-runtime: 0.13.10
-      util-deprecate: 1.0.2
-    dev: false
-
-  /@storybook/core-events/6.5.13:
-    resolution: {integrity: sha512-kL745tPpRKejzHToA3/CoBNbI+NPRVk186vGxXBmk95OEg0TlwgQExP8BnqEtLlRZMbW08e4+6kilc1M1M4N5w==}
-    dependencies:
-      core-js: 3.23.1
-    dev: false
-
-  /@storybook/csf/0.0.2--canary.4566f4d.1:
-    resolution: {integrity: sha512-9OVvMVh3t9znYZwb0Svf/YQoxX2gVOeQTGe2bses2yj+a3+OJnCrUF3/hGv6Em7KujtOdL2LL+JnG49oMVGFgQ==}
-    dependencies:
-      lodash: 4.17.21
-    dev: false
-
-  /@storybook/router/6.5.13_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-sf5aogfirH5ucD0d0hc2mKf2iyWsZsvXhr5kjxUQmgkcoflkGUWhc34sbSQVRQ1i8K5lkLIDH/q2s1Zr2SbzhQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@storybook/client-logger': 6.5.13
-      core-js: 3.23.1
-      memoizerific: 1.11.3
-      qs: 6.10.5
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      regenerator-runtime: 0.13.10
-    dev: false
-
-  /@storybook/semver/7.3.2:
-    resolution: {integrity: sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      core-js: 3.23.1
-      find-up: 4.1.0
-    dev: false
-
-  /@storybook/theming/6.5.13_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-oif5NGFAUQhizo50r+ctw2hZNLWV4dPHai+L/gFvbaSeRBeHSNkIcMoZ2FlrO566HdGZTDutYXcR+xus8rI28g==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@storybook/client-logger': 6.5.13
-      core-js: 3.23.1
-      memoizerific: 1.11.3
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      regenerator-runtime: 0.13.10
-    dev: false
-
   /@testing-library/react-hooks/8.0.1_hiunvzosbwliizyirxfy6hjyim:
     resolution: {integrity: sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==}
     engines: {node: '>=12'}
@@ -3952,10 +3823,6 @@ packages:
     dependencies:
       '@types/node': 18.7.21
     dev: true
-
-  /@types/is-function/1.0.1:
-    resolution: {integrity: sha512-A79HEEiwXTFtfY+Bcbo58M2GRYzCr9itHWzbzHVFNEYCcoU/MMGwYYf721gBrnhpj1s6RGVVha/IgNFnR0Iw/Q==}
-    dev: false
 
   /@types/is-hotkey/0.1.7:
     resolution: {integrity: sha512-yB5C7zcOM7idwYZZ1wKQ3pTfjA9BbvFqRWvKB46GFddxnJtHwi/b9y84ykQtxQPg5qhdpg4Q/kWU3EGoCTmLzQ==}
@@ -4060,10 +3927,6 @@ packages:
 
   /@types/unist/2.0.6:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
-
-  /@types/webpack-env/1.17.0:
-    resolution: {integrity: sha512-eHSaNYEyxRA5IAG0Ym/yCyf86niZUIF/TpWKofQI/CVfh5HsMEUyfE2kwFxha4ow0s5g0LfISQxpDKjbRDrizw==}
-    dev: false
 
   /@types/yauzl/2.10.0:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
@@ -8660,11 +8523,6 @@ packages:
     resolution: {integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==}
     dev: true
 
-  /axe-core/4.4.2:
-    resolution: {integrity: sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==}
-    engines: {node: '>=12'}
-    dev: false
-
   /babel-plugin-styled-components/2.0.7_styled-components@5.3.6:
     resolution: {integrity: sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==}
     peerDependencies:
@@ -8696,10 +8554,6 @@ packages:
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: true
-
-  /batch-processor/1.0.0:
-    resolution: {integrity: sha512-xoLQD8gmmR32MeuBHgH0Tzd5PuSZx71ZsbhVxOCRbgktZEPe4SQy7s9Z50uPp0F/f7iw2XmkHN2xkgbMfckMDA==}
-    dev: false
 
   /bcrypt-pbkdf/1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
@@ -8789,6 +8643,7 @@ packages:
     dependencies:
       function-bind: 1.1.1
       get-intrinsic: 1.1.2
+    dev: true
 
   /callsites/3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -9066,12 +8921,6 @@ packages:
     resolution: {integrity: sha512-Vme1Z6RUDzrb6xAI7EZlVZ5uvOk2F//GaxKUxajDqm9LhOVM1inxNAD2vy+UZDYsd0uyA9s7b3/FVZPSxqrCfg==}
     dependencies:
       toggle-selection: 1.0.6
-    dev: false
-
-  /core-js/3.23.1:
-    resolution: {integrity: sha512-wfMYHWi1WQjpgZNC9kAlN4ut04TM9fUTdi7CqIoTVM7yaiOUQTklOzfb+oWH3r9edQcT3F887swuVmxrV+CC8w==}
-    deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
-    requiresBuild: true
     dev: false
 
   /core-util-is/1.0.2:
@@ -9386,12 +9235,6 @@ packages:
       esutils: 2.0.3
     dev: true
 
-  /dom-helpers/3.4.0:
-    resolution: {integrity: sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==}
-    dependencies:
-      '@babel/runtime': 7.20.1
-    dev: false
-
   /dom-serializer/1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
     dependencies:
@@ -9407,10 +9250,6 @@ packages:
       domhandler: 5.0.3
       entities: 4.4.0
     dev: true
-
-  /dom-walk/0.1.2:
-    resolution: {integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==}
-    dev: false
 
   /domelementtype/2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
@@ -9468,12 +9307,6 @@ packages:
 
   /electron-to-chromium/1.4.258:
     resolution: {integrity: sha512-vutF4q0dTUXoAFI7Vbtdwen/BJVwPgj8GRg/SElOodfH7VTX+svUe62A5BG41QRQGk5HsZPB0M++KH1lAlOt0A==}
-
-  /element-resize-detector/1.2.4:
-    resolution: {integrity: sha512-Fl5Ftk6WwXE0wqCgNoseKWndjzZlDCwuPTcoVZfCP9R3EHQF8qUtr3YUPNETegRBOKqQKPW3n4kiIWngGi8tKg==}
-    dependencies:
-      batch-processor: 1.0.0
-    dev: false
 
   /emoji-regex/8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -10506,6 +10339,7 @@ packages:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+    dev: true
 
   /find-up/5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -10661,6 +10495,7 @@ packages:
       function-bind: 1.1.1
       has: 1.0.3
       has-symbols: 1.0.3
+    dev: true
 
   /get-port/3.2.0:
     resolution: {integrity: sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==}
@@ -10735,13 +10570,6 @@ packages:
       ini: 2.0.0
     dev: true
 
-  /global/4.4.0:
-    resolution: {integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==}
-    dependencies:
-      min-document: 2.19.0
-      process: 0.11.10
-    dev: false
-
   /globals/11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
@@ -10813,12 +10641,14 @@ packages:
   /has-symbols/1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
     engines: {node: '>= 0.4'}
+    dev: true
 
   /has-tostringtag/1.0.0:
     resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
+    dev: true
 
   /has/1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
@@ -11009,12 +10839,6 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /invariant/2.2.4:
-    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
-    dependencies:
-      loose-envify: 1.4.0
-    dev: false
-
   /ipaddr.js/1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -11109,10 +10933,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /is-function/1.0.2:
-    resolution: {integrity: sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==}
-    dev: false
-
   /is-generator-function/1.0.10:
     resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
     engines: {node: '>= 0.4'}
@@ -11197,6 +11017,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       has-tostringtag: 1.0.0
+    dev: true
 
   /is-shared-array-buffer/1.0.2:
     resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==}
@@ -11221,6 +11042,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
+    dev: true
 
   /is-typed-array/1.1.9:
     resolution: {integrity: sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==}
@@ -11262,11 +11084,6 @@ packages:
 
   /isobject/3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  /isobject/4.0.0:
-    resolution: {integrity: sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==}
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -11541,6 +11358,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-locate: 4.1.0
+    dev: true
 
   /locate-path/6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -11634,10 +11452,6 @@ packages:
 
   /make-error/1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
-
-  /map-or-similar/1.5.0:
-    resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
-    dev: false
 
   /markdown-table/3.0.2:
     resolution: {integrity: sha512-y8j3a5/DkJCmS5x4dMCQL+OR0+2EAq3DOtio1COSHsmW2BGXnNCK3v12hJt1LrUz5iZH5g0LmuYOjDdI+czghA==}
@@ -11758,12 +11572,6 @@ packages:
 
   /mdn-data/2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
-    dev: false
-
-  /memoizerific/1.11.3:
-    resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
-    dependencies:
-      map-or-similar: 1.5.0
     dev: false
 
   /merge-stream/2.0.0:
@@ -12059,12 +11867,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /min-document/2.19.0:
-    resolution: {integrity: sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==}
-    dependencies:
-      dom-walk: 0.1.2
-    dev: false
-
   /min-indent/1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -12278,6 +12080,7 @@ packages:
 
   /object-inspect/1.12.2:
     resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
+    dev: true
 
   /object-keys/1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
@@ -12389,6 +12192,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       p-try: 2.2.0
+    dev: true
 
   /p-limit/3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -12409,6 +12213,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-limit: 2.3.0
+    dev: true
 
   /p-locate/5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -12434,6 +12239,7 @@ packages:
   /p-try/2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+    dev: true
 
   /papaparse/5.3.2:
     resolution: {integrity: sha512-6dNZu0Ki+gyV0eBsFKJhYr+MdQYAzFUGlBMNj3GNrmHxmz1lfRa24CjFObPXtjcetlOv5Ad299MhIK0znp3afw==}
@@ -12477,6 +12283,7 @@ packages:
   /path-exists/4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+    dev: true
 
   /path-exists/5.0.0:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
@@ -12691,11 +12498,6 @@ packages:
     resolution: {integrity: sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww==}
     dev: true
 
-  /process/0.11.10:
-    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
-    engines: {node: '>= 0.6.0'}
-    dev: false
-
   /promise/8.1.0:
     resolution: {integrity: sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==}
     dependencies:
@@ -12747,6 +12549,7 @@ packages:
     deprecated: when using stringify with arrayFormat comma, `[]` is appended on single-item arrays. Upgrade to v6.11.0 or downgrade to v6.10.4 to fix.
     dependencies:
       side-channel: 1.0.4
+    dev: true
 
   /qs/6.5.3:
     resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
@@ -12964,15 +12767,6 @@ packages:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
     engines: {node: '>=0.10.0'}
     dev: true
-
-  /react-sizeme/3.0.2:
-    resolution: {integrity: sha512-xOIAOqqSSmKlKFJLO3inBQBdymzDuXx4iuwkNcJmC96jeiOg5ojByvL+g3MW9LPEsojLbC6pf68zOfobK8IPlw==}
-    dependencies:
-      element-resize-detector: 1.2.4
-      invariant: 2.2.4
-      shallowequal: 1.1.0
-      throttle-debounce: 3.0.1
-    dev: false
 
   /react-textarea-autosize/8.4.0_pxzommwrsowkd4kgag6q3sluym:
     resolution: {integrity: sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==}
@@ -13413,6 +13207,7 @@ packages:
       call-bind: 1.0.2
       get-intrinsic: 1.1.2
       object-inspect: 1.12.2
+    dev: true
 
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -13607,10 +13402,6 @@ packages:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
     dev: true
-
-  /store2/2.13.2:
-    resolution: {integrity: sha512-CMtO2Uneg3SAz/d6fZ/6qbqqQHi2ynq6/KzMD/26gTkiEShCcpqFfTHgOxsE0egAq6SX3FmN4CeSqn8BzXQkJg==}
-    dev: false
 
   /strict-event-emitter/0.2.8:
     resolution: {integrity: sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==}
@@ -13880,19 +13671,6 @@ packages:
     transitivePeerDependencies:
       - ts-node
 
-  /telejson/6.0.8:
-    resolution: {integrity: sha512-nerNXi+j8NK1QEfBHtZUN/aLdDcyupA//9kAboYLrtzZlPLpUfqbVGWb9zz91f/mIjRbAYhbgtnJHY8I1b5MBg==}
-    dependencies:
-      '@types/is-function': 1.0.1
-      global: 4.4.0
-      is-function: 1.0.2
-      is-regex: 1.1.4
-      is-symbol: 1.0.4
-      isobject: 4.0.0
-      lodash: 4.17.21
-      memoizerific: 1.11.3
-    dev: false
-
   /text-table/0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
@@ -14016,11 +13794,6 @@ packages:
 
   /trough/2.1.0:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
-    dev: false
-
-  /ts-dedent/2.2.0:
-    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
-    engines: {node: '>=6.10'}
     dev: false
 
   /ts-easing/0.2.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.11
+      '@frontify/fondue': 12.0.0-beta.24
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -75,7 +75,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.11_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -156,7 +156,7 @@ importers:
       vite-plugin-dts: 1.7.0
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.29_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.22_sfoxds7t5ydpegc3knd667wn6m
+      '@frontify/fondue': 12.0.0-beta.24_sfoxds7t5ydpegc3knd667wn6m
     devDependencies:
       '@frontify/eslint-config-typescript': 0.15.5_pcit6nykmxit3vv6c7deq76n7y
       eslint: 8.27.0
@@ -173,7 +173,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.11
+      '@frontify/fondue': 12.0.0-beta.24
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -192,7 +192,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.11_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -218,7 +218,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.11
+      '@frontify/fondue': 12.0.0-beta.24
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -245,7 +245,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.11_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -282,7 +282,7 @@ importers:
       '@codemirror/view': ^6.5.1
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.11
+      '@frontify/fondue': 12.0.0-beta.24
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -307,7 +307,7 @@ importers:
       '@codemirror/state': 6.1.4
       '@codemirror/view': 6.5.1
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.11_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -336,7 +336,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.13
+      '@frontify/fondue': 12.0.0-beta.24
       '@frontify/fondue-tokens': 3.2.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -358,7 +358,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.13_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.2.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -387,7 +387,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.11
+      '@frontify/fondue': 12.0.0-beta.24
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -406,7 +406,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.11_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -433,7 +433,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.2
+      '@frontify/fondue': 12.0.0-beta.24
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -454,7 +454,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -483,7 +483,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.11
+      '@frontify/fondue': 12.0.0-beta.24
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -502,7 +502,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.11_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -528,7 +528,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.11
+      '@frontify/fondue': 12.0.0-beta.24
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -547,7 +547,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.11_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -573,7 +573,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.20
+      '@frontify/fondue': 12.0.0-beta.24
       '@frontify/fondue-tokens': 3.2.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -592,7 +592,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.20_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.2.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -618,7 +618,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.11
+      '@frontify/fondue': 12.0.0-beta.24
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -637,7 +637,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.11_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -663,7 +663,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.11
+      '@frontify/fondue': 12.0.0-beta.24
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -683,7 +683,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.11_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -710,7 +710,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.11
+      '@frontify/fondue': 12.0.0-beta.24
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -729,7 +729,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.11_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -755,7 +755,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-typescript': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.11
+      '@frontify/fondue': 12.0.0-beta.24
       '@frontify/guideline-blocks-settings': workspace:*
       '@testing-library/react-hooks': 8.0.1
       '@types/node': 18.7.21
@@ -779,7 +779,7 @@ importers:
       vitest: 0.25.0
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.11_rv2t7de65xq26o5frb4lun64yi
+      '@frontify/fondue': 12.0.0-beta.24_rv2t7de65xq26o5frb4lun64yi
       '@frontify/guideline-blocks-settings': link:../block-settings
       tinycolor2: 1.4.2
     devDependencies:
@@ -810,7 +810,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.11
+      '@frontify/fondue': 12.0.0-beta.24
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -829,7 +829,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.11_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -855,7 +855,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.11
+      '@frontify/fondue': 12.0.0-beta.24
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -875,7 +875,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.11_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -902,7 +902,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.27
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.11
+      '@frontify/fondue': 12.0.0-beta.24
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.1.2
       '@frontify/guideline-blocks-settings': workspace:*
@@ -923,7 +923,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.27_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.11_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': link:../block-settings
       '@frontify/guideline-blocks-shared': link:../shared
@@ -1702,8 +1702,21 @@ packages:
       tslib: 2.4.0
     dev: false
 
+  /@formatjs/ecma402-abstract/1.13.0:
+    resolution: {integrity: sha512-CQ8Ykd51jYD1n05dtoX6ns6B9n/+6ZAxnWUAonvHC4kkuAemROYBhHkEB4tm1uVrRlE7gLDqXkAnY51Y0pRCWQ==}
+    dependencies:
+      '@formatjs/intl-localematcher': 0.2.31
+      tslib: 2.4.0
+    dev: false
+
   /@formatjs/fast-memoize/1.2.1:
     resolution: {integrity: sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==}
+    dependencies:
+      tslib: 2.4.0
+    dev: false
+
+  /@formatjs/fast-memoize/1.2.6:
+    resolution: {integrity: sha512-9CWZ3+wCkClKHX+i5j+NyoBVqGf0pIskTo6Xl6ihGokYM2yqSSS68JIgeo+99UIHc+7vi9L3/SDSz/dWI9SNlA==}
     dependencies:
       tslib: 2.4.0
     dev: false
@@ -1716,6 +1729,21 @@ packages:
       tslib: 2.4.0
     dev: false
 
+  /@formatjs/icu-messageformat-parser/2.1.10:
+    resolution: {integrity: sha512-KkRMxhifWkRC45dhM9tqm0GXbb6NPYTGVYY3xx891IKc6p++DQrZTnmkVSNNO47OEERLfuP2KkPFPJBuu8z/wg==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.13.0
+      '@formatjs/icu-skeleton-parser': 1.3.14
+      tslib: 2.4.0
+    dev: false
+
+  /@formatjs/icu-skeleton-parser/1.3.14:
+    resolution: {integrity: sha512-7bv60HQQcBb3+TSj+45tOb/CHV5z1hOpwdtS50jsSBXfB+YpGhnoRsZxSRksXeCxMy6xn6tA6VY2601BrrK+OA==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.13.0
+      tslib: 2.4.0
+    dev: false
+
   /@formatjs/icu-skeleton-parser/1.3.6:
     resolution: {integrity: sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==}
     dependencies:
@@ -1725,6 +1753,12 @@ packages:
 
   /@formatjs/intl-localematcher/0.2.25:
     resolution: {integrity: sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==}
+    dependencies:
+      tslib: 2.4.0
+    dev: false
+
+  /@formatjs/intl-localematcher/0.2.31:
+    resolution: {integrity: sha512-9QTjdSBpQ7wHShZgsNzNig5qT3rCPvmZogS/wXZzKotns5skbXgs0I7J8cuN0PPqXyynvNVuN+iOKhNS2eb+ZA==}
     dependencies:
       tslib: 2.4.0
     dev: false
@@ -1845,85 +1879,13 @@ packages:
       - ts-node
     dev: false
 
-  /@frontify/fondue/12.0.0-beta.11_angvksxlvvfhyjj3xhcshgfg2m:
-    resolution: {integrity: sha512-7cXqfCSfUKMB+pFsJVTVhiilHDSkUXSFLfFpxlyEHae2dh7Na1PreIjgUF4anixeEpLwHJzrKqukr1vvp6otUw==}
-    peerDependencies:
-      react: ^17.0.2
-      react-dom: ^17.0.2
+  /@frontify/fondue-tokens/3.2.0_ts-node@10.9.1:
+    resolution: {integrity: sha512-GR2neBdz4bKlqxN+WdBWYHLpJRP+ERGonP97jdekeS/Rxgji6u6ddP4Gwgeu8vZQOorOX9c8bD6IBgKeGg4GCw==}
     dependencies:
-      '@frontify/fondue-tokens': 3.1.0
-      '@popperjs/core': 2.11.5
-      '@react-aria/accordion': 3.0.0-alpha.9_react@17.0.2
-      '@react-aria/aria-modal-polyfill': 3.4.4_react@17.0.2
-      '@react-aria/breadcrumbs': 3.1.10_react@17.0.2
-      '@react-aria/button': 3.5.1_react@17.0.2
-      '@react-aria/checkbox': 3.5.1_react@17.0.2
-      '@react-aria/combobox': 3.2.6_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/dialog': 3.1.9_react@17.0.2
-      '@react-aria/focus': 3.8.0_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/link': 3.2.5_react@17.0.2
-      '@react-aria/listbox': 3.4.5_react@17.0.2
-      '@react-aria/menu': 3.4.4_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/overlays': 3.8.2_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/radio': 3.1.11_react@17.0.2
-      '@react-aria/select': 3.6.5_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/selection': 3.9.1_react@17.0.2
-      '@react-aria/table': 3.2.4_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/tooltip': 3.1.8_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-aria/visually-hidden': 3.2.8_react@17.0.2
-      '@react-stately/checkbox': 3.2.1_react@17.0.2
-      '@react-stately/collections': 3.4.2_react@17.0.2
-      '@react-stately/combobox': 3.2.0_react@17.0.2
-      '@react-stately/list': 3.5.2_react@17.0.2
-      '@react-stately/menu': 3.4.0_react@17.0.2
-      '@react-stately/overlays': 3.4.0_react@17.0.2
-      '@react-stately/radio': 3.5.0_react@17.0.2
-      '@react-stately/select': 3.3.0_react@17.0.2
-      '@react-stately/table': 3.3.0_react@17.0.2
-      '@react-stately/toggle': 3.4.1_react@17.0.2
-      '@react-stately/tooltip': 3.2.0_react@17.0.2
-      '@react-stately/tree': 3.3.1_react@17.0.2
-      '@storybook/addon-a11y': 6.5.9_sfoxds7t5ydpegc3knd667wn6m
-      '@udecode/plate': 16.9.1_3applnbcmonz6yjsxb2hv5truu
-      '@xstate/immer': 0.3.1_immer@9.0.12+xstate@4.32.0
-      '@xstate/react': 1.6.3_3u7fm7vqjqg5ddhec34i275fya
-      date-fns: 2.28.0
-      framer-motion: 6.5.1_sfoxds7t5ydpegc3knd667wn6m
-      immer: 9.0.12
-      react: 17.0.2
-      react-colorful: 5.5.1_sfoxds7t5ydpegc3knd667wn6m
-      react-datepicker: 4.7.0_sfoxds7t5ydpegc3knd667wn6m
-      react-dnd: 15.1.2_pxzommwrsowkd4kgag6q3sluym
-      react-dnd-html5-backend: 15.1.3
-      react-dom: 17.0.2_react@17.0.2
-      react-is: 18.1.0
-      react-popper: 2.3.0_kz2vxbzpsgxv356x2ucg6oykdm
-      react-textarea-autosize: 8.3.4_pxzommwrsowkd4kgag6q3sluym
-      scheduler: 0.20.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-hyperscript: 0.77.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-      tinycolor2: 1.4.2
-      xstate: 4.32.0
+      postcss: 8.4.19
+      tailwindcss: 3.2.3_v776zzvn44o7tpgzieipaairwm
     transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/hoist-non-react-statics'
-      - '@types/node'
-      - '@types/react'
-      - '@urql/core'
-      - '@xstate/fsm'
-      - optics-ts
-      - react-native
-      - supports-color
       - ts-node
-      - valtio
-      - wonka
     dev: false
 
   /@frontify/fondue/12.0.0-beta.11_rv2t7de65xq26o5frb4lun64yi:
@@ -2007,153 +1969,75 @@ packages:
       - wonka
     dev: false
 
-  /@frontify/fondue/12.0.0-beta.13_angvksxlvvfhyjj3xhcshgfg2m:
-    resolution: {integrity: sha512-Zcro5nH55z/Rlq+JYIEPWiVxDByTPaC50ve0sz4ETo+o9J0R7Ga6z8fE4RK/R1NkG3hkW3qNAPO+FogzI9ExXQ==}
-    peerDependencies:
-      react: ^17.0.2
-      react-dom: ^17.0.2
-    dependencies:
-      '@frontify/fondue-tokens': 3.2.0
-      '@popperjs/core': 2.11.5
-      '@react-aria/accordion': 3.0.0-alpha.9_react@17.0.2
-      '@react-aria/aria-modal-polyfill': 3.4.4_react@17.0.2
-      '@react-aria/breadcrumbs': 3.1.10_react@17.0.2
-      '@react-aria/button': 3.5.1_react@17.0.2
-      '@react-aria/checkbox': 3.5.1_react@17.0.2
-      '@react-aria/combobox': 3.2.6_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/dialog': 3.1.9_react@17.0.2
-      '@react-aria/focus': 3.8.0_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/link': 3.2.5_react@17.0.2
-      '@react-aria/listbox': 3.4.5_react@17.0.2
-      '@react-aria/menu': 3.4.4_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/overlays': 3.8.2_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/radio': 3.1.11_react@17.0.2
-      '@react-aria/select': 3.6.5_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/selection': 3.9.1_react@17.0.2
-      '@react-aria/table': 3.2.4_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/tooltip': 3.1.8_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-aria/visually-hidden': 3.2.8_react@17.0.2
-      '@react-stately/checkbox': 3.2.1_react@17.0.2
-      '@react-stately/collections': 3.4.2_react@17.0.2
-      '@react-stately/combobox': 3.2.0_react@17.0.2
-      '@react-stately/list': 3.5.2_react@17.0.2
-      '@react-stately/menu': 3.4.0_react@17.0.2
-      '@react-stately/overlays': 3.4.0_react@17.0.2
-      '@react-stately/radio': 3.5.0_react@17.0.2
-      '@react-stately/select': 3.3.0_react@17.0.2
-      '@react-stately/table': 3.3.0_react@17.0.2
-      '@react-stately/toggle': 3.4.1_react@17.0.2
-      '@react-stately/tooltip': 3.2.0_react@17.0.2
-      '@react-stately/tree': 3.3.1_react@17.0.2
-      '@storybook/addon-a11y': 6.5.9_sfoxds7t5ydpegc3knd667wn6m
-      '@udecode/plate': 16.9.1_3applnbcmonz6yjsxb2hv5truu
-      '@xstate/immer': 0.3.1_immer@9.0.12+xstate@4.32.0
-      '@xstate/react': 1.6.3_3u7fm7vqjqg5ddhec34i275fya
-      date-fns: 2.28.0
-      framer-motion: 6.5.1_sfoxds7t5ydpegc3knd667wn6m
-      immer: 9.0.12
-      react: 17.0.2
-      react-colorful: 5.5.1_sfoxds7t5ydpegc3knd667wn6m
-      react-datepicker: 4.7.0_sfoxds7t5ydpegc3knd667wn6m
-      react-dnd: 15.1.2_pxzommwrsowkd4kgag6q3sluym
-      react-dnd-html5-backend: 15.1.3
-      react-dom: 17.0.2_react@17.0.2
-      react-is: 18.1.0
-      react-popper: 2.3.0_kz2vxbzpsgxv356x2ucg6oykdm
-      react-textarea-autosize: 8.3.4_pxzommwrsowkd4kgag6q3sluym
-      scheduler: 0.20.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-hyperscript: 0.77.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-      tinycolor2: 1.4.2
-      xstate: 4.32.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/hoist-non-react-statics'
-      - '@types/node'
-      - '@types/react'
-      - '@urql/core'
-      - '@xstate/fsm'
-      - optics-ts
-      - react-native
-      - supports-color
-      - ts-node
-      - valtio
-      - wonka
-    dev: false
-
-  /@frontify/fondue/12.0.0-beta.20_angvksxlvvfhyjj3xhcshgfg2m:
-    resolution: {integrity: sha512-ON4fUcfztBNV1FhaOL5QHYIYvGWylOsLEU0R37s57fBCP/Obbf8vvNcFGONJaCnhE64Cf0FjpFju0KLdA6UVtw==}
+  /@frontify/fondue/12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m:
+    resolution: {integrity: sha512-oNfBM9Gj2aJZ2Z0ApcBh6jU+Kj2xt/5KHCLKT8uyi69jYFb0DDRDFehBhU37YIU85SLtk3btGur8LCH8gxAuUQ==}
     engines: {node: ~16}
     peerDependencies:
       react: ^17.0.2
       react-dom: ^17.0.2
     dependencies:
       '@frontify/fondue-tokens': 3.2.0
-      '@popperjs/core': 2.11.5
+      '@popperjs/core': 2.11.6
       '@react-aria/accordion': 3.0.0-alpha.9_react@17.0.2
-      '@react-aria/aria-modal-polyfill': 3.4.4_react@17.0.2
+      '@react-aria/aria-modal-polyfill': 3.6.0_react@17.0.2
       '@react-aria/breadcrumbs': 3.1.10_react@17.0.2
-      '@react-aria/button': 3.5.1_react@17.0.2
-      '@react-aria/checkbox': 3.5.1_react@17.0.2
-      '@react-aria/combobox': 3.2.6_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/dialog': 3.1.9_react@17.0.2
-      '@react-aria/focus': 3.8.0_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/link': 3.2.5_react@17.0.2
-      '@react-aria/listbox': 3.4.5_react@17.0.2
-      '@react-aria/menu': 3.4.4_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/overlays': 3.8.2_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/radio': 3.1.11_react@17.0.2
-      '@react-aria/select': 3.6.5_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/selection': 3.9.1_react@17.0.2
-      '@react-aria/table': 3.2.4_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/tooltip': 3.1.8_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-aria/visually-hidden': 3.2.8_react@17.0.2
-      '@react-stately/checkbox': 3.2.1_react@17.0.2
-      '@react-stately/collections': 3.4.2_react@17.0.2
-      '@react-stately/combobox': 3.2.0_react@17.0.2
-      '@react-stately/list': 3.5.2_react@17.0.2
-      '@react-stately/menu': 3.4.0_react@17.0.2
-      '@react-stately/overlays': 3.4.0_react@17.0.2
-      '@react-stately/radio': 3.5.0_react@17.0.2
-      '@react-stately/select': 3.3.0_react@17.0.2
-      '@react-stately/table': 3.3.0_react@17.0.2
-      '@react-stately/toggle': 3.4.1_react@17.0.2
-      '@react-stately/tooltip': 3.2.0_react@17.0.2
-      '@react-stately/tree': 3.3.1_react@17.0.2
+      '@react-aria/button': 3.6.2_react@17.0.2
+      '@react-aria/checkbox': 3.6.0_react@17.0.2
+      '@react-aria/combobox': 3.4.2_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/dialog': 3.4.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/focus': 3.9.0_react@17.0.2
+      '@react-aria/interactions': 3.12.0_react@17.0.2
+      '@react-aria/link': 3.3.4_react@17.0.2
+      '@react-aria/listbox': 3.7.0_react@17.0.2
+      '@react-aria/menu': 3.6.2_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/overlays': 3.8.1_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/radio': 3.4.0_react@17.0.2
+      '@react-aria/select': 3.8.2_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/selection': 3.11.0_react@17.0.2
+      '@react-aria/table': 3.5.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/tooltip': 3.3.2_react@17.0.2
+      '@react-aria/utils': 3.14.0_react@17.0.2
+      '@react-aria/visually-hidden': 3.5.0_react@17.0.2
+      '@react-stately/checkbox': 3.3.0_react@17.0.2
+      '@react-stately/collections': 3.4.4_react@17.0.2
+      '@react-stately/combobox': 3.2.2_react@17.0.2
+      '@react-stately/list': 3.5.4_react@17.0.2
+      '@react-stately/menu': 3.4.2_react@17.0.2
+      '@react-stately/overlays': 3.4.2_react@17.0.2
+      '@react-stately/radio': 3.6.0_react@17.0.2
+      '@react-stately/select': 3.3.2_react@17.0.2
+      '@react-stately/table': 3.5.0_react@17.0.2
+      '@react-stately/toggle': 3.4.2_react@17.0.2
+      '@react-stately/tooltip': 3.2.2_react@17.0.2
+      '@react-stately/tree': 3.3.4_react@17.0.2
       '@storybook/addon-a11y': 6.5.13_sfoxds7t5ydpegc3knd667wn6m
-      '@udecode/plate': 18.9.0_3applnbcmonz6yjsxb2hv5truu
-      '@xstate/immer': 0.3.1_immer@9.0.12+xstate@4.32.0
-      '@xstate/react': 1.6.3_3u7fm7vqjqg5ddhec34i275fya
-      date-fns: 2.28.0
+      '@udecode/plate': 18.9.0_lq7qkw3fyxdfk55wtvczfr7dqi
+      '@xstate/immer': 0.3.1_immer@9.0.12+xstate@4.28.1
+      '@xstate/react': 1.6.3_gcyz5mxmyrgibkcjljkbjmosn4
+      date-fns: 2.29.3
       escape-html: 1.0.3
-      framer-motion: 6.5.1_sfoxds7t5ydpegc3knd667wn6m
+      framer-motion: 6.4.3_sfoxds7t5ydpegc3knd667wn6m
       immer: 9.0.12
       react: 17.0.2
-      react-colorful: 5.5.1_sfoxds7t5ydpegc3knd667wn6m
-      react-datepicker: 4.7.0_sfoxds7t5ydpegc3knd667wn6m
-      react-dnd: 15.1.2_pxzommwrsowkd4kgag6q3sluym
-      react-dnd-html5-backend: 15.1.3
+      react-colorful: 5.6.1_sfoxds7t5ydpegc3knd667wn6m
+      react-datepicker: 4.8.0_sfoxds7t5ydpegc3knd667wn6m
+      react-dnd: 16.0.1_pxzommwrsowkd4kgag6q3sluym
+      react-dnd-html5-backend: 15.1.2
       react-dom: 17.0.2_react@17.0.2
-      react-is: 18.1.0
-      react-popper: 2.3.0_kz2vxbzpsgxv356x2ucg6oykdm
-      react-textarea-autosize: 8.3.4_pxzommwrsowkd4kgag6q3sluym
+      react-is: 18.2.0
+      react-popper: 2.3.0_vov5yimr6vvxyufd6uigwwkst4
+      react-textarea-autosize: 8.4.0_pxzommwrsowkd4kgag6q3sluym
+      remark-gfm: 3.0.1
+      remark-parse: 10.0.1
       scheduler: 0.20.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-hyperscript: 0.77.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
       tinycolor2: 1.4.2
-      xstate: 4.32.0
+      unified: 10.1.2
+      xstate: 4.28.1
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -2171,153 +2055,161 @@ packages:
       - wonka
     dev: false
 
-  /@frontify/fondue/12.0.0-beta.22_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-+2nLxecWYxpphGi6ZH2uocyKHd0cwfbcYPMAihKXhElGyqUGhdBs+cbt4mL/XAPRrYPAHXk2p3C3DsY8BS8TKw==}
+  /@frontify/fondue/12.0.0-beta.24_rv2t7de65xq26o5frb4lun64yi:
+    resolution: {integrity: sha512-oNfBM9Gj2aJZ2Z0ApcBh6jU+Kj2xt/5KHCLKT8uyi69jYFb0DDRDFehBhU37YIU85SLtk3btGur8LCH8gxAuUQ==}
+    engines: {node: ~16}
+    peerDependencies:
+      react: ^17.0.2
+      react-dom: ^17.0.2
+    dependencies:
+      '@frontify/fondue-tokens': 3.2.0_ts-node@10.9.1
+      '@popperjs/core': 2.11.6
+      '@react-aria/accordion': 3.0.0-alpha.9_react@17.0.2
+      '@react-aria/aria-modal-polyfill': 3.6.0_react@17.0.2
+      '@react-aria/breadcrumbs': 3.1.10_react@17.0.2
+      '@react-aria/button': 3.6.2_react@17.0.2
+      '@react-aria/checkbox': 3.6.0_react@17.0.2
+      '@react-aria/combobox': 3.4.2_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/dialog': 3.4.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/focus': 3.9.0_react@17.0.2
+      '@react-aria/interactions': 3.12.0_react@17.0.2
+      '@react-aria/link': 3.3.4_react@17.0.2
+      '@react-aria/listbox': 3.7.0_react@17.0.2
+      '@react-aria/menu': 3.6.2_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/overlays': 3.8.1_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/radio': 3.4.0_react@17.0.2
+      '@react-aria/select': 3.8.2_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/selection': 3.11.0_react@17.0.2
+      '@react-aria/table': 3.5.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/tooltip': 3.3.2_react@17.0.2
+      '@react-aria/utils': 3.14.0_react@17.0.2
+      '@react-aria/visually-hidden': 3.5.0_react@17.0.2
+      '@react-stately/checkbox': 3.3.0_react@17.0.2
+      '@react-stately/collections': 3.4.4_react@17.0.2
+      '@react-stately/combobox': 3.2.2_react@17.0.2
+      '@react-stately/list': 3.5.4_react@17.0.2
+      '@react-stately/menu': 3.4.2_react@17.0.2
+      '@react-stately/overlays': 3.4.2_react@17.0.2
+      '@react-stately/radio': 3.6.0_react@17.0.2
+      '@react-stately/select': 3.3.2_react@17.0.2
+      '@react-stately/table': 3.5.0_react@17.0.2
+      '@react-stately/toggle': 3.4.2_react@17.0.2
+      '@react-stately/tooltip': 3.2.2_react@17.0.2
+      '@react-stately/tree': 3.3.4_react@17.0.2
+      '@storybook/addon-a11y': 6.5.13_sfoxds7t5ydpegc3knd667wn6m
+      '@udecode/plate': 18.9.0_lq7qkw3fyxdfk55wtvczfr7dqi
+      '@xstate/immer': 0.3.1_immer@9.0.12+xstate@4.28.1
+      '@xstate/react': 1.6.3_gcyz5mxmyrgibkcjljkbjmosn4
+      date-fns: 2.29.3
+      escape-html: 1.0.3
+      framer-motion: 6.4.3_sfoxds7t5ydpegc3knd667wn6m
+      immer: 9.0.12
+      react: 17.0.2
+      react-colorful: 5.6.1_sfoxds7t5ydpegc3knd667wn6m
+      react-datepicker: 4.8.0_sfoxds7t5ydpegc3knd667wn6m
+      react-dnd: 16.0.1_smc5esni47gpbltvxzeziduyte
+      react-dnd-html5-backend: 15.1.2
+      react-dom: 17.0.2_react@17.0.2
+      react-is: 18.2.0
+      react-popper: 2.3.0_vov5yimr6vvxyufd6uigwwkst4
+      react-textarea-autosize: 8.4.0_pxzommwrsowkd4kgag6q3sluym
+      remark-gfm: 3.0.1
+      remark-parse: 10.0.1
+      scheduler: 0.20.2
+      slate: 0.78.0
+      slate-history: 0.66.0_slate@0.78.0
+      slate-hyperscript: 0.77.0_slate@0.78.0
+      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+      tinycolor2: 1.4.2
+      unified: 10.1.2
+      xstate: 4.28.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@tanstack/query-core'
+      - '@types/hoist-non-react-statics'
+      - '@types/node'
+      - '@types/react'
+      - '@urql/core'
+      - '@xstate/fsm'
+      - optics-ts
+      - react-native
+      - supports-color
+      - ts-node
+      - valtio
+      - wonka
+    dev: false
+
+  /@frontify/fondue/12.0.0-beta.24_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-oNfBM9Gj2aJZ2Z0ApcBh6jU+Kj2xt/5KHCLKT8uyi69jYFb0DDRDFehBhU37YIU85SLtk3btGur8LCH8gxAuUQ==}
     engines: {node: ~16}
     peerDependencies:
       react: ^17.0.2
       react-dom: ^17.0.2
     dependencies:
       '@frontify/fondue-tokens': 3.2.0
-      '@popperjs/core': 2.11.5
+      '@popperjs/core': 2.11.6
       '@react-aria/accordion': 3.0.0-alpha.9_react@17.0.2
-      '@react-aria/aria-modal-polyfill': 3.4.4_react@17.0.2
+      '@react-aria/aria-modal-polyfill': 3.6.0_react@17.0.2
       '@react-aria/breadcrumbs': 3.1.10_react@17.0.2
-      '@react-aria/button': 3.5.1_react@17.0.2
-      '@react-aria/checkbox': 3.5.1_react@17.0.2
-      '@react-aria/combobox': 3.2.6_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/dialog': 3.1.9_react@17.0.2
-      '@react-aria/focus': 3.8.0_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/link': 3.2.5_react@17.0.2
-      '@react-aria/listbox': 3.4.5_react@17.0.2
-      '@react-aria/menu': 3.4.4_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/overlays': 3.8.2_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/radio': 3.1.11_react@17.0.2
-      '@react-aria/select': 3.6.5_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/selection': 3.9.1_react@17.0.2
-      '@react-aria/table': 3.2.4_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/tooltip': 3.1.8_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-aria/visually-hidden': 3.2.8_react@17.0.2
-      '@react-stately/checkbox': 3.2.1_react@17.0.2
-      '@react-stately/collections': 3.4.2_react@17.0.2
-      '@react-stately/combobox': 3.2.0_react@17.0.2
-      '@react-stately/list': 3.5.2_react@17.0.2
-      '@react-stately/menu': 3.4.0_react@17.0.2
-      '@react-stately/overlays': 3.4.0_react@17.0.2
-      '@react-stately/radio': 3.5.0_react@17.0.2
-      '@react-stately/select': 3.3.0_react@17.0.2
-      '@react-stately/table': 3.3.0_react@17.0.2
-      '@react-stately/toggle': 3.4.1_react@17.0.2
-      '@react-stately/tooltip': 3.2.0_react@17.0.2
-      '@react-stately/tree': 3.3.1_react@17.0.2
+      '@react-aria/button': 3.6.2_react@17.0.2
+      '@react-aria/checkbox': 3.6.0_react@17.0.2
+      '@react-aria/combobox': 3.4.2_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/dialog': 3.4.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/focus': 3.9.0_react@17.0.2
+      '@react-aria/interactions': 3.12.0_react@17.0.2
+      '@react-aria/link': 3.3.4_react@17.0.2
+      '@react-aria/listbox': 3.7.0_react@17.0.2
+      '@react-aria/menu': 3.6.2_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/overlays': 3.8.1_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/radio': 3.4.0_react@17.0.2
+      '@react-aria/select': 3.8.2_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/selection': 3.11.0_react@17.0.2
+      '@react-aria/table': 3.5.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/tooltip': 3.3.2_react@17.0.2
+      '@react-aria/utils': 3.14.0_react@17.0.2
+      '@react-aria/visually-hidden': 3.5.0_react@17.0.2
+      '@react-stately/checkbox': 3.3.0_react@17.0.2
+      '@react-stately/collections': 3.4.4_react@17.0.2
+      '@react-stately/combobox': 3.2.2_react@17.0.2
+      '@react-stately/list': 3.5.4_react@17.0.2
+      '@react-stately/menu': 3.4.2_react@17.0.2
+      '@react-stately/overlays': 3.4.2_react@17.0.2
+      '@react-stately/radio': 3.6.0_react@17.0.2
+      '@react-stately/select': 3.3.2_react@17.0.2
+      '@react-stately/table': 3.5.0_react@17.0.2
+      '@react-stately/toggle': 3.4.2_react@17.0.2
+      '@react-stately/tooltip': 3.2.2_react@17.0.2
+      '@react-stately/tree': 3.3.4_react@17.0.2
       '@storybook/addon-a11y': 6.5.13_sfoxds7t5ydpegc3knd667wn6m
-      '@udecode/plate': 18.9.0_zanjem6utblhvsgiqea5mzthka
-      '@xstate/immer': 0.3.1_immer@9.0.12+xstate@4.32.0
-      '@xstate/react': 1.6.3_react@17.0.2+xstate@4.32.0
-      date-fns: 2.28.0
+      '@udecode/plate': 18.9.0_ynovzzal4ukqjumbrzchvba2hi
+      '@xstate/immer': 0.3.1_immer@9.0.12+xstate@4.28.1
+      '@xstate/react': 1.6.3_react@17.0.2+xstate@4.28.1
+      date-fns: 2.29.3
       escape-html: 1.0.3
-      framer-motion: 6.5.1_sfoxds7t5ydpegc3knd667wn6m
+      framer-motion: 6.4.3_sfoxds7t5ydpegc3knd667wn6m
       immer: 9.0.12
       react: 17.0.2
-      react-colorful: 5.5.1_sfoxds7t5ydpegc3knd667wn6m
-      react-datepicker: 4.7.0_sfoxds7t5ydpegc3knd667wn6m
-      react-dnd: 15.1.2_react@17.0.2
-      react-dnd-html5-backend: 15.1.3
+      react-colorful: 5.6.1_sfoxds7t5ydpegc3knd667wn6m
+      react-datepicker: 4.8.0_sfoxds7t5ydpegc3knd667wn6m
+      react-dnd: 16.0.1_react@17.0.2
+      react-dnd-html5-backend: 15.1.2
       react-dom: 17.0.2_react@17.0.2
-      react-is: 18.1.0
-      react-popper: 2.3.0_kz2vxbzpsgxv356x2ucg6oykdm
-      react-textarea-autosize: 8.3.4_react@17.0.2
+      react-is: 18.2.0
+      react-popper: 2.3.0_vov5yimr6vvxyufd6uigwwkst4
+      react-textarea-autosize: 8.4.0_react@17.0.2
+      remark-gfm: 3.0.1
+      remark-parse: 10.0.1
       scheduler: 0.20.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-hyperscript: 0.77.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
       tinycolor2: 1.4.2
-      xstate: 4.32.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/hoist-non-react-statics'
-      - '@types/node'
-      - '@types/react'
-      - '@urql/core'
-      - '@xstate/fsm'
-      - optics-ts
-      - react-native
-      - supports-color
-      - ts-node
-      - valtio
-      - wonka
-    dev: false
-
-  /@frontify/fondue/12.0.0-beta.2_angvksxlvvfhyjj3xhcshgfg2m:
-    resolution: {integrity: sha512-kOkIjVfDyyuxK9Y0u7G5eqt+yDbY3x+rCecHScBz4xjXrYmggiATLuILvG2LHU/xnwb7YZZcyGG1bqCaRIPqsw==}
-    peerDependencies:
-      react: ^17.0.2
-      react-dom: ^17.0.2
-    dependencies:
-      '@frontify/fondue-tokens': 3.2.0
-      '@popperjs/core': 2.11.5
-      '@react-aria/accordion': 3.0.0-alpha.9_react@17.0.2
-      '@react-aria/aria-modal-polyfill': 3.4.4_react@17.0.2
-      '@react-aria/breadcrumbs': 3.1.10_react@17.0.2
-      '@react-aria/button': 3.5.1_react@17.0.2
-      '@react-aria/checkbox': 3.5.1_react@17.0.2
-      '@react-aria/combobox': 3.2.6_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/dialog': 3.1.9_react@17.0.2
-      '@react-aria/focus': 3.8.0_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/link': 3.2.5_react@17.0.2
-      '@react-aria/listbox': 3.4.5_react@17.0.2
-      '@react-aria/menu': 3.4.4_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/overlays': 3.8.2_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/radio': 3.1.11_react@17.0.2
-      '@react-aria/select': 3.6.5_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/selection': 3.9.1_react@17.0.2
-      '@react-aria/table': 3.2.4_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/tooltip': 3.1.8_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-aria/visually-hidden': 3.2.8_react@17.0.2
-      '@react-stately/checkbox': 3.2.1_react@17.0.2
-      '@react-stately/collections': 3.4.2_react@17.0.2
-      '@react-stately/combobox': 3.2.0_react@17.0.2
-      '@react-stately/list': 3.5.2_react@17.0.2
-      '@react-stately/menu': 3.4.0_react@17.0.2
-      '@react-stately/overlays': 3.4.0_react@17.0.2
-      '@react-stately/radio': 3.5.0_react@17.0.2
-      '@react-stately/select': 3.3.0_react@17.0.2
-      '@react-stately/table': 3.3.0_react@17.0.2
-      '@react-stately/toggle': 3.4.1_react@17.0.2
-      '@react-stately/tooltip': 3.2.0_react@17.0.2
-      '@react-stately/tree': 3.3.1_react@17.0.2
-      '@storybook/addon-a11y': 6.5.9_sfoxds7t5ydpegc3knd667wn6m
-      '@udecode/plate': 16.9.1_3applnbcmonz6yjsxb2hv5truu
-      '@xstate/immer': 0.3.1_immer@9.0.12+xstate@4.32.0
-      '@xstate/react': 1.6.3_3u7fm7vqjqg5ddhec34i275fya
-      date-fns: 2.28.0
-      framer-motion: 6.5.1_sfoxds7t5ydpegc3knd667wn6m
-      immer: 9.0.12
-      react: 17.0.2
-      react-colorful: 5.5.1_sfoxds7t5ydpegc3knd667wn6m
-      react-datepicker: 4.7.0_sfoxds7t5ydpegc3knd667wn6m
-      react-dnd: 15.1.2_pxzommwrsowkd4kgag6q3sluym
-      react-dnd-html5-backend: 15.1.3
-      react-dom: 17.0.2_react@17.0.2
-      react-is: 18.1.0
-      react-popper: 2.3.0_kz2vxbzpsgxv356x2ucg6oykdm
-      react-textarea-autosize: 8.3.4_pxzommwrsowkd4kgag6q3sluym
-      scheduler: 0.20.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-hyperscript: 0.77.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-      tinycolor2: 1.4.2
-      xstate: 4.32.0
+      unified: 10.1.2
+      xstate: 4.28.1
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -2378,20 +2270,39 @@ packages:
   /@internationalized/date/3.0.0:
     resolution: {integrity: sha512-mvlQCeYNg7JgO+QtIIx1zFJx10CJNVnt8cOjW2pYab1Ap/c7BYybS37Z5oTCdmRZbvnpmWtjhOEH324zlgWHLw==}
     dependencies:
-      '@babel/runtime': 7.17.9
+      '@babel/runtime': 7.20.1
+    dev: false
+
+  /@internationalized/date/3.0.1:
+    resolution: {integrity: sha512-E/3lASs4mAeJ2Z2ye6ab7eUD0bPUfTeNVTAv6IS+ne9UtMu9Uepb9A1U2Ae0hDr6WAlBuvUtrakaxEdYB9TV6Q==}
+    dependencies:
+      '@babel/runtime': 7.20.1
     dev: false
 
   /@internationalized/message/3.0.8:
     resolution: {integrity: sha512-5B9zvBgyPZi0ciPgisW835WTuvjVIWFf4IJex1Swb5mDwonbi0lO2teAjBVGV25NTI0OKq1GM9PAWXXUzv6Waw==}
     dependencies:
-      '@babel/runtime': 7.17.9
+      '@babel/runtime': 7.20.1
       intl-messageformat: 9.13.0
+    dev: false
+
+  /@internationalized/message/3.0.9:
+    resolution: {integrity: sha512-yHQggKWUuSvj1GznVtie4tcYq+xMrkd/lTKCFHp6gG18KbIliDw+UI7sL9+yJPGuWiR083xuLyyhzqiPbNOEww==}
+    dependencies:
+      '@babel/runtime': 7.20.1
+      intl-messageformat: 10.2.1
     dev: false
 
   /@internationalized/number/3.1.1:
     resolution: {integrity: sha512-dBxCQKIxvsZvW2IBt3KsqrCfaw2nV6o6a8xsloJn/hjW0ayeyhKuiiMtTwW3/WGNPP7ZRyDbtuiUEjMwif1ENQ==}
     dependencies:
-      '@babel/runtime': 7.17.9
+      '@babel/runtime': 7.20.1
+    dev: false
+
+  /@internationalized/string/3.0.0:
+    resolution: {integrity: sha512-NUSr4u+mNu5BysXFeVWZW4kvjXylPkU/YYqaWzdNuz1eABfehFiZTEYhWAAMzI3U8DTxfqF9PM3zyhk5gcfz6w==}
+    dependencies:
+      '@babel/runtime': 7.20.1
     dev: false
 
   /@jridgewell/gen-mapping/0.1.1:
@@ -2673,6 +2584,10 @@ packages:
     resolution: {integrity: sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==}
     dev: false
 
+  /@popperjs/core/2.11.6:
+    resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
+    dev: false
+
   /@radix-ui/react-compose-refs/0.1.0_react@17.0.2:
     resolution: {integrity: sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==}
     peerDependencies:
@@ -2687,7 +2602,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.17.9
+      '@babel/runtime': 7.20.1
       react: 17.0.2
     dev: false
 
@@ -2706,7 +2621,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.17.9
+      '@babel/runtime': 7.20.1
       '@radix-ui/react-compose-refs': 1.0.0_react@17.0.2
       react: 17.0.2
     dev: false
@@ -2716,15 +2631,15 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/button': 3.5.1_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/selection': 3.9.1_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-stately/tree': 3.3.1_react@17.0.2
+      '@babel/runtime': 7.20.1
+      '@react-aria/button': 3.6.2_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/selection': 3.12.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-stately/tree': 3.3.4_react@17.0.2
       '@react-types/accordion': 3.0.0-alpha.7_react@17.0.2
-      '@react-types/button': 3.5.1_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
+      '@react-types/button': 3.7.0_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -2739,18 +2654,29 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-aria/aria-modal-polyfill/3.6.0_react@17.0.2:
+    resolution: {integrity: sha512-coWVSX/esVk2z8f8aXbaT4HzIjv6V7tYy+3gbOTACkI96QtXbtzWawq2gNpssNnT6zEh/4Ox2iwKYQEU6xSdEQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-types/shared': 3.16.0_react@17.0.2
+      aria-hidden: 1.1.3
+      react: 17.0.2
+    dev: false
+
   /@react-aria/breadcrumbs/3.1.10_react@17.0.2:
     resolution: {integrity: sha512-kuUVQYDSrA5799icfuG9oIw/+zSECZ9J1QiABUsiOdM64TYeDeULfGLV2RV376SB44V8bK8maoZtJ7ewU5gcHg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1
     dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/i18n': 3.4.1_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/link': 3.2.5_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
+      '@babel/runtime': 7.20.1
+      '@react-aria/i18n': 3.6.2_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/link': 3.3.4_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
       '@react-types/breadcrumbs': 3.3.0_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -2768,6 +2694,21 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-aria/button/3.6.2_react@17.0.2:
+    resolution: {integrity: sha512-8XRcPR5qXKNmnBO6u9FSY8vYa7P1FIgVix07EHBCTZiJYHYxcUsFYRWG9qf2aShGotJs4957unqGH1L1ncRYKQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-stately/toggle': 3.4.3_react@17.0.2
+      '@react-types/button': 3.7.0_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-aria/checkbox/3.5.1_react@17.0.2:
     resolution: {integrity: sha512-a3ONNbjV4nkLRV7G+hQysHwkvKTtB1++A4ceL8psbvbslii62F6qYzmgp/AK5D086cQJGxiqkEPLi049xfGuDA==}
     peerDependencies:
@@ -2781,6 +2722,22 @@ packages:
       '@react-stately/toggle': 3.4.1_react@17.0.2
       '@react-types/checkbox': 3.3.3_react@17.0.2
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-aria/checkbox/3.6.0_react@17.0.2:
+    resolution: {integrity: sha512-E2MZoMZhtHtlS1mYjxTI29JRq4s3Y6d92KHj7tzvcC308d4Bzz0IHJd0bMz/8whoNteU02pQyZ3rDAcGf92bHQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/label': 3.4.3_react@17.0.2
+      '@react-aria/toggle': 3.4.1_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-stately/checkbox': 3.3.0_react@17.0.2
+      '@react-stately/toggle': 3.4.3_react@17.0.2
+      '@react-types/checkbox': 3.4.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -2810,6 +2767,32 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
+  /@react-aria/combobox/3.4.2_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-LFB0L2WLR7hc5J2c36jdgekHigLv4PwZfNRlh+B4VX474pS9Zt33F0FIrCKsYZA8xXzvM+lXr4POjwsoBhmnJw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/i18n': 3.6.2_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/listbox': 3.7.0_react@17.0.2
+      '@react-aria/live-announcer': 3.1.1
+      '@react-aria/menu': 3.6.2_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/overlays': 3.12.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/selection': 3.12.0_react@17.0.2
+      '@react-aria/textfield': 3.8.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-stately/collections': 3.5.0_react@17.0.2
+      '@react-stately/combobox': 3.2.2_react@17.0.2
+      '@react-stately/layout': 3.9.0_react@17.0.2
+      '@react-types/button': 3.7.0_react@17.0.2
+      '@react-types/combobox': 3.5.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    dev: false
+
   /@react-aria/dialog/3.1.9_react@17.0.2:
     resolution: {integrity: sha512-S/HE6XxBU9AiL4TGBjmz4CAEXjCD9nwvV5ofBKlbfPzgimmmSJj3SVNtsawKIt3KyP9AEioyJydM/vbGfccJlw==}
     peerDependencies:
@@ -2823,6 +2806,36 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-aria/dialog/3.4.0_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-h1D7OOe20PhSb4DD40ABVgHMbSA2Y9rSU5lrGf9zuNSYkQIwDz6pTSXp/9roy7SEvf5KAN6zPa1inSVBOTzf3w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/overlays': 3.12.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-stately/overlays': 3.4.3_react@17.0.2
+      '@react-types/dialog': 3.4.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    transitivePeerDependencies:
+      - react-dom
+    dev: false
+
+  /@react-aria/focus/3.10.0_react@17.0.2:
+    resolution: {integrity: sha512-idI7Etgh6y2BYi3X4d+EuUpzR7gPZ94Lf/0UNnVyMkDM9fzcdz/8DCBt0qKOff24HlaLE1rmREt0+iTR/qRgbA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      clsx: 1.1.1
+      react: 17.0.2
+    dev: false
+
   /@react-aria/focus/3.8.0_react@17.0.2:
     resolution: {integrity: sha512-XuaLFdqf/6OyILifkVJo++5k2O+wlpNvXgsJkRWn/wSmB77pZKURm2MMGiSg2u911NqY+829UrSlpmhCZrc8RA==}
     peerDependencies:
@@ -2832,6 +2845,19 @@ packages:
       '@react-aria/interactions': 3.11.0_react@17.0.2
       '@react-aria/utils': 3.13.3_react@17.0.2
       '@react-types/shared': 3.14.1_react@17.0.2
+      clsx: 1.1.1
+      react: 17.0.2
+    dev: false
+
+  /@react-aria/focus/3.9.0_react@17.0.2:
+    resolution: {integrity: sha512-DwesjEjWjFfwAwzv9qeqkyKZNPAYmPa3UrygxzmXeKEg2JpaACGZPxRcmT2EFJFEDbX8daQDEeRGyLO49o5agg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
       clsx: 1.1.1
       react: 17.0.2
     dev: false
@@ -2859,18 +2885,57 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
+  /@react-aria/grid/3.5.1_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-eWwhG9wHb6l6poZSvnhoSSCpNy1kG3HxIpcbMaR2/qllbUYgZ4PASyx4N2TT/VqBUsxCSwC/WqcDka11U9d94w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/i18n': 3.6.2_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/live-announcer': 3.1.1
+      '@react-aria/selection': 3.12.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-stately/grid': 3.4.1_react@17.0.2
+      '@react-stately/selection': 3.11.1_react@17.0.2
+      '@react-stately/virtualizer': 3.4.0_react@17.0.2
+      '@react-types/checkbox': 3.4.1_react@17.0.2
+      '@react-types/grid': 3.1.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    dev: false
+
   /@react-aria/i18n/3.4.1_react@17.0.2:
     resolution: {integrity: sha512-/nrMpWOFmbn9R04JfWgGFRJ/oYBZLIydLBuWVw3ugwyKrHhIj/xRFrAMcGKspEZIymIANv9cnoTYhwk8d/DCEg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.17.9
+      '@babel/runtime': 7.20.1
       '@internationalized/date': 3.0.0
       '@internationalized/message': 3.0.8
       '@internationalized/number': 3.1.1
       '@react-aria/ssr': 3.3.0_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
+      '@react-aria/utils': 3.14.0_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-aria/i18n/3.6.2_react@17.0.2:
+    resolution: {integrity: sha512-/G22mZQcISX6DcKLBn4j/X53y2SOnFfiD4wOEuY7sIZZDryktd+3I/QHukCnNlf0tKK3PdixQLvWa9Q1RqTSaw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@internationalized/date': 3.0.1
+      '@internationalized/message': 3.0.9
+      '@internationalized/number': 3.1.1
+      '@internationalized/string': 3.0.0
+      '@react-aria/ssr': 3.4.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -2882,6 +2947,28 @@ packages:
       '@babel/runtime': 7.17.9
       '@react-aria/utils': 3.13.3_react@17.0.2
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-aria/interactions/3.12.0_react@17.0.2:
+    resolution: {integrity: sha512-KcKurjPZwme9ggvGQjbjqZtZtuyXipTBVMHUah9a3+Dz7vXxhRg5vFaEdM79oQnNsrGFW5xS6SKBehl/JG6BMw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-aria/interactions/3.13.0_react@17.0.2:
+    resolution: {integrity: sha512-gbZL+qs+6FPitR/abAramth4lqz/drEzXwzIDF6p6WyajF805mjyAgZin1/3mQygSE5BwJNDU7jMUSGRvgFyTw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -2908,6 +2995,18 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-aria/label/3.4.3_react@17.0.2:
+    resolution: {integrity: sha512-g8NSHQKha6xOpR0cUQ6cmH/HwGJdebEbyy+c1I6VeW6me8lSF47xLnybnA6LBV4x9hJqkST6rfL/oPaBMCEKNA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-types/label': 3.7.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-aria/link/3.2.5_react@17.0.2:
     resolution: {integrity: sha512-2RfQlZUmTzyHdjv1i7H5bxA4C5cTQonvDNFMzR2AycbN+AudAX8NXNOwPJkNxdxApUJX4EiQ84sGI354yEpa/w==}
     peerDependencies:
@@ -2919,6 +3018,20 @@ packages:
       '@react-aria/utils': 3.13.3_react@17.0.2
       '@react-types/link': 3.2.5_react@17.0.2
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-aria/link/3.3.4_react@17.0.2:
+    resolution: {integrity: sha512-Op0usCd5SAg5OHkCl1+TYbsvT/wWhqadd/3Pi0VD0kKmaSy4GhUNJkTo8n0hS2k3vIq+qRq7zwnON2h5eLVkHA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-types/link': 3.3.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -2940,6 +3053,24 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-aria/listbox/3.7.0_react@17.0.2:
+    resolution: {integrity: sha512-XUWg+ll9LmzJB3WzAklwJY5A/YuRTWd5UM/WSL34aV1O6P/IdLW697Xvr6fpHWMPtkIUeNB6teAAT2M98iWx5Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/label': 3.4.3_react@17.0.2
+      '@react-aria/selection': 3.12.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-stately/collections': 3.5.0_react@17.0.2
+      '@react-stately/list': 3.5.4_react@17.0.2
+      '@react-types/listbox': 3.3.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-aria/live-announcer/3.0.6_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-dXd5knYAFQPNr4ApxGwHXIDBuO50d9koat1ViFI22yS1QJF3y1dcIkBHfiAWIUtGr8AbRbWDZZnHtKrfPl25Zg==}
     peerDependencies:
@@ -2951,6 +3082,12 @@ packages:
       '@react-aria/visually-hidden': 3.2.8_react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
+    dev: false
+
+  /@react-aria/live-announcer/3.1.1:
+    resolution: {integrity: sha512-e7b+dRh1SUTla42vzjdbhGYkeLD7E6wIYjYaHW9zZ37rBkSqLHUhTigh3eT3k5NxFlDD/uRxTYuwaFnWQgR+4g==}
+    dependencies:
+      '@babel/runtime': 7.20.1
     dev: false
 
   /@react-aria/menu/3.4.4_sfoxds7t5ydpegc3knd667wn6m:
@@ -2971,6 +3108,69 @@ packages:
       '@react-types/button': 3.5.1_react@17.0.2
       '@react-types/menu': 3.7.0_react@17.0.2
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    dev: false
+
+  /@react-aria/menu/3.6.2_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-uBZHGuFAtOdoocBVZzoBpZQFJmkt5axlEUKjBgh2BuR5JX8aZiSxyKnfgAeb3aDEi9PZpOp6RWxHzOMBRg4TsA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/i18n': 3.6.2_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/overlays': 3.12.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/selection': 3.12.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-stately/collections': 3.5.0_react@17.0.2
+      '@react-stately/menu': 3.4.2_react@17.0.2
+      '@react-stately/tree': 3.3.4_react@17.0.2
+      '@react-types/button': 3.7.0_react@17.0.2
+      '@react-types/menu': 3.7.3_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    dev: false
+
+  /@react-aria/overlays/3.12.0_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-jsGeLTB3W3S5Cf2zDTxh1ODTNkE69miFDOGMB0VLwS1GWDwDvytcTRpBKY9JBrxad+4u0x6evnah7IbJ61qNBA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/i18n': 3.6.2_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/ssr': 3.4.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-aria/visually-hidden': 3.6.0_react@17.0.2
+      '@react-stately/overlays': 3.4.3_react@17.0.2
+      '@react-types/button': 3.7.0_react@17.0.2
+      '@react-types/overlays': 3.6.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    dev: false
+
+  /@react-aria/overlays/3.8.1_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-6r86wO7DlcYXOwufzxuYWkh/lwgwpKYAhKHL8z8DcErX7mbauoeh2Z3wX+6a27rSrkqRksmsWYJR3nsg55u1DA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/i18n': 3.6.2_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-aria/visually-hidden': 3.6.0_react@17.0.2
+      '@react-stately/overlays': 3.4.3_react@17.0.2
+      '@react-types/button': 3.7.0_react@17.0.2
+      '@react-types/overlays': 3.6.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      dom-helpers: 3.4.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: false
@@ -3011,6 +3211,23 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-aria/radio/3.4.0_react@17.0.2:
+    resolution: {integrity: sha512-DUccHQxfI0PikXXQKarh/hLS/G+ZzfdQ00/sd57jzWsuRyukb+WywQhud29p5uO3wT33/MH9LZgSmb9dlvfabQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/i18n': 3.6.2_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/label': 3.4.3_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-stately/radio': 3.6.0_react@17.0.2
+      '@react-types/radio': 3.3.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-aria/select/3.6.5_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-RIIRGN7vNHIx2Nf43V9UKFLtUKwthIog5akCxQfz1ivIwQ3Pgy+4bs1d7KhFPg8aM7G2w1lGQfv4vMgWwWBjmg==}
     peerDependencies:
@@ -3032,6 +3249,61 @@ packages:
       '@react-types/shared': 3.14.1_react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
+    dev: false
+
+  /@react-aria/select/3.8.2_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-a2lUvB9k54sfoiqyTcl+rq9GKqwcF8RMapaYxaE0VQmUVUl/hk31mTMo5y3giDCpMlrVO0jxve3nZe9YyUOOvg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/i18n': 3.6.2_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/label': 3.4.3_react@17.0.2
+      '@react-aria/listbox': 3.7.0_react@17.0.2
+      '@react-aria/menu': 3.6.2_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/selection': 3.12.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-aria/visually-hidden': 3.6.0_react@17.0.2
+      '@react-stately/select': 3.3.2_react@17.0.2
+      '@react-types/button': 3.7.0_react@17.0.2
+      '@react-types/select': 3.6.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    dev: false
+
+  /@react-aria/selection/3.11.0_react@17.0.2:
+    resolution: {integrity: sha512-2Qcv0PxXqOrYYT1oL+TOaB+lE/jhIPzVEPHVmf8HYzEMP5WBYP8Q+R9no5s8x++b1W0DsbUVwmk9szY48O9Bmw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/i18n': 3.6.2_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-stately/collections': 3.5.0_react@17.0.2
+      '@react-stately/selection': 3.11.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-aria/selection/3.12.0_react@17.0.2:
+    resolution: {integrity: sha512-Akzx5Faxw+sOZFXLCOw6OddDNFbP5Kho3EP6bYJfd2pzMkBc8/JemC/YDrtIuy8e9x6Je9HHSZqtKjwiEaXWog==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/i18n': 3.6.2_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-stately/collections': 3.5.0_react@17.0.2
+      '@react-stately/selection': 3.11.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
     dev: false
 
   /@react-aria/selection/3.9.1_react@17.0.2:
@@ -3059,6 +3331,15 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-aria/ssr/3.4.0_react@17.0.2:
+    resolution: {integrity: sha512-qzuGk14/fUyUAoW/EBwgFcuMkVNXJVGlezTgZ1HovpCZ+p9844E7MUFHE7CuzFzPEIkVeqhBNIoIu+VJJ8YCOA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      react: 17.0.2
+    dev: false
+
   /@react-aria/table/3.2.4_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-2t/EGyNAYsU841ZPLYUkwN+tdXztccgllUJ9qL5a0RJm7DYKKFHHsAYWmnV5ONj/tXqNZQfoqJSzsL6wpTXOZw==}
     peerDependencies:
@@ -3083,6 +3364,30 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
+  /@react-aria/table/3.5.0_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-oYcsIEYbbjAzojRWUsAdtfxPzlEKBmk6o4svDHnGqC9HSj8/yExn8b8RB0veDP7E+5IdO62pUwUy48jBwWu2uw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/grid': 3.5.1_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/i18n': 3.6.2_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/live-announcer': 3.1.1
+      '@react-aria/selection': 3.12.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-stately/table': 3.5.0_react@17.0.2
+      '@react-stately/virtualizer': 3.4.0_react@17.0.2
+      '@react-types/checkbox': 3.4.1_react@17.0.2
+      '@react-types/grid': 3.1.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      '@react-types/table': 3.3.3_react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    dev: false
+
   /@react-aria/textfield/3.5.5_react@17.0.2:
     resolution: {integrity: sha512-ZbGbdObR9cXPXfOr5Ius//nO5Y9yZ+pOT8ymTQTb/X8hLZdfpHqDD9SOjxlTt047ByWfIL0cRlOoEh3MHwvNFg==}
     peerDependencies:
@@ -3094,6 +3399,20 @@ packages:
       '@react-aria/utils': 3.13.3_react@17.0.2
       '@react-types/shared': 3.14.1_react@17.0.2
       '@react-types/textfield': 3.4.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-aria/textfield/3.8.0_react@17.0.2:
+    resolution: {integrity: sha512-PRU8q1gK0auDMH1YekJScZ4EZMrLrL3QJEHMNDdp2GDQlVISbPeTRy2On20DXfiG8GlXAtCWj9BiZhK2OE71DQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/label': 3.4.3_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      '@react-types/textfield': 3.6.1_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3113,6 +3432,22 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-aria/toggle/3.4.1_react@17.0.2:
+    resolution: {integrity: sha512-oVcjqsqvvEXW25vm3F2gxF5Csz8vRNKeF7Kc5pxqLrBohqMausChul+/Zisx5qVB4TL0yO3ygjTGbEvfEYQ1qg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-stately/toggle': 3.4.3_react@17.0.2
+      '@react-types/checkbox': 3.4.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      '@react-types/switch': 3.2.5_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-aria/tooltip/3.1.8_react@17.0.2:
     resolution: {integrity: sha512-f61VVQU1je0wqQpTrfPl+aXAi54XPpe5lTIsxBY9qovzi0BBCAt3b5KofpudxcAqGQnZssXrRnG1IQbATIuUQQ==}
     peerDependencies:
@@ -3125,6 +3460,21 @@ packages:
       '@react-stately/tooltip': 3.2.0_react@17.0.2
       '@react-types/shared': 3.14.1_react@17.0.2
       '@react-types/tooltip': 3.2.2_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-aria/tooltip/3.3.2_react@17.0.2:
+    resolution: {integrity: sha512-k/0/1/bfGp3gZ6JK8giJPgz2bkt+eJigzD5oY4d908KavyJ3nKAZe7hR+0ahT0lj0Z2Xb7M5SZepisk8Kj8LbA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-stately/tooltip': 3.2.2_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      '@react-types/tooltip': 3.2.5_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3154,6 +3504,32 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-aria/utils/3.14.0_react@17.0.2:
+    resolution: {integrity: sha512-DHgmwNBNEhnb6DEYYAfbt99wprBqJJOBBeIpQ2g3+pxwlw4BZ+v4Qr+rDD0ZibWV0mYzt8zOhZ9StpId7iTF0Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/ssr': 3.4.0_react@17.0.2
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      clsx: 1.1.1
+      react: 17.0.2
+    dev: false
+
+  /@react-aria/utils/3.14.1_react@17.0.2:
+    resolution: {integrity: sha512-+ynP0YlxN02MHVEBaeuTrIhBsfBYpfJn36pZm2t7ZEFbafH8DPaMGZ70ffYZXAESkWzRULXL3e79DheWOFI1qA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/ssr': 3.4.0_react@17.0.2
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      clsx: 1.1.1
+      react: 17.0.2
+    dev: false
+
   /@react-aria/visually-hidden/3.2.8_react@17.0.2:
     resolution: {integrity: sha512-SLBID66sUZrCdxaxLhgxypF/UyGuFVFGc+VhqmFi9QacDfAQcoT3DQyXEaKUIDMVtwAtSuWl7BpuooEctKBe6Q==}
     peerDependencies:
@@ -3166,12 +3542,46 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-aria/visually-hidden/3.5.0_react@17.0.2:
+    resolution: {integrity: sha512-tF/kCZCGv1yebwgH21cKbhjSV5CmB5/SAHOUM5YkO5V/lIFjaPtywcamIPI8F0JSfrwGF/Z9EqvqBxvIYGRlCA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      clsx: 1.1.1
+      react: 17.0.2
+    dev: false
+
+  /@react-aria/visually-hidden/3.6.0_react@17.0.2:
+    resolution: {integrity: sha512-W3Ix5wdlVzh2GY7dytqOAyLCXiHzk3S4jLKSaoiCwPJX9fHE5zMlZwahhDy27V0LXfjmdjBltbwyEZOq4G/Q0w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      clsx: 1.1.1
+      react: 17.0.2
+    dev: false
+
+  /@react-dnd/asap/4.0.0:
+    resolution: {integrity: sha512-0XhqJSc6pPoNnf8DhdsPHtUhRzZALVzYMTzRwV4VI6DJNJ/5xxfL9OQUwb8IH5/2x7lSf7nAZrnzUD+16VyOVQ==}
+    dev: false
+
   /@react-dnd/asap/4.0.1:
     resolution: {integrity: sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==}
     dev: false
 
   /@react-dnd/asap/5.0.2:
     resolution: {integrity: sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==}
+    dev: false
+
+  /@react-dnd/invariant/3.0.0:
+    resolution: {integrity: sha512-keberJRIqPX15IK3SWS/iO1t/kGETiL1oczKrDitAaMnQ+kpHf81l3MrRmFjvfqcnApE+izEvwM6GsyoIcpsVA==}
     dev: false
 
   /@react-dnd/invariant/3.0.1:
@@ -3210,6 +3620,19 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-stately/checkbox/3.3.0_react@17.0.2:
+    resolution: {integrity: sha512-hYFJzEoreAmUKkcgd3ErDXtEqp65pfawfcygOr/3pe7MUGzl+MaauVUOg6Dh02Bxt+mdSX4mQXbJSfvm+8bmfA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/toggle': 3.4.3_react@17.0.2
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/checkbox': 3.4.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-stately/collections/3.4.2_react@17.0.2:
     resolution: {integrity: sha512-CmLVWtbX4r3QaTNdI6edtrRKIZRKPuxyD7TmVIaoZBdaOXStTP4wOgyPN1ELww9bvW0MoOaQBbUn5WAPrfifFw==}
     peerDependencies:
@@ -3217,6 +3640,26 @@ packages:
     dependencies:
       '@babel/runtime': 7.17.9
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-stately/collections/3.4.4_react@17.0.2:
+    resolution: {integrity: sha512-gryUYCe6uzqE0ea5frTwOxOPpx/6Z42PRk7KetOh3ddN3Ts0j8XQP08jP1IB/7BC1QidrkHWvDCqGHxRiEjiIg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-stately/collections/3.5.0_react@17.0.2:
+    resolution: {integrity: sha512-3BAMRjJqrka0IGvyK4m3WslqCeiEfQGx7YsXEIgIgMJoLpk6Fi1Eh4CI8coBnl/wcVLiIRMCIvxubwFRWTgzdg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3235,6 +3678,21 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-stately/combobox/3.2.2_react@17.0.2:
+    resolution: {integrity: sha512-kUMxgXskrtwdeEExZkJ9CjF4EJANetj+7970cOevCpy6ePCdrvdgO6+0cMrVvSgZeMaMDZXDIbbF7fqA6w0uXQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/list': 3.5.4_react@17.0.2
+      '@react-stately/menu': 3.4.2_react@17.0.2
+      '@react-stately/select': 3.3.2_react@17.0.2
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/combobox': 3.5.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-stately/grid/3.3.0_react@17.0.2:
     resolution: {integrity: sha512-30z4Kki5QWZvR22f3UrA18eMDOcXmQFzAq5pHbRs1LvxJAaqeAD2KzCT70MCgoA5XzyiOrvIPrKTBRf48du45w==}
     peerDependencies:
@@ -3244,6 +3702,18 @@ packages:
       '@react-stately/selection': 3.10.2_react@17.0.2
       '@react-types/grid': 3.1.2_react@17.0.2
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-stately/grid/3.4.1_react@17.0.2:
+    resolution: {integrity: sha512-IRaqXUQGji87Q+pYYQKJYTuUtgAjoDQaMOlvpvB9HlyK5faXq0H1tJsYAeVYpH0synfzCnr7CN0J6kSTbeL1jA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/selection': 3.11.1_react@17.0.2
+      '@react-types/grid': 3.1.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3260,6 +3730,19 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-stately/layout/3.9.0_react@17.0.2:
+    resolution: {integrity: sha512-uFdK98hIspBV9/RMW/JJaViuWyISdcm5GFplB361JZkhDaYblzomvkoX5Y1dKO5uH/BOjdM2AB5vfCb21oKEhg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/virtualizer': 3.4.0_react@17.0.2
+      '@react-types/grid': 3.1.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      '@react-types/table': 3.3.3_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-stately/list/3.5.2_react@17.0.2:
     resolution: {integrity: sha512-Jv8xzO5oanEMAblLiUUr7uwkMTd5qyczyjxJrv8O52Lwd4GwzJ1w7KggTSZ7JG99fLZozLor3p0foVVvSI1/NA==}
     peerDependencies:
@@ -3270,6 +3753,19 @@ packages:
       '@react-stately/selection': 3.10.2_react@17.0.2
       '@react-stately/utils': 3.5.1_react@17.0.2
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-stately/list/3.5.4_react@17.0.2:
+    resolution: {integrity: sha512-AB0r2RevKVAP2AOQM1JRuCVjS2UUxMJFshA53t8pV+OSVWeyirYccsMR49mWwU60ZnxYqBWVMN+Pl7NTPTnT8w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/collections': 3.5.0_react@17.0.2
+      '@react-stately/selection': 3.11.1_react@17.0.2
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3286,6 +3782,19 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-stately/menu/3.4.2_react@17.0.2:
+    resolution: {integrity: sha512-vFC8EloVEcqf6sgiP6ABIkC41ytjoJiGtj7Ws5OS7PvZNyxxDgJr4V0O3Pxd1T0AjlHCloBbojnvoTRwZiSr/A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/overlays': 3.4.3_react@17.0.2
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/menu': 3.7.3_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-stately/overlays/3.4.0_react@17.0.2:
     resolution: {integrity: sha512-jXVm1V91lWOKh73cFvE9W9JtAE8idSWEUtFlVrlBI/jh0ZOt148UlRVWgHrm7FhaUpyvOFNUyfidRmKMuB+hgw==}
     peerDependencies:
@@ -3297,6 +3806,28 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-stately/overlays/3.4.2_react@17.0.2:
+    resolution: {integrity: sha512-UTCnn0aT+JL4ZhYPQYUWHwhmuR2T3vKTFUEZeZN9sTuDCctg08VfGoASJx8qofqkLwYJXeb8D5PMhhTDPiUQPw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/overlays': 3.6.5_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-stately/overlays/3.4.3_react@17.0.2:
+    resolution: {integrity: sha512-WZCr3J8hj0cplQki1OVBR3MXg2l9V017h15Y2h+TNduWvnKH0yYOE/XfWviAT4KUP0LYoQfCnZ7XMHv+UI+8JA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/overlays': 3.6.5_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-stately/radio/3.5.0_react@17.0.2:
     resolution: {integrity: sha512-qn4+wa9sf3zZXSLrrR9rQpOII8BEQeAkvxyq/YhUQXBpQ8SoF5LobpGIZqp3n8G+Cxzjxd6/GON+lOFxWr0iXA==}
     peerDependencies:
@@ -3305,6 +3836,18 @@ packages:
       '@babel/runtime': 7.17.9
       '@react-stately/utils': 3.5.1_react@17.0.2
       '@react-types/radio': 3.2.2_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-stately/radio/3.6.0_react@17.0.2:
+    resolution: {integrity: sha512-hzNwIapDSnbk5mCim/AgHQTtHRgy2QiW95okfVnGflzO7nnws8WH/s2Va4f7UupWObPv8XTqHADUEng86mVBJA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/radio': 3.3.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3324,6 +3867,22 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-stately/select/3.3.2_react@17.0.2:
+    resolution: {integrity: sha512-/C9fW7HT+V9XnmSTiZZqH5cn+ifY9vdXvIKDbUyna98lFHtDgn7i/UvD5edunOGY0qqSMIO3kJ6/BiNg+gpn6Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/collections': 3.5.0_react@17.0.2
+      '@react-stately/list': 3.5.4_react@17.0.2
+      '@react-stately/menu': 3.4.2_react@17.0.2
+      '@react-stately/selection': 3.11.1_react@17.0.2
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/select': 3.6.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-stately/selection/3.10.2_react@17.0.2:
     resolution: {integrity: sha512-3/iw0BpShWt5ie+YpOzi4Mpa3yKOtlKQZXEc0fZt3v3m3N3fMoCr7Ovkfuz5Svy47HIIN1Pk1WkRJC+CQ4hfDw==}
     peerDependencies:
@@ -3333,6 +3892,18 @@ packages:
       '@react-stately/collections': 3.4.2_react@17.0.2
       '@react-stately/utils': 3.5.1_react@17.0.2
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-stately/selection/3.11.1_react@17.0.2:
+    resolution: {integrity: sha512-UHB6/eH5NJ+Q70G+pmnxohHfR3bh0szT+lOlWPj7Mh76WPu9bu07IHKLEob6PSzyJ81h7+Ysk3hdIgS3TewGog==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/collections': 3.5.0_react@17.0.2
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3351,6 +3922,21 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-stately/table/3.5.0_react@17.0.2:
+    resolution: {integrity: sha512-C0HFfKMCOomqPtRCPs85AtoJGPnGu9mzFfwksFxAssdIatw3t66h5SJS0vSSql7Ku9h70scmvJR+nIOckx0IeA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/collections': 3.5.0_react@17.0.2
+      '@react-stately/grid': 3.4.1_react@17.0.2
+      '@react-stately/selection': 3.11.1_react@17.0.2
+      '@react-types/grid': 3.1.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      '@react-types/table': 3.3.3_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-stately/toggle/3.4.1_react@17.0.2:
     resolution: {integrity: sha512-Dlg7M9W52n0K+Op/H5ywdSCORW70ry6syPSahh+RXQKKdky9bckqmrpO24A92dL7Rci2H4fTsBgZGVla9b/wNQ==}
     peerDependencies:
@@ -3360,6 +3946,30 @@ packages:
       '@react-stately/utils': 3.5.1_react@17.0.2
       '@react-types/checkbox': 3.3.3_react@17.0.2
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-stately/toggle/3.4.2_react@17.0.2:
+    resolution: {integrity: sha512-+pO13Ap/tj4optu6VjQrEAaAoZvJAEwarMUaZvrkc0kdvMTNPdiT/2vhN32yvsSW0ssuFqToa3jMrTylCbpo8w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/checkbox': 3.4.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-stately/toggle/3.4.3_react@17.0.2:
+    resolution: {integrity: sha512-HsJLMa5d9i6SWyDIahkJExkanXZek86//hirsgSU0IvY7YJx33Wek8UwHE5Vskp39DAOu18QMz2GrAngnUErYQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/checkbox': 3.4.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3375,6 +3985,18 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-stately/tooltip/3.2.2_react@17.0.2:
+    resolution: {integrity: sha512-Y9itW2PDRWi/FdMYhpAC/kmXx22mRElADbM1AqKkMkWiJHhTbn2Cr5ie1uZcm+SMb5Dq2ypMV5rUzuiCVVB8/g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/overlays': 3.4.3_react@17.0.2
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/tooltip': 3.2.5_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-stately/tree/3.3.1_react@17.0.2:
     resolution: {integrity: sha512-s/pcafhvUnt2uOIUWRdTpWCBLnGOuG5e9CAzPkwlUCGFXiI7jIJBT8Y4dLP7Iwx6i9U2wZqs22onxH7GHlGgbw==}
     peerDependencies:
@@ -3385,6 +4007,19 @@ packages:
       '@react-stately/selection': 3.10.2_react@17.0.2
       '@react-stately/utils': 3.5.1_react@17.0.2
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-stately/tree/3.3.4_react@17.0.2:
+    resolution: {integrity: sha512-CBgXvwa9qYBsJuxrAiVgGnm48eSxLe/6OjPMwH1pWf4s383Mx73MbbN4fS0oWDeXBVgdqz5/Xg/p8nvPIvl3WQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-stately/collections': 3.5.0_react@17.0.2
+      '@react-stately/selection': 3.11.1_react@17.0.2
+      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3408,12 +4043,23 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-stately/virtualizer/3.4.0_react@17.0.2:
+    resolution: {integrity: sha512-Yy5RKlt6W/1+qjJAVHxPJA0RgpN3KNHcSpnFHdus2OuEvylSXZ2kqwflj97Ao4XfNSpDIs4NQS/eOq+mpZlNqQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-types/accordion/3.0.0-alpha.7_react@17.0.2:
     resolution: {integrity: sha512-h5Nvf/+O+Cl/Vw6m3RNGD3hv7VwKX0ilJe1a473iJgjruzMQybSgpcCdWES31QZdEE+rkjpqTGoG22MusEOE+Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.14.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3422,8 +4068,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1
     dependencies:
-      '@react-types/link': 3.2.5_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
+      '@react-types/link': 3.3.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3432,7 +4078,16 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.14.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-types/button/3.7.0_react@17.0.2:
+    resolution: {integrity: sha512-81BQO3QxSgF9PTXsVozNdNCKxBOB1lpbCWocV99dN1ws9s8uaYw8pmJJZ0LJKLiOsIECQ/3QrhQjmWTDW/qTug==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3445,12 +4100,30 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-types/checkbox/3.4.1_react@17.0.2:
+    resolution: {integrity: sha512-kDMpy9SntjGQ7x00m5zmW8GENPouOtyiDgiEDKsPXUr2iYqHsNtricqVyG9S9+6hqpzuu8BzTcvZamc/xYjzlg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-types/combobox/3.5.2_react@17.0.2:
     resolution: {integrity: sha512-Q1HtiT/Hq+b6q71Evn8nmIfLv08kDEZSlOz5hlZouH9ZGYeTb1huH72biYl9LyIB6NRdNUouo7+I8ddumeAkMA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-types/combobox/3.5.5_react@17.0.2:
+    resolution: {integrity: sha512-gpDo/NTQFd5IfCZoNnG16N4/JfvwXpZBNc15Kn7bF+NcpSDhDpI26BZN4mvK4lljKCheD4VrEl9/3PtImCg7cA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3464,6 +4137,16 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-types/dialog/3.4.5_react@17.0.2:
+    resolution: {integrity: sha512-FkxZAYNRWkZVH5rjlw6qyQ/SpoGcYtNI/JQvn1H/xtZy/OJh2b2ERxGWv5x0RItGSeyATdSwFO1Qnf1Kl2K02A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/overlays': 3.6.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-types/grid/3.1.2_react@17.0.2:
     resolution: {integrity: sha512-9mKhtBZiGlok1APRSR+hTKYFgx8XxRBBLG20/xPI1C8xCGNZvOz7CmK57LmlwYsN1BLo3S2vLOd6+M1qrw2yVg==}
     peerDependencies:
@@ -3473,12 +4156,30 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-types/grid/3.1.5_react@17.0.2:
+    resolution: {integrity: sha512-KiEywsOJ+wdzLmJerAKEMADdvdItaLfhdo3bFfn1lgNUaKiNDJctDYWlhOYsRePf7MIrzoZuXEFnJj45jfpiOQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-types/label/3.6.3_react@17.0.2:
     resolution: {integrity: sha512-Q+8qx4x7+ZqgdfNJorX7CqysYAGAeT1IWzJyNxwcT1OLjFuUIBJyg7njjpkZyK8sFFYdGIKhLxk0Q1Sf8Y5Stw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-types/label/3.7.1_react@17.0.2:
+    resolution: {integrity: sha512-wFpdtjSDBWO4xQQGF57V3PqvVVyE9TPj9ELWLs1yzL09fpXosycuEl5d79RywVlC9aF9dQYUfES09q/DZhRhMQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3492,12 +4193,31 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-types/link/3.3.5_react@17.0.2:
+    resolution: {integrity: sha512-wEeYXqzRPwEwU6AakiRfsPrkGxm2l0gjIc992FBmHPz6MWU8eSATTwzeyI668eRzNrQvOBMI7il6lXuxDm1ZLg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-types/listbox/3.2.5_react@17.0.2:
     resolution: {integrity: sha512-FxZAT0HT1+LASzNffc5faVuIrODyQeN738l3WeCGb2xJAdkImKr4hahtcdduXvT30WVwaPpsynKlhpRRaVxjDA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1
     dependencies:
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-types/listbox/3.3.5_react@17.0.2:
+    resolution: {integrity: sha512-7SMRJWUi7ayzQ7SUPCXXwgI/Ua3vg0PPQOZFsmJ4/E8VG/xK82IV7BYSZiNjUQuGpVZJL0VPndt/RwIrQO4S3w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3511,12 +4231,31 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-types/menu/3.7.3_react@17.0.2:
+    resolution: {integrity: sha512-3Pax24I/FyNKBjKyNR4ePD8eZs35Th57HzJAVjamQg2fHEDRomg9GQ7fdmfGj72Dv3x3JRCoPYqhJ3L5R3kbzg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/overlays': 3.6.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-types/overlays/3.6.2_react@17.0.2:
     resolution: {integrity: sha512-ag9UCIlcNCvMHBORRksdLnQK3ef+CEbrt+TydOxBAxAf+87fXJ/0H6hP/4QTebEA2ixA0qz8CFga81S8ZGnOsQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-types/overlays/3.6.5_react@17.0.2:
+    resolution: {integrity: sha512-IeWcF+YTucCYYHagNh8fZLH6R4YUONO1VHY57WJyIHwMy0qgEaKSQCwq72VO1fQJ0ySZgOgm31FniOyKkg6+eQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3529,12 +4268,30 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-types/radio/3.3.1_react@17.0.2:
+    resolution: {integrity: sha512-q/x0kMvBsu6mH4bIkp/Jjrm9ff5y/p3UR0V4CmQFI7604gQd2Dt1dZMU/2HV9x70r1JfWRrDeRrVjUHVfFL5Vg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-types/select/3.6.2_react@17.0.2:
     resolution: {integrity: sha512-V1ahKVEIA+u4kDOXTw0UoSjJ8T3EJi25PNx/whLYIEMXWw/v8dH+x7Hi7S45cHS+ZxoZXhWIV8WmgDKIUp1U1Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-types/select/3.6.5_react@17.0.2:
+    resolution: {integrity: sha512-FDeSA7TYMNnhsbXREnD4dWRSu21T5M4BLy+J/5VgwDpr3IN9pzbvngK8a3jc8Yg2S3igKYLMLYfmcsx+yk7ohA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3562,6 +4319,14 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-types/shared/3.16.0_react@17.0.2:
+    resolution: {integrity: sha512-IQgU4oAEvMwylEvaTsr2XB1G/mAoMe1JFYLD6G78v++oAR9l8o9MQxZ0YSeANDkqTamb2gKezGoT1RxvSKjVxw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      react: 17.0.2
+    dev: false
+
   /@react-types/switch/3.2.3_react@17.0.2:
     resolution: {integrity: sha512-EKs8FZfRM1zCD5kgLNi8wQKiPMayABZiAhfzkBgHRwlip1joI4F5oXTyonY8hgHrxLP5GUXFL+rNkYOo6LX1uQ==}
     peerDependencies:
@@ -3569,6 +4334,16 @@ packages:
     dependencies:
       '@react-types/checkbox': 3.3.3_react@17.0.2
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-types/switch/3.2.5_react@17.0.2:
+    resolution: {integrity: sha512-DlUL0Bz79SUTRje/i8m6qn4Ipn+q8QnyIkyJhkoHeH1R0YNude8xZrBPWbj3zfdddAGDFSF1NzP69q0xmNAcTQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/checkbox': 3.4.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3582,12 +4357,31 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@react-types/table/3.3.3_react@17.0.2:
+    resolution: {integrity: sha512-rdY8PCzdqumVd6EFgN4NCoNRHdU4dVKH2oufr50TrAVPAz2KyoNXaGcDGe0q4RjQeTk+fc0sCvRZZdpMwHRVpQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/grid': 3.1.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
   /@react-types/textfield/3.4.0_react@17.0.2:
     resolution: {integrity: sha512-NL97JvdzsuGDYGx/JlE/yCceUR4IS1dX6CK9PljI0ZTsOOXLGynJ4HCpayBzbelUA617a+qr/v0c1CxY3y1qfg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1
     dependencies:
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-types/textfield/3.6.1_react@17.0.2:
+    resolution: {integrity: sha512-V3EyYw82GVJQbNN0OAWpOLs/UQij+AgUuJpxh8192p/q0B3/9lqepZ9b+Qts2XgMsA+3Db+KgFMWm2IdjaZbpQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3598,6 +4392,16 @@ packages:
     dependencies:
       '@react-types/overlays': 3.6.2_react@17.0.2
       '@react-types/shared': 3.14.1_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-types/tooltip/3.2.5_react@17.0.2:
+    resolution: {integrity: sha512-D4lN32JwQuA3JbCgcI26mgCkLHIj1WE8MTzf1McaasPkx7gVaqW+wfPyFwt99/Oo52TLvA/1oin78qePP67PSw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/overlays': 3.6.5_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3700,7 +4504,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-sizeme: 3.0.2
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.10
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
     dev: false
@@ -3754,7 +4558,7 @@ packages:
       global: 4.4.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.10
     dev: false
 
   /@storybook/addons/6.5.9_sfoxds7t5ydpegc3knd667wn6m:
@@ -3798,7 +4602,7 @@ packages:
       memoizerific: 1.11.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.10
       store2: 2.13.2
       telejson: 6.0.8
       ts-dedent: 2.2.0
@@ -3876,7 +4680,7 @@ packages:
       qs: 6.10.5
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.10
       util-deprecate: 1.0.2
     dev: false
 
@@ -3930,7 +4734,7 @@ packages:
       qs: 6.10.5
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.10
     dev: false
 
   /@storybook/router/6.5.9_sfoxds7t5ydpegc3knd667wn6m:
@@ -3968,7 +4772,7 @@ packages:
       memoizerific: 1.11.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.10
     dev: false
 
   /@storybook/theming/6.5.9_sfoxds7t5ydpegc3knd667wn6m:
@@ -4068,7 +4872,6 @@ packages:
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
     dependencies:
       '@types/ms': 0.7.31
-    dev: true
 
   /@types/escape-html/1.0.2:
     resolution: {integrity: sha512-gaBLT8pdcexFztLSPRtriHeXY/Kn4907uOCZ4Q3lncFBkheAWOuNt53ypsF8szgxbEJ513UeBzcf4utN0EzEwA==}
@@ -4122,7 +4925,6 @@ packages:
 
   /@types/ms/0.7.31:
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
-    dev: true
 
   /@types/node/10.17.60:
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
@@ -4379,7 +5181,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-alignment/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-alignment/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-ZeKANQVJZDHjBZTH73YQtBh952p8u4R6G3cX7JnfM9TbbIdEBCeW3JfADL72JMv0m++AwXRUbGvYirMX/RQ8Eg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -4388,7 +5190,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -4408,7 +5210,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-alignment/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-alignment/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-ZeKANQVJZDHjBZTH73YQtBh952p8u4R6G3cX7JnfM9TbbIdEBCeW3JfADL72JMv0m++AwXRUbGvYirMX/RQ8Eg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -4417,7 +5219,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -4466,7 +5268,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-autoformat/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-autoformat/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-hr/zLsdSvXoEGD8Xm8Uv45lNAcGeovQ9gOeb5eMlIIaPUPW27HvrX8MYDpstUS4RVwMV2w9kLdXpgHpbhL1nJg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -4475,7 +5277,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -4495,7 +5297,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-autoformat/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-autoformat/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-hr/zLsdSvXoEGD8Xm8Uv45lNAcGeovQ9gOeb5eMlIIaPUPW27HvrX8MYDpstUS4RVwMV2w9kLdXpgHpbhL1nJg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -4504,7 +5306,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -4557,7 +5359,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-basic-elements/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-basic-elements/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-2CasaH7zV9YVwDLCQsoy/go/5tvm/kFw0lCtA13qWUVTeSdB02oDWo0LuEL1kHMlrKgd5A1JNan7BSH9/5OG0Q==}
     peerDependencies:
       react: '>=16.8.0'
@@ -4566,11 +5368,11 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-block-quote': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-code-block': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-heading': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-paragraph': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-block-quote': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-code-block': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-heading': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-paragraph': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -4590,7 +5392,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-basic-elements/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-basic-elements/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-2CasaH7zV9YVwDLCQsoy/go/5tvm/kFw0lCtA13qWUVTeSdB02oDWo0LuEL1kHMlrKgd5A1JNan7BSH9/5OG0Q==}
     peerDependencies:
       react: '>=16.8.0'
@@ -4599,11 +5401,11 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-block-quote': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-code-block': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-heading': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-paragraph': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-block-quote': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-code-block': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-heading': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-paragraph': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -4652,7 +5454,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-basic-marks/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-basic-marks/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-L/n0fBGr8GsN+TTSLWLSddCP4QlDDNYOzGzReb9YAiF1AvzSTE8gTgic+T2rfk7uv04Gig/MiBcnK6uU/iekMQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -4661,7 +5463,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -4681,7 +5483,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-basic-marks/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-basic-marks/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-L/n0fBGr8GsN+TTSLWLSddCP4QlDDNYOzGzReb9YAiF1AvzSTE8gTgic+T2rfk7uv04Gig/MiBcnK6uU/iekMQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -4690,7 +5492,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -4739,7 +5541,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-block-quote/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-block-quote/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-MgfwBwj2fKaPvIy66ElnIZCeiBtSDJEiY640IOodslyFEJinsrKdq4YmD8iPifsYWoVAkveGYmsiOHvSgESzTQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -4748,7 +5550,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -4768,7 +5570,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-block-quote/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-block-quote/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-MgfwBwj2fKaPvIy66ElnIZCeiBtSDJEiY640IOodslyFEJinsrKdq4YmD8iPifsYWoVAkveGYmsiOHvSgESzTQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -4777,7 +5579,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -4826,7 +5628,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-break/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-break/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-spYxIpVj+A82DDj7eE13zXT7H0PUFjXvKkHG+uUUbdvj2H8kreGFWnjuK38QP17/m2lvSwgK1EqUMbQ7qmsw1g==}
     peerDependencies:
       react: '>=16.8.0'
@@ -4835,7 +5637,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -4855,7 +5657,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-break/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-break/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-spYxIpVj+A82DDj7eE13zXT7H0PUFjXvKkHG+uUUbdvj2H8kreGFWnjuK38QP17/m2lvSwgK1EqUMbQ7qmsw1g==}
     peerDependencies:
       react: '>=16.8.0'
@@ -4864,7 +5666,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -4913,7 +5715,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-button/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-button/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-USgJNBUPb9dAyxK9EmlsX6xA8aCI5DcQNo7SzIFG0P2xlXWCu6dgoVCEUSr+1qkVGD5UUGGKG+2b3rEwdgwfgw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -4922,7 +5724,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -4942,7 +5744,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-button/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-button/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-USgJNBUPb9dAyxK9EmlsX6xA8aCI5DcQNo7SzIFG0P2xlXWCu6dgoVCEUSr+1qkVGD5UUGGKG+2b3rEwdgwfgw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -4951,7 +5753,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -5001,7 +5803,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-code-block/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-code-block/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-MsBM8oHKdPWzWk8KekYHfX66xO/cap/4ihwB9wUT5KGaUhyah5a45Q+J8vdXQyzg2LXdAJpwQGZh2hzgrehPiw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5010,7 +5812,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       prismjs: 1.28.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -5031,7 +5833,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-code-block/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-code-block/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-MsBM8oHKdPWzWk8KekYHfX66xO/cap/4ihwB9wUT5KGaUhyah5a45Q+J8vdXQyzg2LXdAJpwQGZh2hzgrehPiw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5040,7 +5842,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       prismjs: 1.28.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -5093,7 +5895,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-combobox/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-combobox/18.9.0_64uzl5e3huym3laqvq32skmtoe:
     resolution: {integrity: sha512-MHscNBBE6Mwz1uaBfiTVL/bExUIFff4dIOAH2/b5Lmpqp5jyKic3BK1GrP3r6eSflh40JoE/6XKNHGAnTngIFQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5102,8 +5904,8 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-floating': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-floating': 18.9.0_64uzl5e3huym3laqvq32skmtoe
       downshift: 6.1.7_react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -5125,7 +5927,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-combobox/18.9.0_l2ob6amovedmgdotpsyjqhcc6q:
+  /@udecode/plate-combobox/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-MHscNBBE6Mwz1uaBfiTVL/bExUIFff4dIOAH2/b5Lmpqp5jyKic3BK1GrP3r6eSflh40JoE/6XKNHGAnTngIFQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5134,8 +5936,8 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-floating': 18.9.0_l2ob6amovedmgdotpsyjqhcc6q
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-floating': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       downshift: 6.1.7_react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -5193,7 +5995,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-core/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-core/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-QYOB/+Y0OGELf426bigwloMBg8K+d+nNL7lmxdLj9ios4FiF0aVidVcP75uyHDC7Vy/9bpiF5Ti8lda4d/n4wQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5205,7 +6007,7 @@ packages:
       '@radix-ui/react-slot': 1.0.1_react@17.0.2
       '@udecode/zustood': 1.1.3_ydxzat5trqpwwhxzo3xpwhm2ti
       clsx: 1.1.1
-      jotai: 1.8.4_nvgnzhxlzgsaoilftx3vuhxn2q
+      jotai: 1.8.4_iskeb5babgxc5jvzp4zlrgistu
       lodash: 4.17.21
       nanoid: 3.3.4
       react: 17.0.2
@@ -5230,7 +6032,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-core/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-core/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-QYOB/+Y0OGELf426bigwloMBg8K+d+nNL7lmxdLj9ios4FiF0aVidVcP75uyHDC7Vy/9bpiF5Ti8lda4d/n4wQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5242,7 +6044,7 @@ packages:
       '@radix-ui/react-slot': 1.0.1_react@17.0.2
       '@udecode/zustood': 1.1.3_ydxzat5trqpwwhxzo3xpwhm2ti
       clsx: 1.1.1
-      jotai: 1.8.4_bbxtl6ryvenc2jc6uyz5mlvgwe
+      jotai: 1.8.4_3b7ya6az73zroop2ncavdncsxq
       lodash: 4.17.21
       nanoid: 3.3.4
       react: 17.0.2
@@ -5296,7 +6098,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-find-replace/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-find-replace/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-HUZGDQ/A7HmioBAH5Aa+6X1zyPTxax0vkMbfaazP87isuQPIYdsR4iHtLHB2NBxImxOk1AK5ZJxBNsSEt0lb7A==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5305,7 +6107,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -5325,7 +6127,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-find-replace/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-find-replace/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-HUZGDQ/A7HmioBAH5Aa+6X1zyPTxax0vkMbfaazP87isuQPIYdsR4iHtLHB2NBxImxOk1AK5ZJxBNsSEt0lb7A==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5334,7 +6136,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -5385,7 +6187,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-floating/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-floating/18.9.0_64uzl5e3huym3laqvq32skmtoe:
     resolution: {integrity: sha512-X0Df7D+/DZxs3l6KuhvXPNcL0izHbQ5L0VD2XxJTETgPRvI036k7lWgnTM0ZtoRD2XLtMqk1OMoeiwQzhLwBpw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5394,8 +6196,8 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@floating-ui/react-dom-interactions': 0.6.6_sfoxds7t5ydpegc3knd667wn6m
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@floating-ui/react-dom-interactions': 0.6.6_hiunvzosbwliizyirxfy6hjyim
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -5416,7 +6218,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-floating/18.9.0_l2ob6amovedmgdotpsyjqhcc6q:
+  /@udecode/plate-floating/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-X0Df7D+/DZxs3l6KuhvXPNcL0izHbQ5L0VD2XxJTETgPRvI036k7lWgnTM0ZtoRD2XLtMqk1OMoeiwQzhLwBpw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5425,8 +6227,8 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@floating-ui/react-dom-interactions': 0.6.6_hiunvzosbwliizyirxfy6hjyim
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@floating-ui/react-dom-interactions': 0.6.6_sfoxds7t5ydpegc3knd667wn6m
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -5476,7 +6278,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-font/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-font/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-HaXJ78NYHp5bCFdZtAlOJBAf5TzkQuN5YL3OAG6ld7SIi6GDgPvnfAwzON+WrpAT1zjBGgghxHFqaLo+/9CasQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5485,7 +6287,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -5505,7 +6307,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-font/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-font/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-HaXJ78NYHp5bCFdZtAlOJBAf5TzkQuN5YL3OAG6ld7SIi6GDgPvnfAwzON+WrpAT1zjBGgghxHFqaLo+/9CasQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5514,7 +6316,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -5563,7 +6365,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-heading/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-heading/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-4MoGcG7IiZcSRRKM87aKj1EFo55HIwA2S8wjsX2coh3YjAJPjf64ZqlX6ArXjH4W9xtoxRk1kquxI0nFp79spg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5572,7 +6374,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -5592,7 +6394,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-heading/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-heading/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-4MoGcG7IiZcSRRKM87aKj1EFo55HIwA2S8wjsX2coh3YjAJPjf64ZqlX6ArXjH4W9xtoxRk1kquxI0nFp79spg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5601,7 +6403,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -5689,7 +6491,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-headless/18.9.0_iqsqo2a4czrjmp6yackpexipx4:
+  /@udecode/plate-headless/18.9.0_6yma2ds5hvjqegqqbzvfhre25q:
     resolution: {integrity: sha512-D81uYwApeUly/6nsFaq4FKy52JYIdZK4FIhOkBbpN/ys/jHqVVattLEYafQht49+yFrYu/ZWlCEO3PB6w+HbKA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5699,42 +6501,42 @@ packages:
       slate-hyperscript: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-alignment': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-autoformat': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-basic-elements': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-basic-marks': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-block-quote': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-break': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-button': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-code-block': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-combobox': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-find-replace': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-floating': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-font': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-heading': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-highlight': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-horizontal-rule': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-indent': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-indent-list': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-kbd': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-line-height': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-link': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-list': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-media': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-mention': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-node-id': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-normalizers': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-paragraph': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-reset-node': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-select': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-selection': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-serializer-csv': 18.9.0_iqsqo2a4czrjmp6yackpexipx4
-      '@udecode/plate-serializer-docx': 18.9.0_iqsqo2a4czrjmp6yackpexipx4
-      '@udecode/plate-serializer-html': 18.9.0_iqsqo2a4czrjmp6yackpexipx4
-      '@udecode/plate-serializer-md': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-table': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-trailing-block': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-alignment': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-autoformat': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-basic-elements': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-basic-marks': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-block-quote': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-break': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-button': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-code-block': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-combobox': 18.9.0_64uzl5e3huym3laqvq32skmtoe
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-find-replace': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-floating': 18.9.0_64uzl5e3huym3laqvq32skmtoe
+      '@udecode/plate-font': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-heading': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-highlight': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-horizontal-rule': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-indent': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-indent-list': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-kbd': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-line-height': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-link': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-list': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-media': 18.9.0_64uzl5e3huym3laqvq32skmtoe
+      '@udecode/plate-mention': 18.9.0_64uzl5e3huym3laqvq32skmtoe
+      '@udecode/plate-node-id': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-normalizers': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-paragraph': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-reset-node': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-select': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-selection': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-serializer-csv': 18.9.0_r5lxuzwuc5e5tbwlobmnfb3tty
+      '@udecode/plate-serializer-docx': 18.9.0_6yma2ds5hvjqegqqbzvfhre25q
+      '@udecode/plate-serializer-html': 18.9.0_r5lxuzwuc5e5tbwlobmnfb3tty
+      '@udecode/plate-serializer-md': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-table': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-trailing-block': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -5757,7 +6559,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-headless/18.9.0_m5fheiiqhtf5rhj4yydfkmxpb4:
+  /@udecode/plate-headless/18.9.0_evqyrkgavtfgptj4a3lbeg4pr4:
     resolution: {integrity: sha512-D81uYwApeUly/6nsFaq4FKy52JYIdZK4FIhOkBbpN/ys/jHqVVattLEYafQht49+yFrYu/ZWlCEO3PB6w+HbKA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5767,42 +6569,42 @@ packages:
       slate-hyperscript: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-alignment': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-autoformat': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-basic-elements': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-basic-marks': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-block-quote': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-break': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-button': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-code-block': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-combobox': 18.9.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-find-replace': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-floating': 18.9.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-font': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-heading': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-highlight': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-horizontal-rule': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-indent': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-indent-list': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-kbd': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-line-height': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-link': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-list': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-media': 18.9.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-mention': 18.9.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-node-id': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-normalizers': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-paragraph': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-reset-node': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-select': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-selection': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-serializer-csv': 18.9.0_4ywyo5sd46ikxdhuv7pegx7nwm
-      '@udecode/plate-serializer-docx': 18.9.0_m5fheiiqhtf5rhj4yydfkmxpb4
-      '@udecode/plate-serializer-html': 18.9.0_4ywyo5sd46ikxdhuv7pegx7nwm
-      '@udecode/plate-serializer-md': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-table': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-trailing-block': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-alignment': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-autoformat': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-basic-elements': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-basic-marks': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-block-quote': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-break': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-button': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-code-block': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-combobox': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-find-replace': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-floating': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-font': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-heading': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-highlight': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-horizontal-rule': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-indent': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-indent-list': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-kbd': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-line-height': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-link': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-list': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-media': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-mention': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-node-id': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-normalizers': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-paragraph': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-reset-node': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-select': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-selection': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-serializer-csv': 18.9.0_evqyrkgavtfgptj4a3lbeg4pr4
+      '@udecode/plate-serializer-docx': 18.9.0_evqyrkgavtfgptj4a3lbeg4pr4
+      '@udecode/plate-serializer-html': 18.9.0_evqyrkgavtfgptj4a3lbeg4pr4
+      '@udecode/plate-serializer-md': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-table': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-trailing-block': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -5854,7 +6656,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-highlight/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-highlight/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-3d7tU6y2ImyMoB+qda5mjp1t/qekuoSiTQTj88f8gMG+RZnDMdLaeEbfqoYHZ5J1GYLsCdd0XYf9qUAcmbNhKA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5863,7 +6665,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -5883,7 +6685,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-highlight/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-highlight/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-3d7tU6y2ImyMoB+qda5mjp1t/qekuoSiTQTj88f8gMG+RZnDMdLaeEbfqoYHZ5J1GYLsCdd0XYf9qUAcmbNhKA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5892,7 +6694,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -5941,7 +6743,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-horizontal-rule/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-horizontal-rule/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-gEt50b891FelP8U9bZZs2C2bJHg6ur1Ba/qfN+2QvIkR2QSbOoXnFaoUccnAAk0ntl3NxSfQebKEwSrjzuLIVg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5950,7 +6752,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -5970,7 +6772,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-horizontal-rule/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-horizontal-rule/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-gEt50b891FelP8U9bZZs2C2bJHg6ur1Ba/qfN+2QvIkR2QSbOoXnFaoUccnAAk0ntl3NxSfQebKEwSrjzuLIVg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -5979,7 +6781,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6030,7 +6832,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-indent-list/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-indent-list/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-SXqwLKNRAV2EhLKky2BxbHzFktig/czPuCa3NburRIcu24b2IznMsHpX5QzMx2vwh5WOvV6D/0hkIIDaGYIyNg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6039,9 +6841,9 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-indent': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-list': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-indent': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-list': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6061,7 +6863,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-indent-list/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-indent-list/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-SXqwLKNRAV2EhLKky2BxbHzFktig/czPuCa3NburRIcu24b2IznMsHpX5QzMx2vwh5WOvV6D/0hkIIDaGYIyNg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6070,9 +6872,9 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-indent': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-list': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-indent': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-list': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6121,7 +6923,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-indent/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-indent/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-Vah3amIkW3akFlbE3nd+7x5vog6i4wEx0YyC1TcG8BXaCjPgIEUrM7OmRBIX6C2E2xeZmI4J6UphValsBBMYvA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6130,7 +6932,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6150,7 +6952,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-indent/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-indent/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-Vah3amIkW3akFlbE3nd+7x5vog6i4wEx0YyC1TcG8BXaCjPgIEUrM7OmRBIX6C2E2xeZmI4J6UphValsBBMYvA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6159,7 +6961,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6208,7 +7010,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-kbd/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-kbd/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-cAipn4b0UypT3Qtk7Travt578Oyh8Rkmg6rgIgSKAKsMVVr1Y+RZ9ZP5bmHOkAVsHP6dPL0k68rnKMeerv8Tdg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6217,7 +7019,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6237,7 +7039,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-kbd/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-kbd/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-cAipn4b0UypT3Qtk7Travt578Oyh8Rkmg6rgIgSKAKsMVVr1Y+RZ9ZP5bmHOkAVsHP6dPL0k68rnKMeerv8Tdg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6246,7 +7048,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6295,7 +7097,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-line-height/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-line-height/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-cQO6Pq3ysYVA6J7yTxF2JgJ4Ov/yvEK9uG7T5zgPjGoZJFxW9USdw5b0JfgN1EO3si2Iw4Q9vzAZRrgcTIP8Zw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6304,7 +7106,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6324,7 +7126,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-line-height/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-line-height/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-cQO6Pq3ysYVA6J7yTxF2JgJ4Ov/yvEK9uG7T5zgPjGoZJFxW9USdw5b0JfgN1EO3si2Iw4Q9vzAZRrgcTIP8Zw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6333,7 +7135,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6384,7 +7186,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-link/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-link/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-nfDbuuItIaG0twMzXZja1sUnu4iT7zvp0/Xsl1etbz2rld8JeuqbNN8rsTVX0E0HTgmkIBtcYlRqE4OSykJD2Q==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6393,9 +7195,9 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-button': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-normalizers': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-button': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-normalizers': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6415,7 +7217,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-link/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-link/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-nfDbuuItIaG0twMzXZja1sUnu4iT7zvp0/Xsl1etbz2rld8JeuqbNN8rsTVX0E0HTgmkIBtcYlRqE4OSykJD2Q==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6424,9 +7226,9 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-button': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-normalizers': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-button': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-normalizers': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6476,7 +7278,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-list/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-list/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-skL040L82SrjHOwTXxu4b6dI6BlyUBq4jbptIvyblUAbjSfCqJJTnk7DuIOQzklkrgSDWoQQxlEVafFfr/ZnYw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6485,8 +7287,8 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-reset-node': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-reset-node': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6506,7 +7308,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-list/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-list/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-skL040L82SrjHOwTXxu4b6dI6BlyUBq4jbptIvyblUAbjSfCqJJTnk7DuIOQzklkrgSDWoQQxlEVafFfr/ZnYw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6515,8 +7317,8 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-reset-node': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-reset-node': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6570,7 +7372,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-media/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-media/18.9.0_64uzl5e3huym3laqvq32skmtoe:
     resolution: {integrity: sha512-RIlXwPz5gcVh4e/xk5HMeN7RGAxhwPnTU/EWJqhWL2wmyJsY6m3evqX8FTZYyNhMP0CQDXCahUbU1AQ3+Vxudw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6579,12 +7381,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       js-video-url-parser: 0.5.1
       re-resizable: 6.9.9_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-textarea-autosize: 8.3.4_react@17.0.2
+      react-textarea-autosize: 8.4.0_pxzommwrsowkd4kgag6q3sluym
       scriptjs: 2.5.9
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
@@ -6604,7 +7406,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-media/18.9.0_l2ob6amovedmgdotpsyjqhcc6q:
+  /@udecode/plate-media/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-RIlXwPz5gcVh4e/xk5HMeN7RGAxhwPnTU/EWJqhWL2wmyJsY6m3evqX8FTZYyNhMP0CQDXCahUbU1AQ3+Vxudw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6613,12 +7415,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       js-video-url-parser: 0.5.1
       re-resizable: 6.9.9_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-textarea-autosize: 8.3.4_pxzommwrsowkd4kgag6q3sluym
+      react-textarea-autosize: 8.4.0_react@17.0.2
       scriptjs: 2.5.9
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
@@ -6669,7 +7471,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-mention/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-mention/18.9.0_64uzl5e3huym3laqvq32skmtoe:
     resolution: {integrity: sha512-9zMTXHn33k6cfc8IRzWJoAP/5FFvt/5q770fBclLvV8t+A/vMxXAEWj3njWySJOo8pXRa4i+Yf5wibZHOgrkVg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6678,8 +7480,8 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-combobox': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-combobox': 18.9.0_64uzl5e3huym3laqvq32skmtoe
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6700,7 +7502,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-mention/18.9.0_l2ob6amovedmgdotpsyjqhcc6q:
+  /@udecode/plate-mention/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-9zMTXHn33k6cfc8IRzWJoAP/5FFvt/5q770fBclLvV8t+A/vMxXAEWj3njWySJOo8pXRa4i+Yf5wibZHOgrkVg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6709,8 +7511,8 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-combobox': 18.9.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-combobox': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6760,7 +7562,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-node-id/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-node-id/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-0LhstU9Cto5RQ9QqbIwApChnxT6kz/6GT1mSG6WSWTuzYLCyg/7JDr2hMo55cjKFqj7o5KdEXaGxV4/y5X/62A==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6769,7 +7571,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6789,7 +7591,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-node-id/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-node-id/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-0LhstU9Cto5RQ9QqbIwApChnxT6kz/6GT1mSG6WSWTuzYLCyg/7JDr2hMo55cjKFqj7o5KdEXaGxV4/y5X/62A==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6798,7 +7600,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6847,7 +7649,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-normalizers/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-normalizers/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-oMnInl7UYyPiDxuVA5NS9lefMizoNDfYbbUbAb4zdDlv4DEA7wZGD7TA4HxzljtMPZqkaLVZ9fsATUbBrvcV4Q==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6856,7 +7658,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6876,7 +7678,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-normalizers/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-normalizers/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-oMnInl7UYyPiDxuVA5NS9lefMizoNDfYbbUbAb4zdDlv4DEA7wZGD7TA4HxzljtMPZqkaLVZ9fsATUbBrvcV4Q==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6885,7 +7687,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6934,7 +7736,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-paragraph/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-paragraph/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-+lXx40p8sT7+AIOzbyrnx0TNtnFcOexf7HKKvy1Sz0rrXyP+1BUfe+Lihj+krBWamY5cAuBEysEcRgJ6PohS8Q==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6943,7 +7745,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6963,7 +7765,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-paragraph/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-paragraph/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-+lXx40p8sT7+AIOzbyrnx0TNtnFcOexf7HKKvy1Sz0rrXyP+1BUfe+Lihj+krBWamY5cAuBEysEcRgJ6PohS8Q==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6972,7 +7774,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -7021,7 +7823,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-reset-node/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-reset-node/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-li9w3r3OsPQOh13v52Th5RVLUX3kwh/RC+VFrRwf3IjkqiMn4ctBNagujjO4fMbMYnBEBPouig2tHUw66JYy7w==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7030,7 +7832,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -7050,7 +7852,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-reset-node/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-reset-node/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-li9w3r3OsPQOh13v52Th5RVLUX3kwh/RC+VFrRwf3IjkqiMn4ctBNagujjO4fMbMYnBEBPouig2tHUw66JYy7w==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7059,7 +7861,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -7108,7 +7910,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-select/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-select/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-pjhzD/jEvSW2PKgfm8NSIERQZ7NwI4lMK8lheuCDNXdwoY7ziMBvjsL9vmtcAArh08z4a5lFdqs09Guq9BK2TA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7117,7 +7919,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -7137,7 +7939,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-select/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-select/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-pjhzD/jEvSW2PKgfm8NSIERQZ7NwI4lMK8lheuCDNXdwoY7ziMBvjsL9vmtcAArh08z4a5lFdqs09Guq9BK2TA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7146,7 +7948,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -7196,7 +7998,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-selection/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-selection/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-+xvi7xe0wIMjjGZa2dkhE45llnWwdczNvzcWI2rGy1kcvj+xoJ+PfDJcUD9++79MVb1wAivm6oPt0eTQ5C5smg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7205,7 +8007,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       '@viselect/vanilla': 3.1.1
       copy-to-clipboard: 3.3.2
       react: 17.0.2
@@ -7227,7 +8029,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-selection/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-selection/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-+xvi7xe0wIMjjGZa2dkhE45llnWwdczNvzcWI2rGy1kcvj+xoJ+PfDJcUD9++79MVb1wAivm6oPt0eTQ5C5smg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7236,7 +8038,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       '@viselect/vanilla': 3.1.1
       copy-to-clipboard: 3.3.2
       react: 17.0.2
@@ -7290,7 +8092,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-serializer-csv/18.9.0_4ywyo5sd46ikxdhuv7pegx7nwm:
+  /@udecode/plate-serializer-csv/18.9.0_evqyrkgavtfgptj4a3lbeg4pr4:
     resolution: {integrity: sha512-zrCic8wHyhu2MpFChwAixbjdXtMxN5X+hAu24CY41HuSA6mx9UFX6oOoSwNYgSGpZ4EV7/oFYyQwiOgj2dxg0g==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7299,8 +8101,8 @@ packages:
       slate-hyperscript: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-table': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-table': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       papaparse: 5.3.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -7322,7 +8124,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-serializer-csv/18.9.0_iqsqo2a4czrjmp6yackpexipx4:
+  /@udecode/plate-serializer-csv/18.9.0_r5lxuzwuc5e5tbwlobmnfb3tty:
     resolution: {integrity: sha512-zrCic8wHyhu2MpFChwAixbjdXtMxN5X+hAu24CY41HuSA6mx9UFX6oOoSwNYgSGpZ4EV7/oFYyQwiOgj2dxg0g==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7331,8 +8133,8 @@ packages:
       slate-hyperscript: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-table': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-table': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       papaparse: 5.3.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -7393,7 +8195,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-serializer-docx/18.9.0_iqsqo2a4czrjmp6yackpexipx4:
+  /@udecode/plate-serializer-docx/18.9.0_6yma2ds5hvjqegqqbzvfhre25q:
     resolution: {integrity: sha512-cqLUcPkJFiWSiPUIly3SlF7aJ4MWSLyMITeMR25gLXwdyJUBc3gJepaEjd2AAJ0l1C7JihHFp1Hl5CmYAot5rw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7403,13 +8205,13 @@ packages:
       slate-hyperscript: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-heading': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-indent': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-indent-list': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-media': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-paragraph': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-table': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-heading': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-indent': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-indent-list': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-media': 18.9.0_64uzl5e3huym3laqvq32skmtoe
+      '@udecode/plate-paragraph': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-table': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -7432,7 +8234,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-serializer-docx/18.9.0_m5fheiiqhtf5rhj4yydfkmxpb4:
+  /@udecode/plate-serializer-docx/18.9.0_evqyrkgavtfgptj4a3lbeg4pr4:
     resolution: {integrity: sha512-cqLUcPkJFiWSiPUIly3SlF7aJ4MWSLyMITeMR25gLXwdyJUBc3gJepaEjd2AAJ0l1C7JihHFp1Hl5CmYAot5rw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7442,13 +8244,13 @@ packages:
       slate-hyperscript: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-heading': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-indent': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-indent-list': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-media': 18.9.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-paragraph': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-table': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-heading': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-indent': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-indent-list': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-media': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-paragraph': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-table': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -7503,7 +8305,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-serializer-html/18.9.0_4ywyo5sd46ikxdhuv7pegx7nwm:
+  /@udecode/plate-serializer-html/18.9.0_evqyrkgavtfgptj4a3lbeg4pr4:
     resolution: {integrity: sha512-pEkIv+Gw4HcACSHT0mQk5iRFXv/hfNwLQMqhOuPBMNSdq5VgVna4ieiASNCUxNsDNcrHVB4WLZ0x/I+DY5ivTQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7513,7 +8315,7 @@ packages:
       slate-hyperscript: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       html-entities: 2.3.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -7535,7 +8337,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-serializer-html/18.9.0_iqsqo2a4czrjmp6yackpexipx4:
+  /@udecode/plate-serializer-html/18.9.0_r5lxuzwuc5e5tbwlobmnfb3tty:
     resolution: {integrity: sha512-pEkIv+Gw4HcACSHT0mQk5iRFXv/hfNwLQMqhOuPBMNSdq5VgVna4ieiASNCUxNsDNcrHVB4WLZ0x/I+DY5ivTQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7545,7 +8347,7 @@ packages:
       slate-hyperscript: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       html-entities: 2.3.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -7606,7 +8408,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-serializer-md/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-serializer-md/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-T2MgnkKptIpBCWWwvhbvpopXSDuwZucx5V07jU6bZH54hVZcfS+n7Ntx/QS1sdgOEFMrPFCwmCpv98hq4yqE6g==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7615,13 +8417,13 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-block-quote': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-code-block': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-heading': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-link': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-list': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-paragraph': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-block-quote': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-code-block': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-heading': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-link': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-list': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-paragraph': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       remark-parse: 9.0.0
@@ -7645,7 +8447,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-serializer-md/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-serializer-md/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-T2MgnkKptIpBCWWwvhbvpopXSDuwZucx5V07jU6bZH54hVZcfS+n7Ntx/QS1sdgOEFMrPFCwmCpv98hq4yqE6g==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7654,13 +8456,13 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-block-quote': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-code-block': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-heading': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-link': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-list': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-paragraph': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-block-quote': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-code-block': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-heading': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-link': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-list': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-paragraph': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       remark-parse: 9.0.0
@@ -7718,7 +8520,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-styled-components/18.9.0_3u2a2wscqng4lreiczswztzzfe:
+  /@udecode/plate-styled-components/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-raO3+SRSak9sdho8dMMrRqHxjx4svXygho4FZ1Vceu3nm/QqpiweAX9oMYXjtzFZq0ZLnVl9bh0bm9Zj0qtX7g==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7729,15 +8531,15 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       clsx: 1.1.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-is: 18.1.0
+      react-is: 18.2.0
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -7752,7 +8554,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-styled-components/18.9.0_dzbq5trwqhlpn2ecbbowqzpj74:
+  /@udecode/plate-styled-components/18.9.0_wou5wzeuv33fydj2evqusvpyse:
     resolution: {integrity: sha512-raO3+SRSak9sdho8dMMrRqHxjx4svXygho4FZ1Vceu3nm/QqpiweAX9oMYXjtzFZq0ZLnVl9bh0bm9Zj0qtX7g==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7763,15 +8565,15 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       clsx: 1.1.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-is: 18.1.0
+      react-is: 18.2.0
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -7815,7 +8617,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-table/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-table/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-6WbHbl9fb0nMny8LS+ZhaGsShCxdxx3L6HoldKqyFVfs1tI5DI3s4qFXWC/Kv9yaZStaz9y/LokcnEGb6EFHFQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7824,7 +8626,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -7844,7 +8646,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-table/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-table/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-6WbHbl9fb0nMny8LS+ZhaGsShCxdxx3L6HoldKqyFVfs1tI5DI3s4qFXWC/Kv9yaZStaz9y/LokcnEGb6EFHFQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7853,7 +8655,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -7902,7 +8704,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-trailing-block/18.9.0_ddgtzrwqh4xxj4gojkva3i2hny:
+  /@udecode/plate-trailing-block/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-fDqMCl5lqC/eUZUQODQylebXm5FUjwtwuQychBu9BAoFFMJ605kDGn5mKfrAbhOxDUObiu6IzDZdA2Za5SAOEw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7911,7 +8713,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -7931,7 +8733,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-trailing-block/18.9.0_lzld3l452jl7ai3c5z6wescmva:
+  /@udecode/plate-trailing-block/18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y:
     resolution: {integrity: sha512-fDqMCl5lqC/eUZUQODQylebXm5FUjwtwuQychBu9BAoFFMJ605kDGn5mKfrAbhOxDUObiu6IzDZdA2Za5SAOEw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7940,7 +8742,7 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -7996,7 +8798,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-alignment/18.9.0_dzbq5trwqhlpn2ecbbowqzpj74:
+  /@udecode/plate-ui-alignment/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-/6xxrfIH0G8rsjNhisz7kaCcIJudgx59nhWmc/ctcjMPaOyYFtGag4UaonoPl2CkHJKAFT8+5LlUD5q/gtQmAg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8006,16 +8808,16 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-alignment': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-toolbar': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-alignment': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-toolbar': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8032,7 +8834,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-alignment/18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy:
+  /@udecode/plate-ui-alignment/18.9.0_xa4rkm4ve7sofl23hnstild5be:
     resolution: {integrity: sha512-/6xxrfIH0G8rsjNhisz7kaCcIJudgx59nhWmc/ctcjMPaOyYFtGag4UaonoPl2CkHJKAFT8+5LlUD5q/gtQmAg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8042,16 +8844,16 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-alignment': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-toolbar': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
+      '@udecode/plate-alignment': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-toolbar': 18.9.0_xa4rkm4ve7sofl23hnstild5be
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8102,7 +8904,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-block-quote/18.9.0_3u2a2wscqng4lreiczswztzzfe:
+  /@udecode/plate-ui-block-quote/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-KNAixt/Eut2LL3BtW2UrNMR9V6CDTX6Jvsz/mnPeYJZ1017qa5RAQsQHw6GcSXd8VgAkixvphulbZDyIyBc1TA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8112,15 +8914,15 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-block-quote': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
+      '@udecode/plate-block-quote': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8136,7 +8938,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-block-quote/18.9.0_dzbq5trwqhlpn2ecbbowqzpj74:
+  /@udecode/plate-ui-block-quote/18.9.0_wou5wzeuv33fydj2evqusvpyse:
     resolution: {integrity: sha512-KNAixt/Eut2LL3BtW2UrNMR9V6CDTX6Jvsz/mnPeYJZ1017qa5RAQsQHw6GcSXd8VgAkixvphulbZDyIyBc1TA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8146,15 +8948,15 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-block-quote': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-block-quote': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8204,7 +9006,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-button/18.9.0_3u2a2wscqng4lreiczswztzzfe:
+  /@udecode/plate-ui-button/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-hCA6uDDAdsJaJDXLp78uCqDhJpca0GQv0m8UG0g+kUZXGM3LsEljYajJGnVVshunVbZP3/0vUL9u1YkZl92MwA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8214,15 +9016,15 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-button': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
+      '@udecode/plate-button': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8238,7 +9040,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-button/18.9.0_dzbq5trwqhlpn2ecbbowqzpj74:
+  /@udecode/plate-ui-button/18.9.0_wou5wzeuv33fydj2evqusvpyse:
     resolution: {integrity: sha512-hCA6uDDAdsJaJDXLp78uCqDhJpca0GQv0m8UG0g+kUZXGM3LsEljYajJGnVVshunVbZP3/0vUL9u1YkZl92MwA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8248,15 +9050,15 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-button': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-button': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8308,7 +9110,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-code-block/18.9.0_dzbq5trwqhlpn2ecbbowqzpj74:
+  /@udecode/plate-ui-code-block/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-6evahJFHIB1kbqwqWVp/Q4+5SCsScqE4TJWu4Zqq7AvitvT2pGG42ZicGXyqUTvY9vG/JGShh5DQYWKBSw+UUw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8318,16 +9120,16 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-code-block': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-toolbar': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-code-block': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-toolbar': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8344,7 +9146,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-code-block/18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy:
+  /@udecode/plate-ui-code-block/18.9.0_xa4rkm4ve7sofl23hnstild5be:
     resolution: {integrity: sha512-6evahJFHIB1kbqwqWVp/Q4+5SCsScqE4TJWu4Zqq7AvitvT2pGG42ZicGXyqUTvY9vG/JGShh5DQYWKBSw+UUw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8354,16 +9156,16 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-code-block': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-toolbar': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
+      '@udecode/plate-code-block': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-toolbar': 18.9.0_xa4rkm4ve7sofl23hnstild5be
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8416,7 +9218,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-combobox/18.9.0_dzbq5trwqhlpn2ecbbowqzpj74:
+  /@udecode/plate-ui-combobox/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-XF8+wdJ8D6PR+vL5/sohgEPVweZ15Cr3uFvRvqCE/EuHQPEe6Qty5kPtd1yZRUXRMTj2LMo/XGorsHc+755IxQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8426,16 +9228,16 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-combobox': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-floating': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-combobox': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-floating': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8452,7 +9254,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-combobox/18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy:
+  /@udecode/plate-ui-combobox/18.9.0_xa4rkm4ve7sofl23hnstild5be:
     resolution: {integrity: sha512-XF8+wdJ8D6PR+vL5/sohgEPVweZ15Cr3uFvRvqCE/EuHQPEe6Qty5kPtd1yZRUXRMTj2LMo/XGorsHc+755IxQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8462,16 +9264,16 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-combobox': 18.9.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-floating': 18.9.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
+      '@udecode/plate-combobox': 18.9.0_64uzl5e3huym3laqvq32skmtoe
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-floating': 18.9.0_64uzl5e3huym3laqvq32skmtoe
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8521,7 +9323,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-cursor/18.9.0_3u2a2wscqng4lreiczswztzzfe:
+  /@udecode/plate-ui-cursor/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-V0+NiREBO+Zdyssd7mhllcXYG9jZoGLq8o76lNPokziKkHFZsFZ9hGZ3JTl9ItzJytmkWiDBq7I63BSGy3P5Aw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8531,14 +9333,14 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8554,7 +9356,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-cursor/18.9.0_dzbq5trwqhlpn2ecbbowqzpj74:
+  /@udecode/plate-ui-cursor/18.9.0_wou5wzeuv33fydj2evqusvpyse:
     resolution: {integrity: sha512-V0+NiREBO+Zdyssd7mhllcXYG9jZoGLq8o76lNPokziKkHFZsFZ9hGZ3JTl9ItzJytmkWiDBq7I63BSGy3P5Aw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8564,14 +9366,14 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8604,7 +9406,7 @@ packages:
       '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
       '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
       react: 17.0.2
-      react-dnd: 15.1.2_pxzommwrsowkd4kgag6q3sluym
+      react-dnd: 15.1.2_smc5esni47gpbltvxzeziduyte
       react-dnd-html5-backend: 15.1.3
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -8626,7 +9428,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-dnd/18.9.0_m3il3u2zkyh55i2vrix3m3uu7i:
+  /@udecode/plate-ui-dnd/18.9.0_6iiboisxvlrbbtm3fecmdrsxqi:
     resolution: {integrity: sha512-r/sfjSKMSlzQ4l9I8bbUE4PJ7yxK7XGG1PLnEL4RigY6l3J6lhXR9DrkWW0l96uRIo/5iVxo/QTNwK8mEalIWg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8640,17 +9442,17 @@ packages:
     dependencies:
       '@react-hook/merged-ref': 1.3.2_react@17.0.2
       '@tippyjs/react': 4.2.6_sfoxds7t5ydpegc3knd667wn6m
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
       raf: 3.4.1
       react: 17.0.2
-      react-dnd: 15.1.2_pxzommwrsowkd4kgag6q3sluym
-      react-dnd-html5-backend: 15.1.3
+      react-dnd: 16.0.1_smc5esni47gpbltvxzeziduyte
+      react-dnd-html5-backend: 15.1.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8666,7 +9468,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-dnd/18.9.0_r2zhihm6uvbhoiqze7ruswur74:
+  /@udecode/plate-ui-dnd/18.9.0_f5ugpcbq63ru5gzodfuevsobhm:
     resolution: {integrity: sha512-r/sfjSKMSlzQ4l9I8bbUE4PJ7yxK7XGG1PLnEL4RigY6l3J6lhXR9DrkWW0l96uRIo/5iVxo/QTNwK8mEalIWg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8680,17 +9482,17 @@ packages:
     dependencies:
       '@react-hook/merged-ref': 1.3.2_react@17.0.2
       '@tippyjs/react': 4.2.6_sfoxds7t5ydpegc3knd667wn6m
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       raf: 3.4.1
       react: 17.0.2
-      react-dnd: 15.1.2_react@17.0.2
-      react-dnd-html5-backend: 15.1.3
+      react-dnd: 16.0.1_react@17.0.2
+      react-dnd-html5-backend: 15.1.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8742,7 +9544,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-find-replace/18.9.0_dzbq5trwqhlpn2ecbbowqzpj74:
+  /@udecode/plate-ui-find-replace/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-kY22kVp0k6vfLM5nwX2n1Vp3+Hu5lquhYKhgoWYFK/Xk/No5E99LRXnUCbAgstkQcvxcIM4RtcwHuCSICArvVA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8752,16 +9554,16 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-find-replace': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-toolbar': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-find-replace': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-toolbar': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8778,7 +9580,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-find-replace/18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy:
+  /@udecode/plate-ui-find-replace/18.9.0_xa4rkm4ve7sofl23hnstild5be:
     resolution: {integrity: sha512-kY22kVp0k6vfLM5nwX2n1Vp3+Hu5lquhYKhgoWYFK/Xk/No5E99LRXnUCbAgstkQcvxcIM4RtcwHuCSICArvVA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8788,16 +9590,16 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-find-replace': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-toolbar': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-find-replace': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-toolbar': 18.9.0_xa4rkm4ve7sofl23hnstild5be
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8851,7 +9653,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-font/18.9.0_dzbq5trwqhlpn2ecbbowqzpj74:
+  /@udecode/plate-ui-font/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-847D/lZTvn3d63cKM3bvBYzZMIxN1kldzUvgxpur/X05ekj72zAiAOj/35QmFPCdrvIVeJG1R34tDslXCBppIA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8861,17 +9663,17 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-font': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-button': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-toolbar': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-font': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-button': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-toolbar': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8888,7 +9690,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-font/18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy:
+  /@udecode/plate-ui-font/18.9.0_xa4rkm4ve7sofl23hnstild5be:
     resolution: {integrity: sha512-847D/lZTvn3d63cKM3bvBYzZMIxN1kldzUvgxpur/X05ekj72zAiAOj/35QmFPCdrvIVeJG1R34tDslXCBppIA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8898,17 +9700,17 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-font': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-button': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-toolbar': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-font': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-button': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-toolbar': 18.9.0_xa4rkm4ve7sofl23hnstild5be
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8961,7 +9763,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-line-height/18.9.0_dzbq5trwqhlpn2ecbbowqzpj74:
+  /@udecode/plate-ui-line-height/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-+Jno1fb8uOKhwCCC8/p3TXH4wkZqHx5gtA/IcyC3YER96zh4fEANL47/VLMNW+1xuSPHOaBGl/bCTowD+PpyAg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8971,16 +9773,16 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-line-height': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-toolbar': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-line-height': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-toolbar': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8997,7 +9799,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-line-height/18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy:
+  /@udecode/plate-ui-line-height/18.9.0_xa4rkm4ve7sofl23hnstild5be:
     resolution: {integrity: sha512-+Jno1fb8uOKhwCCC8/p3TXH4wkZqHx5gtA/IcyC3YER96zh4fEANL47/VLMNW+1xuSPHOaBGl/bCTowD+PpyAg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9007,16 +9809,16 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-line-height': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-toolbar': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-line-height': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-toolbar': 18.9.0_xa4rkm4ve7sofl23hnstild5be
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9070,7 +9872,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-link/18.9.0_dzbq5trwqhlpn2ecbbowqzpj74:
+  /@udecode/plate-ui-link/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-oGOq/645Z0iChuRU/sNbmp8nGPmRwf2e1LxU9OaDrJxMwrjS7GFUYzD+/Wj00CtMZFoaG3ywu6/4GwAD17Yw1w==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9080,17 +9882,17 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-link': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-button': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-toolbar': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-link': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-button': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-toolbar': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9107,7 +9909,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-link/18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy:
+  /@udecode/plate-ui-link/18.9.0_xa4rkm4ve7sofl23hnstild5be:
     resolution: {integrity: sha512-oGOq/645Z0iChuRU/sNbmp8nGPmRwf2e1LxU9OaDrJxMwrjS7GFUYzD+/Wj00CtMZFoaG3ywu6/4GwAD17Yw1w==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9117,17 +9919,17 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-link': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-button': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-toolbar': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-link': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-button': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-toolbar': 18.9.0_xa4rkm4ve7sofl23hnstild5be
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9180,7 +9982,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-list/18.9.0_dzbq5trwqhlpn2ecbbowqzpj74:
+  /@udecode/plate-ui-list/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-pmIWF1eknZLyn46Eke+qk7O9CzNiAiS4Bpq4ypXiz8gNTX2O05/9sUQfj9twRvFAYwxNDmPXuxa+DPdICTzgRA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9190,16 +9992,16 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-list': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-toolbar': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-list': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-toolbar': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9216,7 +10018,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-list/18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy:
+  /@udecode/plate-ui-list/18.9.0_xa4rkm4ve7sofl23hnstild5be:
     resolution: {integrity: sha512-pmIWF1eknZLyn46Eke+qk7O9CzNiAiS4Bpq4ypXiz8gNTX2O05/9sUQfj9twRvFAYwxNDmPXuxa+DPdICTzgRA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9226,16 +10028,16 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-list': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-toolbar': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-list': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-toolbar': 18.9.0_xa4rkm4ve7sofl23hnstild5be
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9292,7 +10094,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-media/18.9.0_dzbq5trwqhlpn2ecbbowqzpj74:
+  /@udecode/plate-ui-media/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-NpWoP+0vuzOuhaDf502hvthVYGX4KSElyZw7Y8/z4TBtkNtb/rVy+XNGRQ+i7/UTBX2X/+1iTN571rALFdiciA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9302,20 +10104,20 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-floating': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-link': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-media': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-link': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-toolbar': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-floating': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-link': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-media': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-link': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-toolbar': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       js-video-url-parser: 0.5.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9332,7 +10134,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-media/18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy:
+  /@udecode/plate-ui-media/18.9.0_xa4rkm4ve7sofl23hnstild5be:
     resolution: {integrity: sha512-NpWoP+0vuzOuhaDf502hvthVYGX4KSElyZw7Y8/z4TBtkNtb/rVy+XNGRQ+i7/UTBX2X/+1iTN571rALFdiciA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9342,20 +10144,20 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-floating': 18.9.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-link': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-media': 18.9.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-link': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-toolbar': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-floating': 18.9.0_64uzl5e3huym3laqvq32skmtoe
+      '@udecode/plate-link': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-media': 18.9.0_64uzl5e3huym3laqvq32skmtoe
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-link': 18.9.0_xa4rkm4ve7sofl23hnstild5be
+      '@udecode/plate-ui-toolbar': 18.9.0_xa4rkm4ve7sofl23hnstild5be
       js-video-url-parser: 0.5.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9409,7 +10211,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-mention/18.9.0_dzbq5trwqhlpn2ecbbowqzpj74:
+  /@udecode/plate-ui-mention/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-Zknjk+lUMtkkrgXy10CZgobQOhHDZLQqGHPjD3CWDteawxLUflE3a5I4+EBlA295jtUz3aTH3lIE3+MglvJKcw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9419,17 +10221,17 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-combobox': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-mention': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-combobox': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-combobox': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-mention': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-combobox': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9446,7 +10248,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-mention/18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy:
+  /@udecode/plate-ui-mention/18.9.0_xa4rkm4ve7sofl23hnstild5be:
     resolution: {integrity: sha512-Zknjk+lUMtkkrgXy10CZgobQOhHDZLQqGHPjD3CWDteawxLUflE3a5I4+EBlA295jtUz3aTH3lIE3+MglvJKcw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9456,17 +10258,17 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-combobox': 18.9.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-mention': 18.9.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-combobox': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
+      '@udecode/plate-combobox': 18.9.0_64uzl5e3huym3laqvq32skmtoe
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-mention': 18.9.0_64uzl5e3huym3laqvq32skmtoe
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-combobox': 18.9.0_xa4rkm4ve7sofl23hnstild5be
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9516,7 +10318,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-placeholder/18.9.0_3u2a2wscqng4lreiczswztzzfe:
+  /@udecode/plate-ui-placeholder/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-muT67OFdkDTNeUWB94hLWXrz49iKzrXHZXRn0ubHansv0z6IuR9STaAElis5y/YvBZSDe8O0b0qsiEHdhgtEGA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9526,14 +10328,14 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9549,7 +10351,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-placeholder/18.9.0_dzbq5trwqhlpn2ecbbowqzpj74:
+  /@udecode/plate-ui-placeholder/18.9.0_wou5wzeuv33fydj2evqusvpyse:
     resolution: {integrity: sha512-muT67OFdkDTNeUWB94hLWXrz49iKzrXHZXRn0ubHansv0z6IuR9STaAElis5y/YvBZSDe8O0b0qsiEHdhgtEGA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9559,14 +10361,14 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9621,7 +10423,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-table/18.9.0_dzbq5trwqhlpn2ecbbowqzpj74:
+  /@udecode/plate-ui-table/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-lCN0Mecj5+yQIS1dQw4XS5AtbdEZosDi7WRT0MxLTp4yuNp1DDUcfjl9PzKFfaqkOLs9/9iHAkznDzC24EV06A==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9631,19 +10433,19 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-floating': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-table': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-ui-button': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-toolbar': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-floating': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-table': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-ui-button': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-toolbar': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       re-resizable: 6.9.9_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9660,7 +10462,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-table/18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy:
+  /@udecode/plate-ui-table/18.9.0_xa4rkm4ve7sofl23hnstild5be:
     resolution: {integrity: sha512-lCN0Mecj5+yQIS1dQw4XS5AtbdEZosDi7WRT0MxLTp4yuNp1DDUcfjl9PzKFfaqkOLs9/9iHAkznDzC24EV06A==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9670,19 +10472,19 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-floating': 18.9.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-table': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-ui-button': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-toolbar': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-floating': 18.9.0_64uzl5e3huym3laqvq32skmtoe
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-table': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-ui-button': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-toolbar': 18.9.0_xa4rkm4ve7sofl23hnstild5be
       re-resizable: 6.9.9_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9737,7 +10539,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-toolbar/18.9.0_dzbq5trwqhlpn2ecbbowqzpj74:
+  /@udecode/plate-ui-toolbar/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-qUwHWnYddJG0Cmtw/dIi+hqe6FlXt2Y4gPd3fB1VpWEYKjBV9jqvqZdMFjpVfOm2SvCPko/upp30aXH0ArtrDQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9748,17 +10550,17 @@ packages:
       styled-components: '>=5.0.0'
     dependencies:
       '@tippyjs/react': 4.2.6_sfoxds7t5ydpegc3knd667wn6m
-      '@udecode/plate-core': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-floating': 18.9.0_ddgtzrwqh4xxj4gojkva3i2hny
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-button': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-floating': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-button': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-use: 17.3.2_sfoxds7t5ydpegc3knd667wn6m
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9775,7 +10577,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-toolbar/18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy:
+  /@udecode/plate-ui-toolbar/18.9.0_xa4rkm4ve7sofl23hnstild5be:
     resolution: {integrity: sha512-qUwHWnYddJG0Cmtw/dIi+hqe6FlXt2Y4gPd3fB1VpWEYKjBV9jqvqZdMFjpVfOm2SvCPko/upp30aXH0ArtrDQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9786,17 +10588,17 @@ packages:
       styled-components: '>=5.0.0'
     dependencies:
       '@tippyjs/react': 4.2.6_sfoxds7t5ydpegc3knd667wn6m
-      '@udecode/plate-core': 18.9.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-floating': 18.9.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-button': 18.9.0_3u2a2wscqng4lreiczswztzzfe
+      '@udecode/plate-core': 18.9.0_blf3u7zakgjrhm5t6ncitc2fqy
+      '@udecode/plate-floating': 18.9.0_64uzl5e3huym3laqvq32skmtoe
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-button': 18.9.0_wou5wzeuv33fydj2evqusvpyse
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-use: 17.3.2_sfoxds7t5ydpegc3knd667wn6m
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9846,7 +10648,7 @@ packages:
       '@udecode/plate-ui-table': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
       '@udecode/plate-ui-toolbar': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
       react: 17.0.2
-      react-dnd: 15.1.2_pxzommwrsowkd4kgag6q3sluym
+      react-dnd: 15.1.2_smc5esni47gpbltvxzeziduyte
       react-dnd-html5-backend: 15.1.3
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -9871,7 +10673,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui/18.9.0_3applnbcmonz6yjsxb2hv5truu:
+  /@udecode/plate-ui/18.9.0_lq7qkw3fyxdfk55wtvczfr7dqi:
     resolution: {integrity: sha512-AEhryLWvuTNABas5lGUZQJ/NahMg6cwz3IZ2Z8fA68T6NafKzcdyrWDm8NctBmU2p3RGeiSEg0+iDMARRPF3mA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9884,34 +10686,34 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-headless': 18.9.0_m5fheiiqhtf5rhj4yydfkmxpb4
-      '@udecode/plate-styled-components': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-alignment': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-block-quote': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-button': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-code-block': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-combobox': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-cursor': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-dnd': 18.9.0_m3il3u2zkyh55i2vrix3m3uu7i
-      '@udecode/plate-ui-find-replace': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-font': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-line-height': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-link': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-list': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-media': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-mention': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-placeholder': 18.9.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-table': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-toolbar': 18.9.0_jbz7ghep6wjhxqiau5fvi2yqxy
+      '@udecode/plate-headless': 18.9.0_6yma2ds5hvjqegqqbzvfhre25q
+      '@udecode/plate-styled-components': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-alignment': 18.9.0_xa4rkm4ve7sofl23hnstild5be
+      '@udecode/plate-ui-block-quote': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-button': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-code-block': 18.9.0_xa4rkm4ve7sofl23hnstild5be
+      '@udecode/plate-ui-combobox': 18.9.0_xa4rkm4ve7sofl23hnstild5be
+      '@udecode/plate-ui-cursor': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-dnd': 18.9.0_6iiboisxvlrbbtm3fecmdrsxqi
+      '@udecode/plate-ui-find-replace': 18.9.0_xa4rkm4ve7sofl23hnstild5be
+      '@udecode/plate-ui-font': 18.9.0_xa4rkm4ve7sofl23hnstild5be
+      '@udecode/plate-ui-line-height': 18.9.0_xa4rkm4ve7sofl23hnstild5be
+      '@udecode/plate-ui-link': 18.9.0_xa4rkm4ve7sofl23hnstild5be
+      '@udecode/plate-ui-list': 18.9.0_xa4rkm4ve7sofl23hnstild5be
+      '@udecode/plate-ui-media': 18.9.0_xa4rkm4ve7sofl23hnstild5be
+      '@udecode/plate-ui-mention': 18.9.0_xa4rkm4ve7sofl23hnstild5be
+      '@udecode/plate-ui-placeholder': 18.9.0_wou5wzeuv33fydj2evqusvpyse
+      '@udecode/plate-ui-table': 18.9.0_xa4rkm4ve7sofl23hnstild5be
+      '@udecode/plate-ui-toolbar': 18.9.0_xa4rkm4ve7sofl23hnstild5be
       react: 17.0.2
-      react-dnd: 15.1.2_pxzommwrsowkd4kgag6q3sluym
-      react-dnd-html5-backend: 15.1.3
+      react-dnd: 16.0.1_smc5esni47gpbltvxzeziduyte
+      react-dnd-html5-backend: 15.1.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-hyperscript: 0.77.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9929,7 +10731,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui/18.9.0_zanjem6utblhvsgiqea5mzthka:
+  /@udecode/plate-ui/18.9.0_ynovzzal4ukqjumbrzchvba2hi:
     resolution: {integrity: sha512-AEhryLWvuTNABas5lGUZQJ/NahMg6cwz3IZ2Z8fA68T6NafKzcdyrWDm8NctBmU2p3RGeiSEg0+iDMARRPF3mA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9942,34 +10744,34 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-headless': 18.9.0_iqsqo2a4czrjmp6yackpexipx4
-      '@udecode/plate-styled-components': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-alignment': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-block-quote': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-button': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-code-block': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-combobox': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-cursor': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-dnd': 18.9.0_r2zhihm6uvbhoiqze7ruswur74
-      '@udecode/plate-ui-find-replace': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-font': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-line-height': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-link': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-list': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-media': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-mention': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-placeholder': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-table': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
-      '@udecode/plate-ui-toolbar': 18.9.0_dzbq5trwqhlpn2ecbbowqzpj74
+      '@udecode/plate-headless': 18.9.0_evqyrkgavtfgptj4a3lbeg4pr4
+      '@udecode/plate-styled-components': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-alignment': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-block-quote': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-button': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-code-block': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-combobox': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-cursor': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-dnd': 18.9.0_f5ugpcbq63ru5gzodfuevsobhm
+      '@udecode/plate-ui-find-replace': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-font': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-line-height': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-link': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-list': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-media': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-mention': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-placeholder': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-table': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
+      '@udecode/plate-ui-toolbar': 18.9.0_boq2e7lx2l7gagjs37x4idb7yy
       react: 17.0.2
-      react-dnd: 15.1.2_react@17.0.2
-      react-dnd-html5-backend: 15.1.3
+      react-dnd: 16.0.1_react@17.0.2
+      react-dnd-html5-backend: 15.1.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-hyperscript: 0.77.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -10026,7 +10828,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate/18.9.0_3applnbcmonz6yjsxb2hv5truu:
+  /@udecode/plate/18.9.0_lq7qkw3fyxdfk55wtvczfr7dqi:
     resolution: {integrity: sha512-8atV08toDZ7bUpiv/wke+vbzPzzMNS/E3kPZKBno4DDvIIg+jx1mMO8arjmxnGGbgQrW4mGaDCMjANNE0rkxfA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -10037,15 +10839,15 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-headless': 18.9.0_m5fheiiqhtf5rhj4yydfkmxpb4
-      '@udecode/plate-ui': 18.9.0_3applnbcmonz6yjsxb2hv5truu
+      '@udecode/plate-headless': 18.9.0_6yma2ds5hvjqegqqbzvfhre25q
+      '@udecode/plate-ui': 18.9.0_lq7qkw3fyxdfk55wtvczfr7dqi
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-hyperscript: 0.77.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -10065,7 +10867,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate/18.9.0_zanjem6utblhvsgiqea5mzthka:
+  /@udecode/plate/18.9.0_ynovzzal4ukqjumbrzchvba2hi:
     resolution: {integrity: sha512-8atV08toDZ7bUpiv/wke+vbzPzzMNS/E3kPZKBno4DDvIIg+jx1mMO8arjmxnGGbgQrW4mGaDCMjANNE0rkxfA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -10076,15 +10878,15 @@ packages:
       slate-react: '>=0.79.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-headless': 18.9.0_iqsqo2a4czrjmp6yackpexipx4
-      '@udecode/plate-ui': 18.9.0_zanjem6utblhvsgiqea5mzthka
+      '@udecode/plate-headless': 18.9.0_evqyrkgavtfgptj4a3lbeg4pr4
+      '@udecode/plate-ui': 18.9.0_ynovzzal4ukqjumbrzchvba2hi
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-hyperscript: 0.77.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -10403,6 +11205,16 @@ packages:
     resolution: {integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==}
     dev: false
 
+  /@xstate/immer/0.3.1_immer@9.0.12+xstate@4.28.1:
+    resolution: {integrity: sha512-YE+KY08IjEEmXo6XKKpeSGW4j9LfcXw+5JVixLLUO3fWQ3M95joWJ40VtGzx0w0zQSzoCNk8NgfvwWBGSbIaTA==}
+    peerDependencies:
+      immer: ^9.0.6
+      xstate: ^4.29.0
+    dependencies:
+      immer: 9.0.12
+      xstate: 4.28.1
+    dev: false
+
   /@xstate/immer/0.3.1_immer@9.0.12+xstate@4.32.0:
     resolution: {integrity: sha512-YE+KY08IjEEmXo6XKKpeSGW4j9LfcXw+5JVixLLUO3fWQ3M95joWJ40VtGzx0w0zQSzoCNk8NgfvwWBGSbIaTA==}
     peerDependencies:
@@ -10433,7 +11245,27 @@ packages:
       - '@types/react'
     dev: false
 
-  /@xstate/react/1.6.3_react@17.0.2+xstate@4.32.0:
+  /@xstate/react/1.6.3_gcyz5mxmyrgibkcjljkbjmosn4:
+    resolution: {integrity: sha512-NCUReRHPGvvCvj2yLZUTfR0qVp6+apc8G83oXSjN4rl89ZjyujiKrTff55bze/HrsvCsP/sUJASf2n0nzMF1KQ==}
+    peerDependencies:
+      '@xstate/fsm': ^1.0.0
+      react: ^16.8.0 || ^17.0.0
+      xstate: ^4.11.0
+    peerDependenciesMeta:
+      '@xstate/fsm':
+        optional: true
+      xstate:
+        optional: true
+    dependencies:
+      react: 17.0.2
+      use-isomorphic-layout-effect: 1.1.2_pxzommwrsowkd4kgag6q3sluym
+      use-subscription: 1.7.0_react@17.0.2
+      xstate: 4.28.1
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
+  /@xstate/react/1.6.3_react@17.0.2+xstate@4.28.1:
     resolution: {integrity: sha512-NCUReRHPGvvCvj2yLZUTfR0qVp6+apc8G83oXSjN4rl89ZjyujiKrTff55bze/HrsvCsP/sUJASf2n0nzMF1KQ==}
     peerDependencies:
       '@xstate/fsm': ^1.0.0
@@ -10448,7 +11280,7 @@ packages:
       react: 17.0.2
       use-isomorphic-layout-effect: 1.1.2_react@17.0.2
       use-subscription: 1.7.0_react@17.0.2
-      xstate: 4.32.0
+      xstate: 4.28.1
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -10742,12 +11574,29 @@ packages:
       styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
     dev: false
 
+  /babel-plugin-styled-components/2.0.7_styled-components@5.3.6:
+    resolution: {integrity: sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==}
+    peerDependencies:
+      styled-components: '>= 2'
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-module-imports': 7.18.6
+      babel-plugin-syntax-jsx: 6.18.0
+      lodash: 4.17.21
+      picomatch: 2.3.1
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    dev: false
+
   /babel-plugin-syntax-jsx/6.18.0:
     resolution: {integrity: sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==}
     dev: false
 
   /bail/1.0.5:
     resolution: {integrity: sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==}
+    dev: false
+
+  /bail/2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
     dev: false
 
   /balanced-match/1.0.2:
@@ -10870,6 +11719,10 @@ packages:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
     dev: true
 
+  /ccount/2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+    dev: false
+
   /chai/4.3.6:
     resolution: {integrity: sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==}
     engines: {node: '>=4'}
@@ -10912,6 +11765,10 @@ packages:
 
   /character-entities/1.2.4:
     resolution: {integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==}
+
+  /character-entities/2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+    dev: false
 
   /character-reference-invalid/1.1.4:
     resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
@@ -11275,6 +12132,11 @@ packages:
     engines: {node: '>=0.11'}
     dev: false
 
+  /date-fns/2.29.3:
+    resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
+    engines: {node: '>=0.11'}
+    dev: false
+
   /dayjs/1.11.6:
     resolution: {integrity: sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ==}
 
@@ -11327,6 +12189,12 @@ packages:
       supports-color: 8.1.1
     dev: true
 
+  /decode-named-character-reference/1.0.2:
+    resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
+    dependencies:
+      character-entities: 2.0.2
+    dev: false
+
   /deep-eql/3.0.1:
     resolution: {integrity: sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==}
     engines: {node: '>=0.12'}
@@ -11365,6 +12233,11 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
+  /dequal/2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+    dev: false
+
   /detective/5.2.1:
     resolution: {integrity: sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==}
     engines: {node: '>=0.8.0'}
@@ -11400,6 +12273,14 @@ packages:
 
   /dlv/1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  /dnd-core/15.1.1:
+    resolution: {integrity: sha512-Mtj/Sltcx7stVXzeDg4g7roTe/AmzRuIf/FYOxX6F8gULbY54w066BlErBOzQfn9RIJ3gAYLGX7wvVvoBSq7ig==}
+    dependencies:
+      '@react-dnd/asap': 4.0.0
+      '@react-dnd/invariant': 3.0.0
+      redux: 4.2.0
+    dev: false
 
   /dnd-core/15.1.2:
     resolution: {integrity: sha512-EOec1LyJUuGRFg0LDa55rSRAUe97uNVKVkUo8iyvzQlcECYTuPblVQfRWXWj1OyPseFIeebWpNmKFy0h6BcF1A==}
@@ -12042,6 +12923,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /escape-string-regexp/5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+    dev: false
+
   /eslint-config-prettier/8.5.0_eslint@8.27.0:
     resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
     hasBin: true
@@ -12614,6 +13500,24 @@ packages:
     resolution: {integrity: sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==}
     dev: true
 
+  /framer-motion/6.4.3_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-prcyOGFkGjwGEgbxObIWteVz1ihuWaDLdR03626cbA1GxTaPRpLb8ioJfWPmP5mwcWC7TlhMOjS5kBYnuiktFA==}
+    peerDependencies:
+      react: '>=16.8 || ^17.0.0 || ^18.0.0'
+      react-dom: '>=16.8 || ^17.0.0 || ^18.0.0'
+    dependencies:
+      '@motionone/dom': 10.12.0
+      framesync: 6.0.1
+      hey-listen: 1.0.8
+      popmotion: 11.0.3
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      style-value-types: 5.0.0
+      tslib: 2.4.0
+    optionalDependencies:
+      '@emotion/is-prop-valid': 0.8.8
+    dev: false
+
   /framer-motion/6.5.1_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==}
     peerDependencies:
@@ -13069,6 +13973,15 @@ packages:
       side-channel: 1.0.4
     dev: true
 
+  /intl-messageformat/10.2.1:
+    resolution: {integrity: sha512-1lrJG2qKzcC1TVzYu1VuB1yiY68LU5rwpbHa2THCzA67Vutkz7+1lv5U20K3Lz5RAiH78zxNztMEtchokMWv8A==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.13.0
+      '@formatjs/fast-memoize': 1.2.6
+      '@formatjs/icu-messageformat-parser': 2.1.10
+      tslib: 2.4.0
+    dev: false
+
   /intl-messageformat/9.13.0:
     resolution: {integrity: sha512-7sGC7QnSQGa5LZP7bXLDhVDtQOeKGeBFGHF2Y8LVBwYZoQZCgWeKoPGTa5GMG8g/TzDgeXuYJQis7Ggiw2xTOw==}
     dependencies:
@@ -13250,6 +14163,11 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /is-plain-obj/4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+    dev: false
+
   /is-plain-object/5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
@@ -13342,6 +14260,45 @@ packages:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
     dev: true
 
+  /jotai/1.8.4_3b7ya6az73zroop2ncavdncsxq:
+    resolution: {integrity: sha512-bkHDHNxm7bU4+bJL4z96fTlJYN34UDRTu3ghEajJrDepayON9YEaxPrXr7xhLnIRntoFC6eDYYhMNA/ilbj2RQ==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      '@babel/template': '*'
+      '@tanstack/query-core': '*'
+      '@urql/core': '*'
+      immer: '*'
+      optics-ts: '*'
+      react: '>=16.8'
+      valtio: '*'
+      wonka: '*'
+      xstate: '*'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@babel/template':
+        optional: true
+      '@tanstack/query-core':
+        optional: true
+      '@urql/core':
+        optional: true
+      immer:
+        optional: true
+      optics-ts:
+        optional: true
+      valtio:
+        optional: true
+      wonka:
+        optional: true
+      xstate:
+        optional: true
+    dependencies:
+      immer: 9.0.12
+      react: 17.0.2
+      xstate: 4.28.1
+    dev: false
+
   /jotai/1.8.4_bbxtl6ryvenc2jc6uyz5mlvgwe:
     resolution: {integrity: sha512-bkHDHNxm7bU4+bJL4z96fTlJYN34UDRTu3ghEajJrDepayON9YEaxPrXr7xhLnIRntoFC6eDYYhMNA/ilbj2RQ==}
     engines: {node: '>=12.7.0'}
@@ -13382,7 +14339,7 @@ packages:
       xstate: 4.32.0
     dev: false
 
-  /jotai/1.8.4_nvgnzhxlzgsaoilftx3vuhxn2q:
+  /jotai/1.8.4_iskeb5babgxc5jvzp4zlrgistu:
     resolution: {integrity: sha512-bkHDHNxm7bU4+bJL4z96fTlJYN34UDRTu3ghEajJrDepayON9YEaxPrXr7xhLnIRntoFC6eDYYhMNA/ilbj2RQ==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
@@ -13416,9 +14373,10 @@ packages:
       xstate:
         optional: true
     dependencies:
+      '@babel/core': 7.20.2
       immer: 9.0.12
       react: 17.0.2
-      xstate: 4.32.0
+      xstate: 4.28.1
     dev: false
 
   /js-cookie/2.2.1:
@@ -13536,6 +14494,11 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /kleur/4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+    dev: false
 
   /kolorist/1.6.0:
     resolution: {integrity: sha512-dLkz37Ab97HWMx9KTes3Tbi3D1ln9fCAy2zr2YVExJasDRPGRaKcoE4fycWNtnCAJfjFqe0cnY+f8KT2JePEXQ==}
@@ -13655,6 +14618,10 @@ packages:
       wrap-ansi: 6.2.0
     dev: true
 
+  /longest-streak/3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+    dev: false
+
   /loose-envify/1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -13701,6 +14668,18 @@ packages:
     resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
     dev: false
 
+  /markdown-table/3.0.2:
+    resolution: {integrity: sha512-y8j3a5/DkJCmS5x4dMCQL+OR0+2EAq3DOtio1COSHsmW2BGXnNCK3v12hJt1LrUz5iZH5g0LmuYOjDdI+czghA==}
+    dev: false
+
+  /mdast-util-find-and-replace/2.2.1:
+    resolution: {integrity: sha512-SobxkQXFAdd4b5WmEakmkVoh18icjQRxGy5OWTCzgsLRm1Fu/KCtwD1HIQSsmq5ZRjVH0Ehwg6/Fn3xIUk+nKw==}
+    dependencies:
+      escape-string-regexp: 5.0.0
+      unist-util-is: 5.1.1
+      unist-util-visit-parents: 5.1.1
+    dev: false
+
   /mdast-util-from-markdown/0.8.5:
     resolution: {integrity: sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==}
     dependencies:
@@ -13712,8 +14691,99 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /mdast-util-from-markdown/1.2.0:
+    resolution: {integrity: sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      '@types/unist': 2.0.6
+      decode-named-character-reference: 1.0.2
+      mdast-util-to-string: 3.1.0
+      micromark: 3.1.0
+      micromark-util-decode-numeric-character-reference: 1.0.0
+      micromark-util-decode-string: 1.0.2
+      micromark-util-normalize-identifier: 1.0.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      unist-util-stringify-position: 3.0.2
+      uvu: 0.5.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-gfm-autolink-literal/1.0.2:
+    resolution: {integrity: sha512-FzopkOd4xTTBeGXhXSBU0OCDDh5lUj2rd+HQqG92Ld+jL4lpUfgX2AT2OHAVP9aEeDKp7G92fuooSZcYJA3cRg==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      ccount: 2.0.1
+      mdast-util-find-and-replace: 2.2.1
+      micromark-util-character: 1.1.0
+    dev: false
+
+  /mdast-util-gfm-footnote/1.0.1:
+    resolution: {integrity: sha512-p+PrYlkw9DeCRkTVw1duWqPRHX6Ywh2BNKJQcZbCwAuP/59B0Lk9kakuAd7KbQprVO4GzdW8eS5++A9PUSqIyw==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      mdast-util-to-markdown: 1.3.0
+      micromark-util-normalize-identifier: 1.0.0
+    dev: false
+
+  /mdast-util-gfm-strikethrough/1.0.2:
+    resolution: {integrity: sha512-T/4DVHXcujH6jx1yqpcAYYwd+z5lAYMw4Ls6yhTfbMMtCt0PHY4gEfhW9+lKsLBtyhUGKRIzcUA2FATVqnvPDA==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      mdast-util-to-markdown: 1.3.0
+    dev: false
+
+  /mdast-util-gfm-table/1.0.6:
+    resolution: {integrity: sha512-uHR+fqFq3IvB3Rd4+kzXW8dmpxUhvgCQZep6KdjsLK4O6meK5dYZEayLtIxNus1XO3gfjfcIFe8a7L0HZRGgag==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      markdown-table: 3.0.2
+      mdast-util-from-markdown: 1.2.0
+      mdast-util-to-markdown: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-gfm-task-list-item/1.0.1:
+    resolution: {integrity: sha512-KZ4KLmPdABXOsfnM6JHUIjxEvcx2ulk656Z/4Balw071/5qgnhz+H1uGtf2zIGnrnvDC8xR4Fj9uKbjAFGNIeA==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      mdast-util-to-markdown: 1.3.0
+    dev: false
+
+  /mdast-util-gfm/2.0.1:
+    resolution: {integrity: sha512-42yHBbfWIFisaAfV1eixlabbsa6q7vHeSPY+cg+BBjX51M8xhgMacqH9g6TftB/9+YkcI0ooV4ncfrJslzm/RQ==}
+    dependencies:
+      mdast-util-from-markdown: 1.2.0
+      mdast-util-gfm-autolink-literal: 1.0.2
+      mdast-util-gfm-footnote: 1.0.1
+      mdast-util-gfm-strikethrough: 1.0.2
+      mdast-util-gfm-table: 1.0.6
+      mdast-util-gfm-task-list-item: 1.0.1
+      mdast-util-to-markdown: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-to-markdown/1.3.0:
+    resolution: {integrity: sha512-6tUSs4r+KK4JGTTiQ7FfHmVOaDrLQJPmpjD6wPMlHGUVXoG9Vjc3jIeP+uyBWRf8clwB2blM+W7+KrlMYQnftA==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      '@types/unist': 2.0.6
+      longest-streak: 3.1.0
+      mdast-util-to-string: 3.1.0
+      micromark-util-decode-string: 1.0.2
+      unist-util-visit: 4.1.1
+      zwitch: 2.0.4
+    dev: false
+
   /mdast-util-to-string/2.0.0:
     resolution: {integrity: sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==}
+
+  /mdast-util-to-string/3.1.0:
+    resolution: {integrity: sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==}
+    dev: false
 
   /mdn-data/2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
@@ -13737,6 +14807,231 @@ packages:
     resolution: {integrity: sha512-+TZ5dUDPKPJaU/rscTzxyN8ZkX7eAVLAiQU/e+YINleXPv03SCmJShaMT1If1liTH8OcmWXZs0CmzCBRBLcMpA==}
     dev: true
 
+  /micromark-core-commonmark/1.0.6:
+    resolution: {integrity: sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==}
+    dependencies:
+      decode-named-character-reference: 1.0.2
+      micromark-factory-destination: 1.0.0
+      micromark-factory-label: 1.0.2
+      micromark-factory-space: 1.0.0
+      micromark-factory-title: 1.0.2
+      micromark-factory-whitespace: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-chunked: 1.0.0
+      micromark-util-classify-character: 1.0.0
+      micromark-util-html-tag-name: 1.1.0
+      micromark-util-normalize-identifier: 1.0.0
+      micromark-util-resolve-all: 1.0.0
+      micromark-util-subtokenize: 1.0.2
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-extension-gfm-autolink-literal/1.0.3:
+    resolution: {integrity: sha512-i3dmvU0htawfWED8aHMMAzAVp/F0Z+0bPh3YrbTPPL1v4YAlCZpy5rBO5p0LPYiZo0zFVkoYh7vDU7yQSiCMjg==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-sanitize-uri: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-extension-gfm-footnote/1.0.4:
+    resolution: {integrity: sha512-E/fmPmDqLiMUP8mLJ8NbJWJ4bTw6tS+FEQS8CcuDtZpILuOb2kjLqPEeAePF1djXROHXChM/wPJw0iS4kHCcIg==}
+    dependencies:
+      micromark-core-commonmark: 1.0.6
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-normalize-identifier: 1.0.0
+      micromark-util-sanitize-uri: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-extension-gfm-strikethrough/1.0.4:
+    resolution: {integrity: sha512-/vjHU/lalmjZCT5xt7CcHVJGq8sYRm80z24qAKXzaHzem/xsDYb2yLL+NNVbYvmpLx3O7SYPuGL5pzusL9CLIQ==}
+    dependencies:
+      micromark-util-chunked: 1.0.0
+      micromark-util-classify-character: 1.0.0
+      micromark-util-resolve-all: 1.0.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-extension-gfm-table/1.0.5:
+    resolution: {integrity: sha512-xAZ8J1X9W9K3JTJTUL7G6wSKhp2ZYHrFk5qJgY/4B33scJzE2kpfRL6oiw/veJTbt7jiM/1rngLlOKPWr1G+vg==}
+    dependencies:
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-extension-gfm-tagfilter/1.0.1:
+    resolution: {integrity: sha512-Ty6psLAcAjboRa/UKUbbUcwjVAv5plxmpUTy2XC/3nJFL37eHej8jrHrRzkqcpipJliuBH30DTs7+3wqNcQUVA==}
+    dependencies:
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-extension-gfm-task-list-item/1.0.3:
+    resolution: {integrity: sha512-PpysK2S1Q/5VXi72IIapbi/jliaiOFzv7THH4amwXeYXLq3l1uo8/2Be0Ac1rEwK20MQEsGH2ltAZLNY2KI/0Q==}
+    dependencies:
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-extension-gfm/2.0.1:
+    resolution: {integrity: sha512-p2sGjajLa0iYiGQdT0oelahRYtMWvLjy8J9LOCxzIQsllMCGLbsLW+Nc+N4vi02jcRJvedVJ68cjelKIO6bpDA==}
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 1.0.3
+      micromark-extension-gfm-footnote: 1.0.4
+      micromark-extension-gfm-strikethrough: 1.0.4
+      micromark-extension-gfm-table: 1.0.5
+      micromark-extension-gfm-tagfilter: 1.0.1
+      micromark-extension-gfm-task-list-item: 1.0.3
+      micromark-util-combine-extensions: 1.0.0
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-factory-destination/1.0.0:
+    resolution: {integrity: sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-factory-label/1.0.2:
+    resolution: {integrity: sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-factory-space/1.0.0:
+    resolution: {integrity: sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-factory-title/1.0.2:
+    resolution: {integrity: sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==}
+    dependencies:
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-factory-whitespace/1.0.0:
+    resolution: {integrity: sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==}
+    dependencies:
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-util-character/1.1.0:
+    resolution: {integrity: sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==}
+    dependencies:
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-util-chunked/1.0.0:
+    resolution: {integrity: sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==}
+    dependencies:
+      micromark-util-symbol: 1.0.1
+    dev: false
+
+  /micromark-util-classify-character/1.0.0:
+    resolution: {integrity: sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-util-combine-extensions/1.0.0:
+    resolution: {integrity: sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==}
+    dependencies:
+      micromark-util-chunked: 1.0.0
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-util-decode-numeric-character-reference/1.0.0:
+    resolution: {integrity: sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==}
+    dependencies:
+      micromark-util-symbol: 1.0.1
+    dev: false
+
+  /micromark-util-decode-string/1.0.2:
+    resolution: {integrity: sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==}
+    dependencies:
+      decode-named-character-reference: 1.0.2
+      micromark-util-character: 1.1.0
+      micromark-util-decode-numeric-character-reference: 1.0.0
+      micromark-util-symbol: 1.0.1
+    dev: false
+
+  /micromark-util-encode/1.0.1:
+    resolution: {integrity: sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA==}
+    dev: false
+
+  /micromark-util-html-tag-name/1.1.0:
+    resolution: {integrity: sha512-BKlClMmYROy9UiV03SwNmckkjn8QHVaWkqoAqzivabvdGcwNGMMMH/5szAnywmsTBUzDsU57/mFi0sp4BQO6dA==}
+    dev: false
+
+  /micromark-util-normalize-identifier/1.0.0:
+    resolution: {integrity: sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==}
+    dependencies:
+      micromark-util-symbol: 1.0.1
+    dev: false
+
+  /micromark-util-resolve-all/1.0.0:
+    resolution: {integrity: sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==}
+    dependencies:
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-util-sanitize-uri/1.1.0:
+    resolution: {integrity: sha512-RoxtuSCX6sUNtxhbmsEFQfWzs8VN7cTctmBPvYivo98xb/kDEoTCtJQX5wyzIYEmk/lvNFTat4hL8oW0KndFpg==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-encode: 1.0.1
+      micromark-util-symbol: 1.0.1
+    dev: false
+
+  /micromark-util-subtokenize/1.0.2:
+    resolution: {integrity: sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==}
+    dependencies:
+      micromark-util-chunked: 1.0.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-util-symbol/1.0.1:
+    resolution: {integrity: sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==}
+    dev: false
+
+  /micromark-util-types/1.0.2:
+    resolution: {integrity: sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w==}
+    dev: false
+
   /micromark/2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
     dependencies:
@@ -13744,6 +15039,30 @@ packages:
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
+
+  /micromark/3.1.0:
+    resolution: {integrity: sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==}
+    dependencies:
+      '@types/debug': 4.1.7
+      debug: 4.3.4
+      decode-named-character-reference: 1.0.2
+      micromark-core-commonmark: 1.0.6
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-chunked: 1.0.0
+      micromark-util-combine-extensions: 1.0.0
+      micromark-util-decode-numeric-character-reference: 1.0.0
+      micromark-util-encode: 1.0.1
+      micromark-util-normalize-identifier: 1.0.0
+      micromark-util-resolve-all: 1.0.0
+      micromark-util-sanitize-uri: 1.1.0
+      micromark-util-subtokenize: 1.0.2
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /micromatch/4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
@@ -13820,6 +15139,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dev: true
+
+  /mri/1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+    dev: false
 
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -14506,6 +15830,16 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
+  /react-colorful/5.6.1_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    dev: false
+
   /react-datepicker/4.7.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-FS8KgbwqpxmJBv/bUdA42MYqYZa+fEYcpc746DZiHvVE2nhjrW/dg7c5B5fIUuI8gZET6FOzuDgezNcj568Czw==}
     peerDependencies:
@@ -14522,6 +15856,28 @@ packages:
       react-popper: 2.3.0_kz2vxbzpsgxv356x2ucg6oykdm
     dev: false
 
+  /react-datepicker/4.8.0_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-u69zXGHMpxAa4LeYR83vucQoUCJQ6m/WBsSxmUMu/M8ahTSVMMyiyQzauHgZA2NUr9y0FUgOAix71hGYUb6tvg==}
+    peerDependencies:
+      react: ^16.9.0 || ^17 || ^18
+      react-dom: ^16.9.0 || ^17 || ^18
+    dependencies:
+      '@popperjs/core': 2.11.6
+      classnames: 2.3.1
+      date-fns: 2.29.3
+      prop-types: 15.8.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-onclickoutside: 6.12.1_sfoxds7t5ydpegc3knd667wn6m
+      react-popper: 2.3.0_vov5yimr6vvxyufd6uigwwkst4
+    dev: false
+
+  /react-dnd-html5-backend/15.1.2:
+    resolution: {integrity: sha512-mem9QbutUF+aA2YC1y47G3ECjnYV/sCYKSnu5Jd7cbg3fLMPAwbnTf/JayYdnCH5l3eg9akD9dQt+cD0UdF8QQ==}
+    dependencies:
+      dnd-core: 15.1.1
+    dev: false
+
   /react-dnd-html5-backend/15.1.3:
     resolution: {integrity: sha512-HH/8nOEmrrcRGHMqJR91FOwhnLlx5SRLXmsQwZT3IPcBjx88WT+0pWC5A4tDOYDdoooh9k+KMPvWfxooR5TcOA==}
     dependencies:
@@ -14532,53 +15888,6 @@ packages:
     resolution: {integrity: sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==}
     dependencies:
       dnd-core: 16.0.1
-    dev: false
-
-  /react-dnd/15.1.2_pxzommwrsowkd4kgag6q3sluym:
-    resolution: {integrity: sha512-EaSbMD9iFJDY/o48T3c8wn3uWU+2uxfFojhesZN3LhigJoAIvH2iOjxofSA9KbqhAKP6V9P853G6XG8JngKVtA==}
-    peerDependencies:
-      '@types/hoist-non-react-statics': '>= 3.3.1'
-      '@types/node': '>= 12'
-      '@types/react': '>= 16'
-      react: '>= 16.14'
-    peerDependenciesMeta:
-      '@types/hoist-non-react-statics':
-        optional: true
-      '@types/node':
-        optional: true
-      '@types/react':
-        optional: true
-    dependencies:
-      '@react-dnd/invariant': 3.0.1
-      '@react-dnd/shallowequal': 3.0.1
-      '@types/react': 17.0.50
-      dnd-core: 15.1.2
-      fast-deep-equal: 3.1.3
-      hoist-non-react-statics: 3.3.2
-      react: 17.0.2
-    dev: false
-
-  /react-dnd/15.1.2_react@17.0.2:
-    resolution: {integrity: sha512-EaSbMD9iFJDY/o48T3c8wn3uWU+2uxfFojhesZN3LhigJoAIvH2iOjxofSA9KbqhAKP6V9P853G6XG8JngKVtA==}
-    peerDependencies:
-      '@types/hoist-non-react-statics': '>= 3.3.1'
-      '@types/node': '>= 12'
-      '@types/react': '>= 16'
-      react: '>= 16.14'
-    peerDependenciesMeta:
-      '@types/hoist-non-react-statics':
-        optional: true
-      '@types/node':
-        optional: true
-      '@types/react':
-        optional: true
-    dependencies:
-      '@react-dnd/invariant': 3.0.1
-      '@react-dnd/shallowequal': 3.0.1
-      dnd-core: 15.1.2
-      fast-deep-equal: 3.1.3
-      hoist-non-react-statics: 3.3.2
-      react: 17.0.2
     dev: false
 
   /react-dnd/15.1.2_smc5esni47gpbltvxzeziduyte:
@@ -14623,6 +15932,54 @@ packages:
     dependencies:
       '@react-dnd/invariant': 4.0.2
       '@react-dnd/shallowequal': 4.0.2
+      '@types/react': 17.0.50
+      dnd-core: 16.0.1
+      fast-deep-equal: 3.1.3
+      hoist-non-react-statics: 3.3.2
+      react: 17.0.2
+    dev: false
+
+  /react-dnd/16.0.1_react@17.0.2:
+    resolution: {integrity: sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==}
+    peerDependencies:
+      '@types/hoist-non-react-statics': '>= 3.3.1'
+      '@types/node': '>= 12'
+      '@types/react': '>= 16'
+      react: '>= 16.14'
+    peerDependenciesMeta:
+      '@types/hoist-non-react-statics':
+        optional: true
+      '@types/node':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@react-dnd/invariant': 4.0.2
+      '@react-dnd/shallowequal': 4.0.2
+      dnd-core: 16.0.1
+      fast-deep-equal: 3.1.3
+      hoist-non-react-statics: 3.3.2
+      react: 17.0.2
+    dev: false
+
+  /react-dnd/16.0.1_smc5esni47gpbltvxzeziduyte:
+    resolution: {integrity: sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==}
+    peerDependencies:
+      '@types/hoist-non-react-statics': '>= 3.3.1'
+      '@types/node': '>= 12'
+      '@types/react': '>= 16'
+      react: '>= 16.14'
+    peerDependenciesMeta:
+      '@types/hoist-non-react-statics':
+        optional: true
+      '@types/node':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@react-dnd/invariant': 4.0.2
+      '@react-dnd/shallowequal': 4.0.2
+      '@types/node': 18.7.21
       '@types/react': 17.0.50
       dnd-core: 16.0.1
       fast-deep-equal: 3.1.3
@@ -14676,6 +16033,10 @@ packages:
     resolution: {integrity: sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==}
     dev: false
 
+  /react-is/18.2.0:
+    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+    dev: false
+
   /react-onclickoutside/6.12.1_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-a5Q7CkWznBRUWPmocCvE8b6lEYw1s6+opp/60dCunhO+G6E4tDTO2Sd2jKE+leEnnrLAE2Wj5DlDHNqj5wPv1Q==}
     peerDependencies:
@@ -14694,6 +16055,20 @@ packages:
       react-dom: ^16.8.0 || ^17 || ^18
     dependencies:
       '@popperjs/core': 2.11.5
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-fast-compare: 3.2.0
+      warning: 4.0.3
+    dev: false
+
+  /react-popper/2.3.0_vov5yimr6vvxyufd6uigwwkst4:
+    resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
+    peerDependencies:
+      '@popperjs/core': ^2.0.0
+      react: ^16.8.0 || ^17 || ^18
+      react-dom: ^16.8.0 || ^17 || ^18
+    dependencies:
+      '@popperjs/core': 2.11.6
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-fast-compare: 3.2.0
@@ -14741,13 +16116,27 @@ packages:
       - '@types/react'
     dev: false
 
-  /react-textarea-autosize/8.3.4_react@17.0.2:
-    resolution: {integrity: sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==}
+  /react-textarea-autosize/8.4.0_pxzommwrsowkd4kgag6q3sluym:
+    resolution: {integrity: sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==}
     engines: {node: '>=10'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.17.9
+      '@babel/runtime': 7.20.1
+      react: 17.0.2
+      use-composed-ref: 1.3.0_react@17.0.2
+      use-latest: 1.2.1_pxzommwrsowkd4kgag6q3sluym
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
+  /react-textarea-autosize/8.4.0_react@17.0.2:
+    resolution: {integrity: sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.1
       react: 17.0.2
       use-composed-ref: 1.3.0_react@17.0.2
       use-latest: 1.2.1_react@17.0.2
@@ -14919,6 +16308,27 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /remark-gfm/3.0.1:
+    resolution: {integrity: sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      mdast-util-gfm: 2.0.1
+      micromark-extension-gfm: 2.0.1
+      unified: 10.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /remark-parse/10.0.1:
+    resolution: {integrity: sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      mdast-util-from-markdown: 1.2.0
+      unified: 10.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /remark-parse/9.0.0:
     resolution: {integrity: sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==}
     dependencies:
@@ -15044,6 +16454,13 @@ packages:
     dependencies:
       tslib: 2.4.0
     dev: true
+
+  /sade/1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+    dependencies:
+      mri: 1.2.0
+    dev: false
 
   /safe-buffer/5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -15475,6 +16892,30 @@ packages:
       supports-color: 5.5.0
     dev: false
 
+  /styled-components/5.3.6_v5ja746gkdtknuc6tj46sve3be:
+    resolution: {integrity: sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    peerDependencies:
+      react: '>= 16.8.0'
+      react-dom: '>= 16.8.0'
+      react-is: '>= 16.8.0'
+    dependencies:
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/traverse': 7.20.1_supports-color@5.5.0
+      '@emotion/is-prop-valid': 1.1.2
+      '@emotion/stylis': 0.8.5
+      '@emotion/unitless': 0.7.5
+      babel-plugin-styled-components: 2.0.7_styled-components@5.3.6
+      css-to-react-native: 3.0.0
+      hoist-non-react-statics: 3.3.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-is: 18.2.0
+      shallowequal: 1.1.0
+      supports-color: 5.5.0
+    dev: false
+
   /stylis/4.1.1:
     resolution: {integrity: sha512-lVrM/bNdhVX2OgBFNa2YJ9Lxj7kPzylieHd3TNjuGE0Re9JB7joL5VUKOVH1kdNNJTgGPpT8hmwIAPLaSyEVFQ==}
     dev: false
@@ -15751,6 +17192,10 @@ packages:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
     dev: false
 
+  /trough/2.1.0:
+    resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
+    dev: false
+
   /ts-dedent/2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -15882,6 +17327,18 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
+  /unified/10.1.2:
+    resolution: {integrity: sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==}
+    dependencies:
+      '@types/unist': 2.0.6
+      bail: 2.0.2
+      extend: 3.0.2
+      is-buffer: 2.0.5
+      is-plain-obj: 4.1.0
+      trough: 2.1.0
+      vfile: 5.3.6
+    dev: false
+
   /unified/9.2.2:
     resolution: {integrity: sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==}
     dependencies:
@@ -15894,10 +17351,35 @@ packages:
       vfile: 4.2.1
     dev: false
 
+  /unist-util-is/5.1.1:
+    resolution: {integrity: sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==}
+    dev: false
+
   /unist-util-stringify-position/2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
     dependencies:
       '@types/unist': 2.0.6
+
+  /unist-util-stringify-position/3.0.2:
+    resolution: {integrity: sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==}
+    dependencies:
+      '@types/unist': 2.0.6
+    dev: false
+
+  /unist-util-visit-parents/5.1.1:
+    resolution: {integrity: sha512-gks4baapT/kNRaWxuGkl5BIhoanZo7sC/cUT/JToSRNL1dYoXRFl75d++NkjYk4TAu2uv2Px+l8guMajogeuiw==}
+    dependencies:
+      '@types/unist': 2.0.6
+      unist-util-is: 5.1.1
+    dev: false
+
+  /unist-util-visit/4.1.1:
+    resolution: {integrity: sha512-n9KN3WV9k4h1DxYR1LoajgN93wpEi/7ZplVe02IoB4gH5ctI1AaF2670BLHQYbwj+pY83gFtyeySFiyMHJklrg==}
+    dependencies:
+      '@types/unist': 2.0.6
+      unist-util-is: 5.1.1
+      unist-util-visit-parents: 5.1.1
+    dev: false
 
   /universalify/0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -16053,6 +17535,17 @@ packages:
     hasBin: true
     dev: true
 
+  /uvu/0.5.6:
+    resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      dequal: 2.0.3
+      diff: 5.0.0
+      kleur: 4.1.5
+      sade: 1.8.1
+    dev: false
+
   /v8-compile-cache-lib/3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
@@ -16088,6 +17581,13 @@ packages:
       unist-util-stringify-position: 2.0.3
     dev: false
 
+  /vfile-message/3.1.3:
+    resolution: {integrity: sha512-0yaU+rj2gKAyEk12ffdSbBfjnnj+b1zqTBv3OQCTn8yEB02bsPizwdBPrLJjHnK+cU9EMMcUnNv938XcZIkmdA==}
+    dependencies:
+      '@types/unist': 2.0.6
+      unist-util-stringify-position: 3.0.2
+    dev: false
+
   /vfile/4.2.1:
     resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==}
     dependencies:
@@ -16095,6 +17595,15 @@ packages:
       is-buffer: 2.0.5
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
+    dev: false
+
+  /vfile/5.3.6:
+    resolution: {integrity: sha512-ADBsmerdGBs2WYckrLBEmuETSPyTD4TuLxTrw0DvjirxW1ra4ZwkbzG8ndsv3Q57smvHxo677MHaQrY9yxH8cA==}
+    dependencies:
+      '@types/unist': 2.0.6
+      is-buffer: 2.0.5
+      unist-util-stringify-position: 3.0.2
+      vfile-message: 3.1.3
     dev: false
 
   /vite-plugin-dts/1.7.0_vite@3.2.3:
@@ -16375,6 +17884,10 @@ packages:
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  /xstate/4.28.1:
+    resolution: {integrity: sha512-0xvaegeZNeHJAJvpjznyNr91qB1xy1PqeYMDyknh5S23TBPQJUHS81hk8W3UcvnB9uNs0YmOU2daoqb3WegzYQ==}
+    dev: false
+
   /xstate/4.32.0:
     resolution: {integrity: sha512-62gETqwnw4pBRe+tVWMt8hLgWEU8lq2qO8VN5PWmTELceRVt3I1bu1cwdraVRHUn4Bb2lnhNzn1A73oShuC+8g==}
     dev: false
@@ -16471,4 +17984,8 @@ packages:
         optional: true
     dependencies:
       react: 17.0.2
+    dev: false
+
+  /zwitch/2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
       '@4tw/cypress-drag-drop': 2.2.1
       '@babel/core': 7.20.2
       '@cypress/vite-dev-server': 4.0.1
-      '@frontify/fondue': 12.0.0-beta.11
+      '@frontify/fondue': 12.0.0-beta.24
       '@testing-library/react-hooks': 8.0.1
       '@types/node': 18.7.21
       '@types/react': 17.0.50
@@ -27,7 +27,7 @@ importers:
       vite: 3.2.3
       vitest: 0.25.0
     dependencies:
-      '@frontify/fondue': 12.0.0-beta.11_rv2t7de65xq26o5frb4lun64yi
+      '@frontify/fondue': 12.0.0-beta.24_rv2t7de65xq26o5frb4lun64yi
       glob: 8.0.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -1695,13 +1695,6 @@ packages:
       - '@types/react'
     dev: false
 
-  /@formatjs/ecma402-abstract/1.11.4:
-    resolution: {integrity: sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==}
-    dependencies:
-      '@formatjs/intl-localematcher': 0.2.25
-      tslib: 2.4.0
-    dev: false
-
   /@formatjs/ecma402-abstract/1.13.0:
     resolution: {integrity: sha512-CQ8Ykd51jYD1n05dtoX6ns6B9n/+6ZAxnWUAonvHC4kkuAemROYBhHkEB4tm1uVrRlE7gLDqXkAnY51Y0pRCWQ==}
     dependencies:
@@ -1709,23 +1702,9 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /@formatjs/fast-memoize/1.2.1:
-    resolution: {integrity: sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==}
-    dependencies:
-      tslib: 2.4.0
-    dev: false
-
   /@formatjs/fast-memoize/1.2.6:
     resolution: {integrity: sha512-9CWZ3+wCkClKHX+i5j+NyoBVqGf0pIskTo6Xl6ihGokYM2yqSSS68JIgeo+99UIHc+7vi9L3/SDSz/dWI9SNlA==}
     dependencies:
-      tslib: 2.4.0
-    dev: false
-
-  /@formatjs/icu-messageformat-parser/2.1.0:
-    resolution: {integrity: sha512-Qxv/lmCN6hKpBSss2uQ8IROVnta2r9jd3ymUEIjm2UyIkUCHVcbUVRGL/KS/wv7876edvsPe+hjHVJ4z8YuVaw==}
-    dependencies:
-      '@formatjs/ecma402-abstract': 1.11.4
-      '@formatjs/icu-skeleton-parser': 1.3.6
       tslib: 2.4.0
     dev: false
 
@@ -1741,19 +1720,6 @@ packages:
     resolution: {integrity: sha512-7bv60HQQcBb3+TSj+45tOb/CHV5z1hOpwdtS50jsSBXfB+YpGhnoRsZxSRksXeCxMy6xn6tA6VY2601BrrK+OA==}
     dependencies:
       '@formatjs/ecma402-abstract': 1.13.0
-      tslib: 2.4.0
-    dev: false
-
-  /@formatjs/icu-skeleton-parser/1.3.6:
-    resolution: {integrity: sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==}
-    dependencies:
-      '@formatjs/ecma402-abstract': 1.11.4
-      tslib: 2.4.0
-    dev: false
-
-  /@formatjs/intl-localematcher/0.2.25:
-    resolution: {integrity: sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==}
-    dependencies:
       tslib: 2.4.0
     dev: false
 
@@ -1860,16 +1826,6 @@ packages:
       - ts-node
     dev: false
 
-  /@frontify/fondue-tokens/3.1.0_ts-node@10.9.1:
-    resolution: {integrity: sha512-/Dc8fPFtMbIjRBSPHi4oX7jLixbY8WR0k/Zp/NLZ+XSoXOZES2fD4RfEzqGm5d9FihetVqoHvlw9rDJWQRj7xg==}
-    dependencies:
-      postcss: 8.4.19
-      scheduler: 0.20.2
-      tailwindcss: 3.2.3_v776zzvn44o7tpgzieipaairwm
-    transitivePeerDependencies:
-      - ts-node
-    dev: false
-
   /@frontify/fondue-tokens/3.2.0:
     resolution: {integrity: sha512-GR2neBdz4bKlqxN+WdBWYHLpJRP+ERGonP97jdekeS/Rxgji6u6ddP4Gwgeu8vZQOorOX9c8bD6IBgKeGg4GCw==}
     dependencies:
@@ -1886,87 +1842,6 @@ packages:
       tailwindcss: 3.2.3_v776zzvn44o7tpgzieipaairwm
     transitivePeerDependencies:
       - ts-node
-    dev: false
-
-  /@frontify/fondue/12.0.0-beta.11_rv2t7de65xq26o5frb4lun64yi:
-    resolution: {integrity: sha512-7cXqfCSfUKMB+pFsJVTVhiilHDSkUXSFLfFpxlyEHae2dh7Na1PreIjgUF4anixeEpLwHJzrKqukr1vvp6otUw==}
-    peerDependencies:
-      react: ^17.0.2
-      react-dom: ^17.0.2
-    dependencies:
-      '@frontify/fondue-tokens': 3.1.0_ts-node@10.9.1
-      '@popperjs/core': 2.11.5
-      '@react-aria/accordion': 3.0.0-alpha.9_react@17.0.2
-      '@react-aria/aria-modal-polyfill': 3.4.4_react@17.0.2
-      '@react-aria/breadcrumbs': 3.1.10_react@17.0.2
-      '@react-aria/button': 3.5.1_react@17.0.2
-      '@react-aria/checkbox': 3.5.1_react@17.0.2
-      '@react-aria/combobox': 3.2.6_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/dialog': 3.1.9_react@17.0.2
-      '@react-aria/focus': 3.8.0_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/link': 3.2.5_react@17.0.2
-      '@react-aria/listbox': 3.4.5_react@17.0.2
-      '@react-aria/menu': 3.4.4_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/overlays': 3.8.2_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/radio': 3.1.11_react@17.0.2
-      '@react-aria/select': 3.6.5_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/selection': 3.9.1_react@17.0.2
-      '@react-aria/table': 3.2.4_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/tooltip': 3.1.8_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-aria/visually-hidden': 3.2.8_react@17.0.2
-      '@react-stately/checkbox': 3.2.1_react@17.0.2
-      '@react-stately/collections': 3.4.2_react@17.0.2
-      '@react-stately/combobox': 3.2.0_react@17.0.2
-      '@react-stately/list': 3.5.2_react@17.0.2
-      '@react-stately/menu': 3.4.0_react@17.0.2
-      '@react-stately/overlays': 3.4.0_react@17.0.2
-      '@react-stately/radio': 3.5.0_react@17.0.2
-      '@react-stately/select': 3.3.0_react@17.0.2
-      '@react-stately/table': 3.3.0_react@17.0.2
-      '@react-stately/toggle': 3.4.1_react@17.0.2
-      '@react-stately/tooltip': 3.2.0_react@17.0.2
-      '@react-stately/tree': 3.3.1_react@17.0.2
-      '@storybook/addon-a11y': 6.5.9_sfoxds7t5ydpegc3knd667wn6m
-      '@udecode/plate': 16.9.1_3applnbcmonz6yjsxb2hv5truu
-      '@xstate/immer': 0.3.1_immer@9.0.12+xstate@4.32.0
-      '@xstate/react': 1.6.3_3u7fm7vqjqg5ddhec34i275fya
-      date-fns: 2.28.0
-      framer-motion: 6.5.1_sfoxds7t5ydpegc3knd667wn6m
-      immer: 9.0.12
-      react: 17.0.2
-      react-colorful: 5.5.1_sfoxds7t5ydpegc3knd667wn6m
-      react-datepicker: 4.7.0_sfoxds7t5ydpegc3knd667wn6m
-      react-dnd: 15.1.2_smc5esni47gpbltvxzeziduyte
-      react-dnd-html5-backend: 15.1.3
-      react-dom: 17.0.2_react@17.0.2
-      react-is: 18.1.0
-      react-popper: 2.3.0_kz2vxbzpsgxv356x2ucg6oykdm
-      react-textarea-autosize: 8.3.4_pxzommwrsowkd4kgag6q3sluym
-      scheduler: 0.20.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-hyperscript: 0.77.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-      tinycolor2: 1.4.2
-      xstate: 4.32.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/hoist-non-react-statics'
-      - '@types/node'
-      - '@types/react'
-      - '@urql/core'
-      - '@xstate/fsm'
-      - optics-ts
-      - react-native
-      - supports-color
-      - ts-node
-      - valtio
-      - wonka
     dev: false
 
   /@frontify/fondue/12.0.0-beta.24_angvksxlvvfhyjj3xhcshgfg2m:
@@ -2267,23 +2142,10 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
-  /@internationalized/date/3.0.0:
-    resolution: {integrity: sha512-mvlQCeYNg7JgO+QtIIx1zFJx10CJNVnt8cOjW2pYab1Ap/c7BYybS37Z5oTCdmRZbvnpmWtjhOEH324zlgWHLw==}
-    dependencies:
-      '@babel/runtime': 7.20.1
-    dev: false
-
   /@internationalized/date/3.0.1:
     resolution: {integrity: sha512-E/3lASs4mAeJ2Z2ye6ab7eUD0bPUfTeNVTAv6IS+ne9UtMu9Uepb9A1U2Ae0hDr6WAlBuvUtrakaxEdYB9TV6Q==}
     dependencies:
       '@babel/runtime': 7.20.1
-    dev: false
-
-  /@internationalized/message/3.0.8:
-    resolution: {integrity: sha512-5B9zvBgyPZi0ciPgisW835WTuvjVIWFf4IJex1Swb5mDwonbi0lO2teAjBVGV25NTI0OKq1GM9PAWXXUzv6Waw==}
-    dependencies:
-      '@babel/runtime': 7.20.1
-      intl-messageformat: 9.13.0
     dev: false
 
   /@internationalized/message/3.0.9:
@@ -2580,21 +2442,8 @@ packages:
     resolution: {integrity: sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==}
     dev: true
 
-  /@popperjs/core/2.11.5:
-    resolution: {integrity: sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==}
-    dev: false
-
   /@popperjs/core/2.11.6:
     resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
-    dev: false
-
-  /@radix-ui/react-compose-refs/0.1.0_react@17.0.2:
-    resolution: {integrity: sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==}
-    peerDependencies:
-      react: ^16.8 || ^17.0
-    dependencies:
-      '@babel/runtime': 7.17.9
-      react: 17.0.2
     dev: false
 
   /@radix-ui/react-compose-refs/1.0.0_react@17.0.2:
@@ -2603,16 +2452,6 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.20.1
-      react: 17.0.2
-    dev: false
-
-  /@radix-ui/react-slot/0.1.2_react@17.0.2:
-    resolution: {integrity: sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==}
-    peerDependencies:
-      react: ^16.8 || ^17.0
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@radix-ui/react-compose-refs': 0.1.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -2643,17 +2482,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-aria/aria-modal-polyfill/3.4.4_react@17.0.2:
-    resolution: {integrity: sha512-M4gUmyuf8RP+i+k0l1TRYqeAAXtnqdDw9KfJrQCdgyjRFD/QQpA/+5CGu7JrnSP5W/7m3xOv4qpHR+zGxLPB8Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-types/shared': 3.14.1_react@17.0.2
-      aria-hidden: 1.1.3
-      react: 17.0.2
-    dev: false
-
   /@react-aria/aria-modal-polyfill/3.6.0_react@17.0.2:
     resolution: {integrity: sha512-coWVSX/esVk2z8f8aXbaT4HzIjv6V7tYy+3gbOTACkI96QtXbtzWawq2gNpssNnT6zEh/4Ox2iwKYQEU6xSdEQ==}
     peerDependencies:
@@ -2677,20 +2505,6 @@ packages:
       '@react-aria/utils': 3.14.1_react@17.0.2
       '@react-types/breadcrumbs': 3.3.0_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
-      react: 17.0.2
-    dev: false
-
-  /@react-aria/button/3.5.1_react@17.0.2:
-    resolution: {integrity: sha512-M0AaDeJoM4wu2xkv1FvbhuvWB78yF8yNE91KkyEW+TMBiEjSaij61jyov95m08DT2EXSxuXnch3BoP8s3XHj4g==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/focus': 3.8.0_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-stately/toggle': 3.4.1_react@17.0.2
-      '@react-types/button': 3.5.1_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -2741,32 +2555,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-aria/combobox/3.2.6_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-/I+YmuLWKq7SNP9eYXaOg5mCNsLJcXCTXas3w5ZsPDTPb9rpVes6nmsz+otBYlb5sTxvGS/sD0036vlI+O0cdg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/i18n': 3.4.1_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/listbox': 3.4.5_react@17.0.2
-      '@react-aria/live-announcer': 3.0.6_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/menu': 3.4.4_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/overlays': 3.8.2_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/selection': 3.9.1_react@17.0.2
-      '@react-aria/textfield': 3.5.5_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-stately/collections': 3.4.2_react@17.0.2
-      '@react-stately/combobox': 3.2.0_react@17.0.2
-      '@react-stately/layout': 3.4.5_react@17.0.2
-      '@react-types/button': 3.5.1_react@17.0.2
-      '@react-types/combobox': 3.5.2_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-    dev: false
-
   /@react-aria/combobox/3.4.2_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-LFB0L2WLR7hc5J2c36jdgekHigLv4PwZfNRlh+B4VX474pS9Zt33F0FIrCKsYZA8xXzvM+lXr4POjwsoBhmnJw==}
     peerDependencies:
@@ -2791,19 +2579,6 @@ packages:
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-    dev: false
-
-  /@react-aria/dialog/3.1.9_react@17.0.2:
-    resolution: {integrity: sha512-S/HE6XxBU9AiL4TGBjmz4CAEXjCD9nwvV5ofBKlbfPzgimmmSJj3SVNtsawKIt3KyP9AEioyJydM/vbGfccJlw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/focus': 3.8.0_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-stately/overlays': 3.4.0_react@17.0.2
-      '@react-types/dialog': 3.3.5_react@17.0.2
-      react: 17.0.2
     dev: false
 
   /@react-aria/dialog/3.4.0_sfoxds7t5ydpegc3knd667wn6m:
@@ -2862,29 +2637,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-aria/grid/3.2.6_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-hNQHJkedMMAj+XmqbFW97Nybe5nEh+mRWB5SD7yuIvBLOFxnWid2BUF6zRA6nkZpfsPPTY1YHefgCGzQTFxbNQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/focus': 3.8.0_react@17.0.2
-      '@react-aria/i18n': 3.4.1_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/live-announcer': 3.0.6_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/selection': 3.9.1_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-stately/grid': 3.3.0_react@17.0.2
-      '@react-stately/selection': 3.10.2_react@17.0.2
-      '@react-stately/virtualizer': 3.1.9_react@17.0.2
-      '@react-types/checkbox': 3.3.3_react@17.0.2
-      '@react-types/grid': 3.1.2_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-    dev: false
-
   /@react-aria/grid/3.5.1_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-eWwhG9wHb6l6poZSvnhoSSCpNy1kG3HxIpcbMaR2/qllbUYgZ4PASyx4N2TT/VqBUsxCSwC/WqcDka11U9d94w==}
     peerDependencies:
@@ -2906,21 +2658,6 @@ packages:
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-    dev: false
-
-  /@react-aria/i18n/3.4.1_react@17.0.2:
-    resolution: {integrity: sha512-/nrMpWOFmbn9R04JfWgGFRJ/oYBZLIydLBuWVw3ugwyKrHhIj/xRFrAMcGKspEZIymIANv9cnoTYhwk8d/DCEg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.20.1
-      '@internationalized/date': 3.0.0
-      '@internationalized/message': 3.0.8
-      '@internationalized/number': 3.1.1
-      '@react-aria/ssr': 3.3.0_react@17.0.2
-      '@react-aria/utils': 3.14.0_react@17.0.2
-      '@react-types/shared': 3.16.0_react@17.0.2
-      react: 17.0.2
     dev: false
 
   /@react-aria/i18n/3.6.2_react@17.0.2:
@@ -3007,20 +2744,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-aria/link/3.2.5_react@17.0.2:
-    resolution: {integrity: sha512-2RfQlZUmTzyHdjv1i7H5bxA4C5cTQonvDNFMzR2AycbN+AudAX8NXNOwPJkNxdxApUJX4EiQ84sGI354yEpa/w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/focus': 3.8.0_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-types/link': 3.2.5_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-aria/link/3.3.4_react@17.0.2:
     resolution: {integrity: sha512-Op0usCd5SAg5OHkCl1+TYbsvT/wWhqadd/3Pi0VD0kKmaSy4GhUNJkTo8n0hS2k3vIq+qRq7zwnON2h5eLVkHA==}
     peerDependencies:
@@ -3032,24 +2755,6 @@ packages:
       '@react-aria/utils': 3.14.1_react@17.0.2
       '@react-types/link': 3.3.5_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
-      react: 17.0.2
-    dev: false
-
-  /@react-aria/listbox/3.4.5_react@17.0.2:
-    resolution: {integrity: sha512-D1Y6fr4ZMGho1EO2eq+uhXs98Iqz78EXbcqIcuNEwyLyQ8w87jl5uGR/0Fhy9/t6qjkTlJ5iyFIJu8CNTXuSJA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/focus': 3.8.0_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/label': 3.4.1_react@17.0.2
-      '@react-aria/selection': 3.9.1_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-stately/collections': 3.4.2_react@17.0.2
-      '@react-stately/list': 3.5.2_react@17.0.2
-      '@react-types/listbox': 3.2.5_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3071,45 +2776,10 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-aria/live-announcer/3.0.6_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-dXd5knYAFQPNr4ApxGwHXIDBuO50d9koat1ViFI22yS1QJF3y1dcIkBHfiAWIUtGr8AbRbWDZZnHtKrfPl25Zg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-aria/visually-hidden': 3.2.8_react@17.0.2
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-    dev: false
-
   /@react-aria/live-announcer/3.1.1:
     resolution: {integrity: sha512-e7b+dRh1SUTla42vzjdbhGYkeLD7E6wIYjYaHW9zZ37rBkSqLHUhTigh3eT3k5NxFlDD/uRxTYuwaFnWQgR+4g==}
     dependencies:
       '@babel/runtime': 7.20.1
-    dev: false
-
-  /@react-aria/menu/3.4.4_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-PoeadoSKv4mgx+05KLiRfupu30Pku7nzuL3e+3FAaWi5KyX8siiX6ADMZp8ulnYXoQgQ4C7XzulbwiSE1P/nxg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/i18n': 3.4.1_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/overlays': 3.8.2_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/selection': 3.9.1_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-stately/collections': 3.4.2_react@17.0.2
-      '@react-stately/menu': 3.4.0_react@17.0.2
-      '@react-stately/tree': 3.3.1_react@17.0.2
-      '@react-types/button': 3.5.1_react@17.0.2
-      '@react-types/menu': 3.7.0_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
     dev: false
 
   /@react-aria/menu/3.6.2_sfoxds7t5ydpegc3knd667wn6m:
@@ -3175,42 +2845,6 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@react-aria/overlays/3.8.2_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-HeOkYUILH4CrMVv3HkTrcK1jeZ2NJ7tS39tTciEGZ9JO1d8nUJ5jzDGGiQ587T9YWc1EYxiA+fbnn5Krxyq8IQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/i18n': 3.4.1_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-aria/visually-hidden': 3.2.8_react@17.0.2
-      '@react-stately/overlays': 3.4.0_react@17.0.2
-      '@react-types/button': 3.5.1_react@17.0.2
-      '@react-types/overlays': 3.6.2_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      dom-helpers: 3.4.0
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-    dev: false
-
-  /@react-aria/radio/3.1.11_react@17.0.2:
-    resolution: {integrity: sha512-xT7FgxECPgGHFDCiMu9QZlRJheesjy13N5KwIfCwKt+Tl8ZDacZ8jxswPrDpTfdwdQaA0TCiHWcmfWkAs790Yw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/focus': 3.8.0_react@17.0.2
-      '@react-aria/i18n': 3.4.1_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/label': 3.4.1_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-stately/radio': 3.5.0_react@17.0.2
-      '@react-types/radio': 3.2.2_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-aria/radio/3.4.0_react@17.0.2:
     resolution: {integrity: sha512-DUccHQxfI0PikXXQKarh/hLS/G+ZzfdQ00/sd57jzWsuRyukb+WywQhud29p5uO3wT33/MH9LZgSmb9dlvfabQ==}
     peerDependencies:
@@ -3226,29 +2860,6 @@ packages:
       '@react-types/radio': 3.3.1_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
-    dev: false
-
-  /@react-aria/select/3.6.5_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-RIIRGN7vNHIx2Nf43V9UKFLtUKwthIog5akCxQfz1ivIwQ3Pgy+4bs1d7KhFPg8aM7G2w1lGQfv4vMgWwWBjmg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/i18n': 3.4.1_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/label': 3.4.1_react@17.0.2
-      '@react-aria/listbox': 3.4.5_react@17.0.2
-      '@react-aria/menu': 3.4.4_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/selection': 3.9.1_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-aria/visually-hidden': 3.2.8_react@17.0.2
-      '@react-stately/select': 3.3.0_react@17.0.2
-      '@react-types/button': 3.5.1_react@17.0.2
-      '@react-types/select': 3.6.2_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
     dev: false
 
   /@react-aria/select/3.8.2_sfoxds7t5ydpegc3knd667wn6m:
@@ -3306,22 +2917,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-aria/selection/3.9.1_react@17.0.2:
-    resolution: {integrity: sha512-xUjhiVu5HLAxun9crpBLjfXfJc75oMgzKoCwRTCZinPvTdLLqYVFy6U/lTmQzkulIHLyUaJ94EE8IsfSUUzfLw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/focus': 3.8.0_react@17.0.2
-      '@react-aria/i18n': 3.4.1_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-stately/collections': 3.4.2_react@17.0.2
-      '@react-stately/selection': 3.10.2_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-aria/ssr/3.3.0_react@17.0.2:
     resolution: {integrity: sha512-yNqUDuOVZIUGP81R87BJVi/ZUZp/nYOBXbPsRe7oltJOfErQZD+UezMpw4vM2KRz18cURffvmC8tJ6JTeyDtaQ==}
     peerDependencies:
@@ -3338,30 +2933,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.1
       react: 17.0.2
-    dev: false
-
-  /@react-aria/table/3.2.4_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-2t/EGyNAYsU841ZPLYUkwN+tdXztccgllUJ9qL5a0RJm7DYKKFHHsAYWmnV5ONj/tXqNZQfoqJSzsL6wpTXOZw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/focus': 3.8.0_react@17.0.2
-      '@react-aria/grid': 3.2.6_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/i18n': 3.4.1_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/live-announcer': 3.0.6_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/selection': 3.9.1_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-stately/table': 3.3.0_react@17.0.2
-      '@react-stately/virtualizer': 3.1.9_react@17.0.2
-      '@react-types/checkbox': 3.3.3_react@17.0.2
-      '@react-types/grid': 3.1.2_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      '@react-types/table': 3.3.0_react@17.0.2
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
     dev: false
 
   /@react-aria/table/3.5.0_sfoxds7t5ydpegc3knd667wn6m:
@@ -3386,20 +2957,6 @@ packages:
       '@react-types/table': 3.3.3_react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-    dev: false
-
-  /@react-aria/textfield/3.5.5_react@17.0.2:
-    resolution: {integrity: sha512-ZbGbdObR9cXPXfOr5Ius//nO5Y9yZ+pOT8ymTQTb/X8hLZdfpHqDD9SOjxlTt047ByWfIL0cRlOoEh3MHwvNFg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/focus': 3.8.0_react@17.0.2
-      '@react-aria/label': 3.4.1_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      '@react-types/textfield': 3.4.0_react@17.0.2
-      react: 17.0.2
     dev: false
 
   /@react-aria/textfield/3.8.0_react@17.0.2:
@@ -3445,21 +3002,6 @@ packages:
       '@react-types/checkbox': 3.4.1_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       '@react-types/switch': 3.2.5_react@17.0.2
-      react: 17.0.2
-    dev: false
-
-  /@react-aria/tooltip/3.1.8_react@17.0.2:
-    resolution: {integrity: sha512-f61VVQU1je0wqQpTrfPl+aXAi54XPpe5lTIsxBY9qovzi0BBCAt3b5KofpudxcAqGQnZssXrRnG1IQbATIuUQQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/focus': 3.8.0_react@17.0.2
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-stately/tooltip': 3.2.0_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      '@react-types/tooltip': 3.2.2_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3530,18 +3072,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-aria/visually-hidden/3.2.8_react@17.0.2:
-    resolution: {integrity: sha512-SLBID66sUZrCdxaxLhgxypF/UyGuFVFGc+VhqmFi9QacDfAQcoT3DQyXEaKUIDMVtwAtSuWl7BpuooEctKBe6Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      clsx: 1.1.1
-      react: 17.0.2
-    dev: false
-
   /@react-aria/visually-hidden/3.5.0_react@17.0.2:
     resolution: {integrity: sha512-tF/kCZCGv1yebwgH21cKbhjSV5CmB5/SAHOUM5YkO5V/lIFjaPtywcamIPI8F0JSfrwGF/Z9EqvqBxvIYGRlCA==}
     peerDependencies:
@@ -3572,10 +3102,6 @@ packages:
     resolution: {integrity: sha512-0XhqJSc6pPoNnf8DhdsPHtUhRzZALVzYMTzRwV4VI6DJNJ/5xxfL9OQUwb8IH5/2x7lSf7nAZrnzUD+16VyOVQ==}
     dev: false
 
-  /@react-dnd/asap/4.0.1:
-    resolution: {integrity: sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==}
-    dev: false
-
   /@react-dnd/asap/5.0.2:
     resolution: {integrity: sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==}
     dev: false
@@ -3584,16 +3110,8 @@ packages:
     resolution: {integrity: sha512-keberJRIqPX15IK3SWS/iO1t/kGETiL1oczKrDitAaMnQ+kpHf81l3MrRmFjvfqcnApE+izEvwM6GsyoIcpsVA==}
     dev: false
 
-  /@react-dnd/invariant/3.0.1:
-    resolution: {integrity: sha512-blqduwV86oiKw2Gr44wbe3pj3Z/OsXirc7ybCv9F/pLAR+Aih8F3rjeJzK0ANgtYKv5lCpkGVoZAeKitKDaD/g==}
-    dev: false
-
   /@react-dnd/invariant/4.0.2:
     resolution: {integrity: sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==}
-    dev: false
-
-  /@react-dnd/shallowequal/3.0.1:
-    resolution: {integrity: sha512-XjDVbs3ZU16CO1h5Q3Ew2RPJqmZBDE/EVf1LYp6ePEffs3V/MX9ZbL5bJr8qiK5SbGmUMuDoaFgyKacYz8prRA==}
     dev: false
 
   /@react-dnd/shallowequal/4.0.2:
@@ -3633,16 +3151,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-stately/collections/3.4.2_react@17.0.2:
-    resolution: {integrity: sha512-CmLVWtbX4r3QaTNdI6edtrRKIZRKPuxyD7TmVIaoZBdaOXStTP4wOgyPN1ELww9bvW0MoOaQBbUn5WAPrfifFw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-stately/collections/3.4.4_react@17.0.2:
     resolution: {integrity: sha512-gryUYCe6uzqE0ea5frTwOxOPpx/6Z42PRk7KetOh3ddN3Ts0j8XQP08jP1IB/7BC1QidrkHWvDCqGHxRiEjiIg==}
     peerDependencies:
@@ -3663,21 +3171,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-stately/combobox/3.2.0_react@17.0.2:
-    resolution: {integrity: sha512-77TOvsqBk5xBKc19PIAsi/w7T0lKXMxsOvSfWlOG/StF14d5TJUuhk7CJWCzSgAl3LVhuAKKq5AeZMKAfIrB3w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-stately/list': 3.5.2_react@17.0.2
-      '@react-stately/menu': 3.4.0_react@17.0.2
-      '@react-stately/select': 3.3.0_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
-      '@react-types/combobox': 3.5.2_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-stately/combobox/3.2.2_react@17.0.2:
     resolution: {integrity: sha512-kUMxgXskrtwdeEExZkJ9CjF4EJANetj+7970cOevCpy6ePCdrvdgO6+0cMrVvSgZeMaMDZXDIbbF7fqA6w0uXQ==}
     peerDependencies:
@@ -3693,18 +3186,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-stately/grid/3.3.0_react@17.0.2:
-    resolution: {integrity: sha512-30z4Kki5QWZvR22f3UrA18eMDOcXmQFzAq5pHbRs1LvxJAaqeAD2KzCT70MCgoA5XzyiOrvIPrKTBRf48du45w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-stately/selection': 3.10.2_react@17.0.2
-      '@react-types/grid': 3.1.2_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-stately/grid/3.4.1_react@17.0.2:
     resolution: {integrity: sha512-IRaqXUQGji87Q+pYYQKJYTuUtgAjoDQaMOlvpvB9HlyK5faXq0H1tJsYAeVYpH0synfzCnr7CN0J6kSTbeL1jA==}
     peerDependencies:
@@ -3714,19 +3195,6 @@ packages:
       '@react-stately/selection': 3.11.1_react@17.0.2
       '@react-types/grid': 3.1.5_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
-      react: 17.0.2
-    dev: false
-
-  /@react-stately/layout/3.4.5_react@17.0.2:
-    resolution: {integrity: sha512-+u7LVvX5bAUYI49oGV5TOvRA4mpEh6PlDIXluO0l3/WAq9EpT7XJYqt5qxIyfSF5O5VSFvcCcV3HMuqmqY/oVA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-stately/virtualizer': 3.1.9_react@17.0.2
-      '@react-types/grid': 3.1.2_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      '@react-types/table': 3.3.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3743,19 +3211,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-stately/list/3.5.2_react@17.0.2:
-    resolution: {integrity: sha512-Jv8xzO5oanEMAblLiUUr7uwkMTd5qyczyjxJrv8O52Lwd4GwzJ1w7KggTSZ7JG99fLZozLor3p0foVVvSI1/NA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-stately/collections': 3.4.2_react@17.0.2
-      '@react-stately/selection': 3.10.2_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-stately/list/3.5.4_react@17.0.2:
     resolution: {integrity: sha512-AB0r2RevKVAP2AOQM1JRuCVjS2UUxMJFshA53t8pV+OSVWeyirYccsMR49mWwU60ZnxYqBWVMN+Pl7NTPTnT8w==}
     peerDependencies:
@@ -3769,19 +3224,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-stately/menu/3.4.0_react@17.0.2:
-    resolution: {integrity: sha512-xdNS3K0PmSjpNhH/Xnskfexxyo909Jkkfux4zhP5Ivk4Vkp0eThb6v9AIomUAo163PuOnHQFen1ZmwFEs92xMw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-stately/overlays': 3.4.0_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
-      '@react-types/menu': 3.7.0_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-stately/menu/3.4.2_react@17.0.2:
     resolution: {integrity: sha512-vFC8EloVEcqf6sgiP6ABIkC41ytjoJiGtj7Ws5OS7PvZNyxxDgJr4V0O3Pxd1T0AjlHCloBbojnvoTRwZiSr/A==}
     peerDependencies:
@@ -3792,17 +3234,6 @@ packages:
       '@react-stately/utils': 3.5.1_react@17.0.2
       '@react-types/menu': 3.7.3_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
-      react: 17.0.2
-    dev: false
-
-  /@react-stately/overlays/3.4.0_react@17.0.2:
-    resolution: {integrity: sha512-jXVm1V91lWOKh73cFvE9W9JtAE8idSWEUtFlVrlBI/jh0ZOt148UlRVWgHrm7FhaUpyvOFNUyfidRmKMuB+hgw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-stately/utils': 3.5.1_react@17.0.2
-      '@react-types/overlays': 3.6.2_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3828,17 +3259,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-stately/radio/3.5.0_react@17.0.2:
-    resolution: {integrity: sha512-qn4+wa9sf3zZXSLrrR9rQpOII8BEQeAkvxyq/YhUQXBpQ8SoF5LobpGIZqp3n8G+Cxzjxd6/GON+lOFxWr0iXA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-stately/utils': 3.5.1_react@17.0.2
-      '@react-types/radio': 3.2.2_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-stately/radio/3.6.0_react@17.0.2:
     resolution: {integrity: sha512-hzNwIapDSnbk5mCim/AgHQTtHRgy2QiW95okfVnGflzO7nnws8WH/s2Va4f7UupWObPv8XTqHADUEng86mVBJA==}
     peerDependencies:
@@ -3848,22 +3268,6 @@ packages:
       '@react-stately/utils': 3.5.1_react@17.0.2
       '@react-types/radio': 3.3.1_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
-      react: 17.0.2
-    dev: false
-
-  /@react-stately/select/3.3.0_react@17.0.2:
-    resolution: {integrity: sha512-amF7N8izlD8Dtja75uPdvBMme9KTwuJ6HHtPAVtoVOdSDcD7yb8GTRNhsjvfW8YPm8jkrUwkSobegqaEtRM5eQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-stately/collections': 3.4.2_react@17.0.2
-      '@react-stately/list': 3.5.2_react@17.0.2
-      '@react-stately/menu': 3.4.0_react@17.0.2
-      '@react-stately/selection': 3.10.2_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
-      '@react-types/select': 3.6.2_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3883,18 +3287,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-stately/selection/3.10.2_react@17.0.2:
-    resolution: {integrity: sha512-3/iw0BpShWt5ie+YpOzi4Mpa3yKOtlKQZXEc0fZt3v3m3N3fMoCr7Ovkfuz5Svy47HIIN1Pk1WkRJC+CQ4hfDw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-stately/collections': 3.4.2_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-stately/selection/3.11.1_react@17.0.2:
     resolution: {integrity: sha512-UHB6/eH5NJ+Q70G+pmnxohHfR3bh0szT+lOlWPj7Mh76WPu9bu07IHKLEob6PSzyJ81h7+Ysk3hdIgS3TewGog==}
     peerDependencies:
@@ -3904,21 +3296,6 @@ packages:
       '@react-stately/collections': 3.5.0_react@17.0.2
       '@react-stately/utils': 3.5.1_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
-      react: 17.0.2
-    dev: false
-
-  /@react-stately/table/3.3.0_react@17.0.2:
-    resolution: {integrity: sha512-qhZdgyD0EyePW/U/VlJCGLBNuzo2H1hQSgfRJ7+E5QVbqDwUUQ6Safz1EQ3Jhh64IcTDqxvKL3arr8THT7UKdA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-stately/collections': 3.4.2_react@17.0.2
-      '@react-stately/grid': 3.3.0_react@17.0.2
-      '@react-stately/selection': 3.10.2_react@17.0.2
-      '@react-types/grid': 3.1.2_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      '@react-types/table': 3.3.0_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3973,18 +3350,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-stately/tooltip/3.2.0_react@17.0.2:
-    resolution: {integrity: sha512-OoO/vUPWLJG05sV2fPH5K7kt+aMBqFgxKn59LxvGzS4hCeI58WLeGeJhbEOwMyF9+GO7JtdUssVrqMeahKUrzg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-stately/overlays': 3.4.0_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
-      '@react-types/tooltip': 3.2.2_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-stately/tooltip/3.2.2_react@17.0.2:
     resolution: {integrity: sha512-Y9itW2PDRWi/FdMYhpAC/kmXx22mRElADbM1AqKkMkWiJHhTbn2Cr5ie1uZcm+SMb5Dq2ypMV5rUzuiCVVB8/g==}
     peerDependencies:
@@ -3994,19 +3359,6 @@ packages:
       '@react-stately/overlays': 3.4.3_react@17.0.2
       '@react-stately/utils': 3.5.1_react@17.0.2
       '@react-types/tooltip': 3.2.5_react@17.0.2
-      react: 17.0.2
-    dev: false
-
-  /@react-stately/tree/3.3.1_react@17.0.2:
-    resolution: {integrity: sha512-s/pcafhvUnt2uOIUWRdTpWCBLnGOuG5e9CAzPkwlUCGFXiI7jIJBT8Y4dLP7Iwx6i9U2wZqs22onxH7GHlGgbw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-stately/collections': 3.4.2_react@17.0.2
-      '@react-stately/selection': 3.10.2_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -4029,17 +3381,6 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.17.9
-      react: 17.0.2
-    dev: false
-
-  /@react-stately/virtualizer/3.1.9_react@17.0.2:
-    resolution: {integrity: sha512-to0CQU4l08ZI/Ar3h/BeDqFTjK0nJUfhdk8mTpP+bV0RGBQnDwqCnrLFdQCc3Xl8fbYWa+Y6pvSUqJ0rq6Bp7Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@react-aria/utils': 3.13.3_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -4073,15 +3414,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-types/button/3.5.1_react@17.0.2:
-    resolution: {integrity: sha512-GxTikDKfuztu1r0LWHmqG1AD5yM9F6WFzwAYgLltn8B7RshzpJcYSfpYsh1e64z84YJpEoj+DD8XGGSc0p/rvw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.16.0_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-types/button/3.7.0_react@17.0.2:
     resolution: {integrity: sha512-81BQO3QxSgF9PTXsVozNdNCKxBOB1lpbCWocV99dN1ws9s8uaYw8pmJJZ0LJKLiOsIECQ/3QrhQjmWTDW/qTug==}
     peerDependencies:
@@ -4109,31 +3441,12 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-types/combobox/3.5.2_react@17.0.2:
-    resolution: {integrity: sha512-Q1HtiT/Hq+b6q71Evn8nmIfLv08kDEZSlOz5hlZouH9ZGYeTb1huH72biYl9LyIB6NRdNUouo7+I8ddumeAkMA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-types/combobox/3.5.5_react@17.0.2:
     resolution: {integrity: sha512-gpDo/NTQFd5IfCZoNnG16N4/JfvwXpZBNc15Kn7bF+NcpSDhDpI26BZN4mvK4lljKCheD4VrEl9/3PtImCg7cA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-types/shared': 3.16.0_react@17.0.2
-      react: 17.0.2
-    dev: false
-
-  /@react-types/dialog/3.3.5_react@17.0.2:
-    resolution: {integrity: sha512-K77big4JVDy6nhIv5V8PbnfHOeTK8JeGBLAEhl1DGCgCnPhq2eJ/R342rSjQobSyyaVUAYu1Z4AW4jjBSM17ug==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@react-types/overlays': 3.6.2_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -4144,15 +3457,6 @@ packages:
     dependencies:
       '@react-types/overlays': 3.6.5_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
-      react: 17.0.2
-    dev: false
-
-  /@react-types/grid/3.1.2_react@17.0.2:
-    resolution: {integrity: sha512-9mKhtBZiGlok1APRSR+hTKYFgx8XxRBBLG20/xPI1C8xCGNZvOz7CmK57LmlwYsN1BLo3S2vLOd6+M1qrw2yVg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.14.1_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -4183,16 +3487,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-types/link/3.2.5_react@17.0.2:
-    resolution: {integrity: sha512-i2e7tgncMGd1w5d6zHi5n3ixkOA6jNjkJZM617Qh2UwOsTtcXD7yrQvwHo1KaZQnAzoBNNxtv6+a8bT3oLPdIg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@react-aria/interactions': 3.11.0_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-types/link/3.3.5_react@17.0.2:
     resolution: {integrity: sha512-wEeYXqzRPwEwU6AakiRfsPrkGxm2l0gjIc992FBmHPz6MWU8eSATTwzeyI668eRzNrQvOBMI7il6lXuxDm1ZLg==}
     peerDependencies:
@@ -4203,31 +3497,12 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-types/listbox/3.2.5_react@17.0.2:
-    resolution: {integrity: sha512-FxZAT0HT1+LASzNffc5faVuIrODyQeN738l3WeCGb2xJAdkImKr4hahtcdduXvT30WVwaPpsynKlhpRRaVxjDA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-types/listbox/3.3.5_react@17.0.2:
     resolution: {integrity: sha512-7SMRJWUi7ayzQ7SUPCXXwgI/Ua3vg0PPQOZFsmJ4/E8VG/xK82IV7BYSZiNjUQuGpVZJL0VPndt/RwIrQO4S3w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-types/shared': 3.16.0_react@17.0.2
-      react: 17.0.2
-    dev: false
-
-  /@react-types/menu/3.7.0_react@17.0.2:
-    resolution: {integrity: sha512-1kEyyb0tERlPdZ67lsC2fMZ2TTh0OdS1hcb01PrSkGna/S+H/Q9M65Xc+q9eu7QoC4+DN4Flh/7vNRT82kVlHg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/overlays': 3.6.2_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -4241,15 +3516,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-types/overlays/3.6.2_react@17.0.2:
-    resolution: {integrity: sha512-ag9UCIlcNCvMHBORRksdLnQK3ef+CEbrt+TydOxBAxAf+87fXJ/0H6hP/4QTebEA2ixA0qz8CFga81S8ZGnOsQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-types/overlays/3.6.5_react@17.0.2:
     resolution: {integrity: sha512-IeWcF+YTucCYYHagNh8fZLH6R4YUONO1VHY57WJyIHwMy0qgEaKSQCwq72VO1fQJ0ySZgOgm31FniOyKkg6+eQ==}
     peerDependencies:
@@ -4259,30 +3525,12 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-types/radio/3.2.2_react@17.0.2:
-    resolution: {integrity: sha512-JBnfEUu4T6Z+SRsALKnzmx/4AqeIbdHEOumHSlAlX5iLPUywvELn22PVvF+YHh7bOeXKcVv+4/rXnTZWcsAK1g==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-types/radio/3.3.1_react@17.0.2:
     resolution: {integrity: sha512-q/x0kMvBsu6mH4bIkp/Jjrm9ff5y/p3UR0V4CmQFI7604gQd2Dt1dZMU/2HV9x70r1JfWRrDeRrVjUHVfFL5Vg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-types/shared': 3.16.0_react@17.0.2
-      react: 17.0.2
-    dev: false
-
-  /@react-types/select/3.6.2_react@17.0.2:
-    resolution: {integrity: sha512-V1ahKVEIA+u4kDOXTw0UoSjJ8T3EJi25PNx/whLYIEMXWw/v8dH+x7Hi7S45cHS+ZxoZXhWIV8WmgDKIUp1U1Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.14.1_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -4347,16 +3595,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-types/table/3.3.0_react@17.0.2:
-    resolution: {integrity: sha512-spq1h0+RuClbedH26d8SX8bGJUWO3x/MrRuoxN/XThCR+8rayp+QjCz7Pz2a5rqMniRh91O8rOOdqjbWbP4b7g==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/grid': 3.1.2_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-types/table/3.3.3_react@17.0.2:
     resolution: {integrity: sha512-rdY8PCzdqumVd6EFgN4NCoNRHdU4dVKH2oufr50TrAVPAz2KyoNXaGcDGe0q4RjQeTk+fc0sCvRZZdpMwHRVpQ==}
     peerDependencies:
@@ -4367,31 +3605,12 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-types/textfield/3.4.0_react@17.0.2:
-    resolution: {integrity: sha512-NL97JvdzsuGDYGx/JlE/yCceUR4IS1dX6CK9PljI0ZTsOOXLGynJ4HCpayBzbelUA617a+qr/v0c1CxY3y1qfg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1
-    dependencies:
-      '@react-types/shared': 3.14.1_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-types/textfield/3.6.1_react@17.0.2:
     resolution: {integrity: sha512-V3EyYw82GVJQbNN0OAWpOLs/UQij+AgUuJpxh8192p/q0B3/9lqepZ9b+Qts2XgMsA+3Db+KgFMWm2IdjaZbpQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@react-types/shared': 3.16.0_react@17.0.2
-      react: 17.0.2
-    dev: false
-
-  /@react-types/tooltip/3.2.2_react@17.0.2:
-    resolution: {integrity: sha512-EAvIOOaHvkxg8vIDXKJc8Sac7wLN80Erp6MH+kr7Ybmr94SHH7jnOPF6CkfcDE2WqYm5vqyerc6MPO/iQVyhZg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/overlays': 3.6.2_react@17.0.2
-      '@react-types/shared': 3.14.1_react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -4509,37 +3728,6 @@ packages:
       util-deprecate: 1.0.2
     dev: false
 
-  /@storybook/addon-a11y/6.5.9_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-jRiuJ2xlN8quVq2lOqpxqyuwAj8xLcgVBPy+Mf220u7AZmmbS/0sONyHKROfEBjJoHQAQYqn2vSAeuQZuTWyVA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-    dependencies:
-      '@storybook/addons': 6.5.9_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/api': 6.5.9_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/channels': 6.5.9
-      '@storybook/client-logger': 6.5.9
-      '@storybook/components': 6.5.9_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/core-events': 6.5.9
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/theming': 6.5.9_sfoxds7t5ydpegc3knd667wn6m
-      axe-core: 4.4.2
-      core-js: 3.23.1
-      global: 4.4.0
-      lodash: 4.17.21
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      react-sizeme: 3.0.2
-      regenerator-runtime: 0.13.9
-      ts-dedent: 2.2.0
-      util-deprecate: 1.0.2
-    dev: false
-
   /@storybook/addons/6.5.13_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-18CqzNnrGMfeZtiKz+R/3rHtSNnfNwz6y6prIQIbWseK16jY8ELTfIFGviwO5V2OqpbHDQi5+xQQ63QAIb89YA==}
     peerDependencies:
@@ -4559,27 +3747,6 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       regenerator-runtime: 0.13.10
-    dev: false
-
-  /@storybook/addons/6.5.9_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-adwdiXg+mntfPocLc1KXjZXyLgGk7Aac699Fwe+OUYPEC5tW347Rm/kFatcE556d42o5czcRiq3ZSIGWnm9ieQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@storybook/api': 6.5.9_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/channels': 6.5.9
-      '@storybook/client-logger': 6.5.9
-      '@storybook/core-events': 6.5.9
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/router': 6.5.9_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/theming': 6.5.9_sfoxds7t5ydpegc3knd667wn6m
-      '@types/webpack-env': 1.17.0
-      core-js: 3.23.1
-      global: 4.4.0
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      regenerator-runtime: 0.13.9
     dev: false
 
   /@storybook/api/6.5.13_sfoxds7t5ydpegc3knd667wn6m:
@@ -4609,33 +3776,6 @@ packages:
       util-deprecate: 1.0.2
     dev: false
 
-  /@storybook/api/6.5.9_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-9ylztnty4Y+ALU/ehW3BML9czjCAFsWvrwuCi6UgcwNjswwjSX3VRLhfD1KT3pl16ho//95LgZ0LnSwROCcPOA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@storybook/channels': 6.5.9
-      '@storybook/client-logger': 6.5.9
-      '@storybook/core-events': 6.5.9
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/router': 6.5.9_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/semver': 7.3.2
-      '@storybook/theming': 6.5.9_sfoxds7t5ydpegc3knd667wn6m
-      core-js: 3.23.1
-      fast-deep-equal: 3.1.3
-      global: 4.4.0
-      lodash: 4.17.21
-      memoizerific: 1.11.3
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      regenerator-runtime: 0.13.9
-      store2: 2.13.2
-      telejson: 6.0.8
-      ts-dedent: 2.2.0
-      util-deprecate: 1.0.2
-    dev: false
-
   /@storybook/channels/6.5.13:
     resolution: {integrity: sha512-sGYSilE30bz0jG+HdHnkv0B4XkAv2hP+KRZr4xmnv+MOOQpRnZpJ5Z3HVU16s17cj/83NWihKj6BuKcEVzyilg==}
     dependencies:
@@ -4644,23 +3784,8 @@ packages:
       util-deprecate: 1.0.2
     dev: false
 
-  /@storybook/channels/6.5.9:
-    resolution: {integrity: sha512-FvGA35nV38UPXWOl9ERapFTJaxwSTamQ339s2Ev7E9riyRG+GRkgTWzf5kECJgS1PAYKd/7m/RqKJT9BVv6A5g==}
-    dependencies:
-      core-js: 3.23.1
-      ts-dedent: 2.2.0
-      util-deprecate: 1.0.2
-    dev: false
-
   /@storybook/client-logger/6.5.13:
     resolution: {integrity: sha512-F2SMW3LWFGXLm2ENTwTitrLWJgmMXRf3CWQXdN2EbkNCIBHy5Zcbt+91K4OX8e2e5h9gjGfrdYbyYDYOoUCEfA==}
-    dependencies:
-      core-js: 3.23.1
-      global: 4.4.0
-    dev: false
-
-  /@storybook/client-logger/6.5.9:
-    resolution: {integrity: sha512-DOHL6p0uiDd3gV/Sb2FR+Vh6OiPrrf8BrA06uvXWsMRIIvEEvnparxv9EvPg7FlmUX0T3nq7d3juwjx4F8Wbcg==}
     dependencies:
       core-js: 3.23.1
       global: 4.4.0
@@ -4684,34 +3809,8 @@ packages:
       util-deprecate: 1.0.2
     dev: false
 
-  /@storybook/components/6.5.9_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-BhfX980O9zn/1J4FNMeDo8ZvL1m5Ml3T4HRpfYmEBnf8oW5b5BeF6S2K2cwFStZRjWqm1feUcwNpZxCBVMkQnQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@storybook/client-logger': 6.5.9
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/theming': 6.5.9_sfoxds7t5ydpegc3knd667wn6m
-      '@types/react-syntax-highlighter': 11.0.5
-      core-js: 3.23.1
-      memoizerific: 1.11.3
-      qs: 6.10.5
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      react-syntax-highlighter: 15.5.0_react@17.0.2
-      regenerator-runtime: 0.13.9
-      util-deprecate: 1.0.2
-    dev: false
-
   /@storybook/core-events/6.5.13:
     resolution: {integrity: sha512-kL745tPpRKejzHToA3/CoBNbI+NPRVk186vGxXBmk95OEg0TlwgQExP8BnqEtLlRZMbW08e4+6kilc1M1M4N5w==}
-    dependencies:
-      core-js: 3.23.1
-    dev: false
-
-  /@storybook/core-events/6.5.9:
-    resolution: {integrity: sha512-tXt7a3ZvJOCeEKpNa/B5rQM5VI7UJLlOh3IHOImWn4HqoBRrZvbourmac+PRZAtXpos0h3c6554Hjapj/Sny5Q==}
     dependencies:
       core-js: 3.23.1
     dev: false
@@ -4737,21 +3836,6 @@ packages:
       regenerator-runtime: 0.13.10
     dev: false
 
-  /@storybook/router/6.5.9_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-G2Xp/2r8vU2O34eelE+G5VbEEVFDeHcCURrVJEROh6dq2asFJAPbzslVXSeCqgOTNLSpRDJ2NcN5BckkNqmqJg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@storybook/client-logger': 6.5.9
-      core-js: 3.23.1
-      memoizerific: 1.11.3
-      qs: 6.10.5
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      regenerator-runtime: 0.13.9
-    dev: false
-
   /@storybook/semver/7.3.2:
     resolution: {integrity: sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==}
     engines: {node: '>=10'}
@@ -4773,20 +3857,6 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       regenerator-runtime: 0.13.10
-    dev: false
-
-  /@storybook/theming/6.5.9_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-KM0AMP5jMQPAdaO8tlbFCYqx9uYM/hZXGSVUhznhLYu7bhNAIK7ZVmXxyE/z/khM++8eUHzRoZGiO/cwCkg9Xw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@storybook/client-logger': 6.5.9
-      core-js: 3.23.1
-      memoizerific: 1.11.3
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      regenerator-runtime: 0.13.9
     dev: false
 
   /@testing-library/react-hooks/8.0.1_hiunvzosbwliizyirxfy6hjyim:
@@ -4883,12 +3953,6 @@ packages:
       '@types/node': 18.7.21
     dev: true
 
-  /@types/hast/2.3.4:
-    resolution: {integrity: sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==}
-    dependencies:
-      '@types/unist': 2.0.6
-    dev: false
-
   /@types/is-function/1.0.1:
     resolution: {integrity: sha512-A79HEEiwXTFtfY+Bcbo58M2GRYzCr9itHWzbzHVFNEYCcoU/MMGwYYf721gBrnhpj1s6RGVVha/IgNFnR0Iw/Q==}
     dev: false
@@ -4962,26 +4026,12 @@ packages:
       '@types/react': 17.0.50
     dev: true
 
-  /@types/react-syntax-highlighter/11.0.5:
-    resolution: {integrity: sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==}
-    dependencies:
-      '@types/react': 18.0.20
-    dev: false
-
   /@types/react/17.0.50:
     resolution: {integrity: sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
       csstype: 3.1.1
-
-  /@types/react/18.0.20:
-    resolution: {integrity: sha512-MWul1teSPxujEHVwZl4a5HxQ9vVNsjTchVA+xRqv/VYGCuKGAU6UhfrTdF5aBefwD1BHUD8i/zq+O/vyCm/FrA==}
-    dependencies:
-      '@types/prop-types': 15.7.5
-      '@types/scheduler': 0.16.2
-      csstype: 3.1.1
-    dev: false
 
   /@types/scheduler/0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
@@ -5152,35 +4202,6 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
-  /@udecode/plate-alignment/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-d/Fv88lQ6lkl007CSQoQaTaz8H38g2nYF88iA3imoPkWdfEphjWlNx5xR/4VU+DVNTH/tvUuNm/pSH0UWG+ZBg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-alignment/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-ZeKANQVJZDHjBZTH73YQtBh952p8u4R6G3cX7JnfM9TbbIdEBCeW3JfADL72JMv0m++AwXRUbGvYirMX/RQ8Eg==}
     peerDependencies:
@@ -5239,35 +4260,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-autoformat/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-DIrQV/A5yRiwlgjygxGWOiceIkmtDyvsXJ6K+lwyumOFu0XpLw1l67s6+s2TEnJYPitMcMOdhIxqCNE0pVedVw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-autoformat/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-hr/zLsdSvXoEGD8Xm8Uv45lNAcGeovQ9gOeb5eMlIIaPUPW27HvrX8MYDpstUS4RVwMV2w9kLdXpgHpbhL1nJg==}
     peerDependencies:
@@ -5307,39 +4299,6 @@ packages:
       slate-react: '>=0.79.0'
     dependencies:
       '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-basic-elements/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-qMzRL5N9RsoUjj+FcgSf5IEAyeR0ysfDaf7tQOL5lEqYhqk1vnJh8JZqQqxnRo1yugvFlE0WvszXU8Nq2ZFO1A==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-block-quote': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-code-block': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-heading': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-paragraph': 16.8.0_lzld3l452jl7ai3c5z6wescmva
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -5425,35 +4384,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-basic-marks/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-yqRVR+zowfjzOK9AxDZ//hiq6+tNUFY2gGJck8ClGMr5y9pbQfCDOyL7nkgbS7mUO4vzZmDIOjl+spGvOUVuSg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-basic-marks/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-L/n0fBGr8GsN+TTSLWLSddCP4QlDDNYOzGzReb9YAiF1AvzSTE8gTgic+T2rfk7uv04Gig/MiBcnK6uU/iekMQ==}
     peerDependencies:
@@ -5493,35 +4423,6 @@ packages:
       slate-react: '>=0.79.0'
     dependencies:
       '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-block-quote/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-lVGotr93cMD4+3wJNV/LvF2aLRhnp3qOEMbFRKbFqt9sjuI98gviqizAtHo5yw34NoYiz4YDTa2wOyXNKg/FJg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -5599,35 +4500,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-break/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-48WpW9/SqngeTP6ZNRi90j89iOii7mhI6ImYd6uA4QbhrE9rtDLm+HRHmy1uNaOlJLECZ2jp4+2yWTN6rbObdg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-break/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-spYxIpVj+A82DDj7eE13zXT7H0PUFjXvKkHG+uUUbdvj2H8kreGFWnjuK38QP17/m2lvSwgK1EqUMbQ7qmsw1g==}
     peerDependencies:
@@ -5686,35 +4558,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-button/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-1FPMGTAYddSO08YoOJWf97wbrOLACUIxN2YI0QhOLl8k60bKKHlhhO5Bt/JV6uFElrpZiCjn6aBhE+wKxEs1gw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-button/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-USgJNBUPb9dAyxK9EmlsX6xA8aCI5DcQNo7SzIFG0P2xlXWCu6dgoVCEUSr+1qkVGD5UUGGKG+2b3rEwdgwfgw==}
     peerDependencies:
@@ -5754,36 +4597,6 @@ packages:
       slate-react: '>=0.79.0'
     dependencies:
       '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-code-block/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-mtFy2IPuPF62qzMnqol6qk6Ag7dPco547Blcwf7UI/RFcRuCuX8/O/4phokz3ji35dZ06/oTrWWf0kGOpR/8Lw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      prismjs: 1.28.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -5863,38 +4676,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-combobox/16.8.0_l2ob6amovedmgdotpsyjqhcc6q:
-    resolution: {integrity: sha512-wyLavjSk58xsxp1vBwanRubx47CobjKEYOZY2zU2IHc/uSiPI4ut2Y6reXzEdG7NZYGHVJ2dNWLutFAcUc+NPg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-floating': 16.8.0_l2ob6amovedmgdotpsyjqhcc6q
-      downshift: 6.1.7_react@17.0.2
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-combobox/18.9.0_64uzl5e3huym3laqvq32skmtoe:
     resolution: {integrity: sha512-MHscNBBE6Mwz1uaBfiTVL/bExUIFff4dIOAH2/b5Lmpqp5jyKic3BK1GrP3r6eSflh40JoE/6XKNHGAnTngIFQ==}
     peerDependencies:
@@ -5949,42 +4730,6 @@ packages:
       - '@babel/template'
       - '@tanstack/query-core'
       - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-core/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-zd6ZxwDOuazKWGT4DFiQxQ8z3t2xAoBzg3JC5lY+4Xj/By5zjZD/ZmQAAogRWErC4ZNL6SqA2EbHDZij6hNrWg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@radix-ui/react-slot': 0.1.2_react@17.0.2
-      '@udecode/zustood': 1.1.3_ydxzat5trqpwwhxzo3xpwhm2ti
-      clsx: 1.1.1
-      jotai: 1.8.4_bbxtl6ryvenc2jc6uyz5mlvgwe
-      lodash: 4.17.21
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      react-hotkeys-hook: 3.4.7_sfoxds7t5ydpegc3knd667wn6m
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      use-deep-compare: 1.1.0_react@17.0.2
-      zustand: 3.7.2_react@17.0.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
       - '@urql/core'
       - immer
       - optics-ts
@@ -6069,35 +4814,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-find-replace/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-VWtXbGdvP1mLu3MA9A7WrZl3rmIxzxOgnezpUCzZiGLsIuCsp87UCaS+e5FTpmxz1Ca7suer0ir2sJ//BErAIQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-find-replace/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-HUZGDQ/A7HmioBAH5Aa+6X1zyPTxax0vkMbfaazP87isuQPIYdsR4iHtLHB2NBxImxOk1AK5ZJxBNsSEt0lb7A==}
     peerDependencies:
@@ -6146,37 +4862,6 @@ packages:
       - '@babel/core'
       - '@babel/template'
       - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-floating/16.8.0_l2ob6amovedmgdotpsyjqhcc6q:
-    resolution: {integrity: sha512-i9yHOGsHCaiFEFcqIj7k/8DQufTCqPmCV4seG2xyRqrzMULRgIsLCgogEosRF4mYvYXb04UhTkZ82aN6AfYdSw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@floating-ui/react-dom-interactions': 0.6.6_hiunvzosbwliizyirxfy6hjyim
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
       - '@urql/core'
       - immer
       - optics-ts
@@ -6249,35 +4934,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-font/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-jKAY0nUtwBPGBe1jdPhc2AZvPj1RwZicbG3v9nHQgQpcR/49MAmnR3fF8XV53CBu9LDPypAKvF2CI4V8bnXAJw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-font/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-HaXJ78NYHp5bCFdZtAlOJBAf5TzkQuN5YL3OAG6ld7SIi6GDgPvnfAwzON+WrpAT1zjBGgghxHFqaLo+/9CasQ==}
     peerDependencies:
@@ -6317,35 +4973,6 @@ packages:
       slate-react: '>=0.79.0'
     dependencies:
       '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-heading/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-L6JUgeRFkDL6lrf/CpvOMHrBBDZScJPYrmXhGzdv11MU4f34sllf5C/WLCygMRERKaDZ/CO3wt6/B18nTDTOHA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6418,74 +5045,6 @@ packages:
       - optics-ts
       - react-native
       - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-headless/16.9.1_m5fheiiqhtf5rhj4yydfkmxpb4:
-    resolution: {integrity: sha512-wR0V4IwjnPXe+yWYDmIDTP7yVI1bXh6kr9iVKp6C2DCXX6+fn/n52KN6DWIth85ze+9KAa6IK1+T87dEifpqDA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-alignment': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-autoformat': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-basic-elements': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-basic-marks': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-block-quote': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-break': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-button': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-code-block': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-combobox': 16.8.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-find-replace': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-floating': 16.8.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-font': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-heading': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-highlight': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-horizontal-rule': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-indent': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-indent-list': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-kbd': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-line-height': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-link': 16.9.1_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-list': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-media': 16.8.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-mention': 16.8.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-node-id': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-normalizers': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-paragraph': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-reset-node': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-select': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-selection': 16.8.1_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-serializer-csv': 16.8.0_4ywyo5sd46ikxdhuv7pegx7nwm
-      '@udecode/plate-serializer-docx': 16.8.0_m5fheiiqhtf5rhj4yydfkmxpb4
-      '@udecode/plate-serializer-html': 16.8.0_4ywyo5sd46ikxdhuv7pegx7nwm
-      '@udecode/plate-serializer-md': 16.9.1_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-table': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-trailing-block': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-hyperscript: 0.77.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - supports-color
       - valtio
       - wonka
       - xstate
@@ -6627,35 +5186,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-highlight/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-Rd7ufUlgDfQPy0AwALpWiQBPS9PLLUZvRdPutE0tJjGAq2YOF71DRVr2nk2CQduhAcg0mmhD4z0guy6ZeJManw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-highlight/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-3d7tU6y2ImyMoB+qda5mjp1t/qekuoSiTQTj88f8gMG+RZnDMdLaeEbfqoYHZ5J1GYLsCdd0XYf9qUAcmbNhKA==}
     peerDependencies:
@@ -6714,35 +5244,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-horizontal-rule/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-Gr8wfkIXabdMnNILPdgJzvOcXJF/VTvnky8NbH1JNrmim1n6bZLiSxY+Txo7KhVF0zbGX5UykAujPDzsjPz9ug==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-horizontal-rule/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-gEt50b891FelP8U9bZZs2C2bJHg6ur1Ba/qfN+2QvIkR2QSbOoXnFaoUccnAAk0ntl3NxSfQebKEwSrjzuLIVg==}
     peerDependencies:
@@ -6782,37 +5283,6 @@ packages:
       slate-react: '>=0.79.0'
     dependencies:
       '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-indent-list/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-sfRaYiEAqO1hsGHxfDidk1DXkIJOoTiAV5SARSSVdOmLu1m4YYT2Z/tmxMRxwI6ttV+rUjbKtnF1XbliQmWdlA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-indent': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-list': 16.8.0_lzld3l452jl7ai3c5z6wescmva
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -6894,35 +5364,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-indent/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-bvhWAUCS539AK4wDBXeYv1gnE6tGukiNOz+laV5urV/9hbHEgMYa5AeA9F9NY1erZtNjy6G+hwZNPh3yrkycWw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-indent/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-Vah3amIkW3akFlbE3nd+7x5vog6i4wEx0YyC1TcG8BXaCjPgIEUrM7OmRBIX6C2E2xeZmI4J6UphValsBBMYvA==}
     peerDependencies:
@@ -6962,35 +5403,6 @@ packages:
       slate-react: '>=0.79.0'
     dependencies:
       '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-kbd/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-V6hYWFBf2LQVAU7Ewf4GmcJElsMrBzNa0fkPwzy8hDmRxG7z2dRJ0HEBK2SUX0UKP8iJv6r6VNklJu96S7U2kg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -7068,35 +5480,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-line-height/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-eD4FOcTh3hmh54H0OK2sknc7XQeyQQOij5dAfsEqA88Ycb5d9Ku0o+6dDXcBneh/GVlrUba96bTKZkYWd1zqSA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-line-height/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-cQO6Pq3ysYVA6J7yTxF2JgJ4Ov/yvEK9uG7T5zgPjGoZJFxW9USdw5b0JfgN1EO3si2Iw4Q9vzAZRrgcTIP8Zw==}
     peerDependencies:
@@ -7136,37 +5519,6 @@ packages:
       slate-react: '>=0.79.0'
     dependencies:
       '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-link/16.9.1_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-pf2CkH2FP8JDl6ad9yZalYin6VtYmwMgCpFVVbjTMgWrpUUqMkyUtiVboha+B0jL3CS9xuDDhfds9/zYlEWYYg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-button': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-normalizers': 16.8.0_lzld3l452jl7ai3c5z6wescmva
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -7248,36 +5600,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-list/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-TNEzHS0NfYAClV3rNVa7sOD0XGBK7ykwA/uEb/tLom2L0HSyITMJQuTyStLELQ15Yn8Bz4BBfo68h/dPYXKjHg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-reset-node': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-list/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-skL040L82SrjHOwTXxu4b6dI6BlyUBq4jbptIvyblUAbjSfCqJJTnk7DuIOQzklkrgSDWoQQxlEVafFfr/ZnYw==}
     peerDependencies:
@@ -7338,40 +5660,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-media/16.8.0_l2ob6amovedmgdotpsyjqhcc6q:
-    resolution: {integrity: sha512-EpYA/my8d0z2cBYxlPBtBTC134AOMYV60AH8n3TjnLpFdE69WcS2FjHlueDkt0QvteRlPILlMQ0o2zd7BMPe3Q==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      js-video-url-parser: 0.5.1
-      re-resizable: 6.9.9_sfoxds7t5ydpegc3knd667wn6m
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      react-textarea-autosize: 8.3.4_pxzommwrsowkd4kgag6q3sluym
-      scriptjs: 2.5.9
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-media/18.9.0_64uzl5e3huym3laqvq32skmtoe:
     resolution: {integrity: sha512-RIlXwPz5gcVh4e/xk5HMeN7RGAxhwPnTU/EWJqhWL2wmyJsY6m3evqX8FTZYyNhMP0CQDXCahUbU1AQ3+Vxudw==}
     peerDependencies:
@@ -7422,37 +5710,6 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       react-textarea-autosize: 8.4.0_react@17.0.2
       scriptjs: 2.5.9
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-mention/16.8.0_l2ob6amovedmgdotpsyjqhcc6q:
-    resolution: {integrity: sha512-w9+6O1mjd8T/abJyD9XcfFR6nbRTY98nVQ7UYCosp+mr5DQGtRf54KaNv0vWtpdXmy5q2MolKRyu8J7Ot1ZqOA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-combobox': 16.8.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
@@ -7533,35 +5790,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-node-id/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-QVEm+mZKqv9zfeFcx1IuW1F+qupR8P7evldoPxmx+nWKYk46mzoN0Zar2+mkiVtzyLS9VMTuNTbsIE975trQPg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-node-id/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-0LhstU9Cto5RQ9QqbIwApChnxT6kz/6GT1mSG6WSWTuzYLCyg/7JDr2hMo55cjKFqj7o5KdEXaGxV4/y5X/62A==}
     peerDependencies:
@@ -7601,35 +5829,6 @@ packages:
       slate-react: '>=0.79.0'
     dependencies:
       '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-normalizers/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-51o+2ir9yumTjbcMsvLu78PW/e9nXqkiHtM/eIw4QGUXjKDOJf2gAJk447OXLGPBnAn29ucfrSRAwVmAGzlpeg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -7707,35 +5906,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-paragraph/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-p44WrWqIrtfJZpjslSjnqh6g9AcajlRs1BiJf6CGU9U5ITNTltUtl9+NL0Miabibgk0Hz1SguFZ7RCVOLWtL1w==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-paragraph/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-+lXx40p8sT7+AIOzbyrnx0TNtnFcOexf7HKKvy1Sz0rrXyP+1BUfe+Lihj+krBWamY5cAuBEysEcRgJ6PohS8Q==}
     peerDependencies:
@@ -7775,35 +5945,6 @@ packages:
       slate-react: '>=0.79.0'
     dependencies:
       '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-reset-node/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-ex6WEAAlgMAC4iEFxP3pxmbRPA7lCfMJJQDrJlZBT9VwOdBTSZDLWcjosPI4nYg+7r01frYH75pVwfkGlW/NUA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -7881,35 +6022,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-select/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-W08xMr1UcXU9Kz9rU1CELTXzV9Sw5uBOj8efm7Bfg1jreAwEnGKZUQ9Ctx9JyQ2GgRHTzi69VF2LglSkTFeVwA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-select/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-pjhzD/jEvSW2PKgfm8NSIERQZ7NwI4lMK8lheuCDNXdwoY7ziMBvjsL9vmtcAArh08z4a5lFdqs09Guq9BK2TA==}
     peerDependencies:
@@ -7949,36 +6061,6 @@ packages:
       slate-react: '>=0.79.0'
     dependencies:
       '@udecode/plate-core': 18.9.0_mp6j26o5qfgd3xbgw4xo3ahu4y
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-selection/16.8.1_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-0PLuMU8A7ow5qmCio7s4G8WKarXVWO7a2fdt2DWIocdTo99JSCHGaZCzL8XTlyXxoNOCKrfoC297B8gVi3r72A==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@viselect/vanilla': 3.1.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
@@ -8060,38 +6142,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-serializer-csv/16.8.0_4ywyo5sd46ikxdhuv7pegx7nwm:
-    resolution: {integrity: sha512-I+13F+1GcdoTTuC6HAb02nby8W3ATyBsI8eVZzmRccWgEbC5sAQ+pyx/SUZL5asxE6kg4hx7G+TOI0qjIZeeMw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-table': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      papaparse: 5.3.2
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-hyperscript: 0.77.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - slate-history
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-serializer-csv/18.9.0_evqyrkgavtfgptj4a3lbeg4pr4:
     resolution: {integrity: sha512-zrCic8wHyhu2MpFChwAixbjdXtMxN5X+hAu24CY41HuSA6mx9UFX6oOoSwNYgSGpZ4EV7/oFYyQwiOgj2dxg0g==}
     peerDependencies:
@@ -8151,45 +6201,6 @@ packages:
       - react-native
       - scheduler
       - slate-history
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-serializer-docx/16.8.0_m5fheiiqhtf5rhj4yydfkmxpb4:
-    resolution: {integrity: sha512-ZGXMIBT6HQIaDcSCHEatiUW4ekJMAy64wbtCpoByDIKwAliNzIcs2btMFVZkcjN+X1j5PrAfT4WfZ/bPt3NH3Q==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-heading': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-indent': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-indent-list': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-media': 16.8.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-paragraph': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-table': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-hyperscript: 0.77.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      validator: 13.7.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
       - valtio
       - wonka
       - xstate
@@ -8273,38 +6284,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-serializer-html/16.8.0_4ywyo5sd46ikxdhuv7pegx7nwm:
-    resolution: {integrity: sha512-AY2OvWLiLbuiubgV9LzagBBdwu9mEvgBH3MLIK19pw6yB01/yPqL0cbVT0HE8YKWG9KutzRcxinoFuNG/5FNAw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      html-entities: 2.3.3
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-hyperscript: 0.77.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-serializer-html/18.9.0_evqyrkgavtfgptj4a3lbeg4pr4:
     resolution: {integrity: sha512-pEkIv+Gw4HcACSHT0mQk5iRFXv/hfNwLQMqhOuPBMNSdq5VgVna4ieiASNCUxNsDNcrHVB4WLZ0x/I+DY5ivTQ==}
     peerDependencies:
@@ -8364,45 +6343,6 @@ packages:
       - optics-ts
       - react-native
       - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-serializer-md/16.9.1_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-ceK1KKoRzZbUqptRMEumu+nDUyzi2Riu67QbXKtJAb1FkQ/cyxfyudvMdR+vSHwOsZAoByKnWHts/q0zoXuGew==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-block-quote': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-code-block': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-heading': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-link': 16.9.1_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-list': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-paragraph': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      remark-parse: 9.0.0
-      remark-slate: 1.8.6
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      unified: 9.2.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - supports-color
       - valtio
       - wonka
       - xstate
@@ -8486,40 +6426,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-styled-components/16.8.0_3u2a2wscqng4lreiczswztzzfe:
-    resolution: {integrity: sha512-wOHvK1wcUjUJRKNIzU2IAskBUycgJ3owlmh5b+1qwgByECjvvzjxISZiDZhnIHJFpx+CfmTreext0HicBAz58g==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      react-is: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      clsx: 1.1.1
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      react-is: 18.1.0
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-styled-components/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-raO3+SRSak9sdho8dMMrRqHxjx4svXygho4FZ1Vceu3nm/QqpiweAX9oMYXjtzFZq0ZLnVl9bh0bm9Zj0qtX7g==}
     peerDependencies:
@@ -8574,35 +6480,6 @@ packages:
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-table/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-6GBRw0mpiYwMMnS1XyjOJ2jK7v0C+MlIsExs3P9JjHuIxy4BZKCHF9tBs2RMBJ7vK1hR9wxcwSVI1f9wG+C2nw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8675,35 +6552,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-trailing-block/16.8.0_lzld3l452jl7ai3c5z6wescmva:
-    resolution: {integrity: sha512-eaawcb5oCyKfvPBrXmD6J+dXv7+7wypCXqAvDQwbdS/0pckc8SZKT6j6Un2vsticCTZkmtRyEc8+x2RdZLFikg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-trailing-block/18.9.0_blf3u7zakgjrhm5t6ncitc2fqy:
     resolution: {integrity: sha512-fDqMCl5lqC/eUZUQODQylebXm5FUjwtwuQychBu9BAoFFMJ605kDGn5mKfrAbhOxDUObiu6IzDZdA2Za5SAOEw==}
     peerDependencies:
@@ -8755,42 +6603,6 @@ packages:
       - '@urql/core'
       - immer
       - optics-ts
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-ui-alignment/16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy:
-    resolution: {integrity: sha512-c+thv0uZKmhHN7LDJkVuQJSCg1C4DTrYexYirHT7zu85G9r8G/Brov9vpTnPLDM9P823lo/SkBMaY0qv1Bs2WQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-alignment': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-toolbar': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
       - react-native
       - scheduler
       - valtio
@@ -8870,40 +6682,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-block-quote/16.8.0_3u2a2wscqng4lreiczswztzzfe:
-    resolution: {integrity: sha512-OgF7cDU/gBiadNCX7J2jqY8P96/RxrJX2JWsv0dEfVfmfArjas4J2vCOXEAVYpz79s77HBkhp3+3kImRQsUyIQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-block-quote': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-block-quote/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-KNAixt/Eut2LL3BtW2UrNMR9V6CDTX6Jvsz/mnPeYJZ1017qa5RAQsQHw6GcSXd8VgAkixvphulbZDyIyBc1TA==}
     peerDependencies:
@@ -8957,40 +6735,6 @@ packages:
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-ui-button/16.8.0_3u2a2wscqng4lreiczswztzzfe:
-    resolution: {integrity: sha512-19qS5BXtXRm7pnXxVKHbIacSSc9ml/931gU6ll9qim6gJ6wgqGyUXKK03ivpzS0Gk7+5cWbSV1ib5NyGqW8gyA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-button': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9074,42 +6818,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-code-block/16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy:
-    resolution: {integrity: sha512-MT85/G/m9NGBATLEMImdY7F18V1wCe7CgBlhD7vuwom0diQjbwPEMQ9t7Q5yexiHbzFl+6WOSbjSYPWsLartsQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-code-block': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-toolbar': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-code-block/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-6evahJFHIB1kbqwqWVp/Q4+5SCsScqE4TJWu4Zqq7AvitvT2pGG42ZicGXyqUTvY9vG/JGShh5DQYWKBSw+UUw==}
     peerDependencies:
@@ -9166,42 +6874,6 @@ packages:
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-ui-combobox/16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy:
-    resolution: {integrity: sha512-NLxW4jG89Xk2Qn01iyKMU8Ae9nXPhbPBeK76Ts5RgxlaqOsfIQDgNysv4yfMm1hYwsmc4cWhT4TYl+OkBqGe7A==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-combobox': 16.8.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-floating': 16.8.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9290,39 +6962,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-cursor/16.8.0_3u2a2wscqng4lreiczswztzzfe:
-    resolution: {integrity: sha512-n4ry53exgKcz1P0NG9kGtfcZo7D5QbrURoRyOG6JYfNKUQ7HTXi5Du1+s9+3lSrs3ILv1BzsmNRSkDLDSvOpQA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-cursor/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-V0+NiREBO+Zdyssd7mhllcXYG9jZoGLq8o76lNPokziKkHFZsFZ9hGZ3JTl9ItzJytmkWiDBq7I63BSGy3P5Aw==}
     peerDependencies:
@@ -9374,45 +7013,6 @@ packages:
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-ui-dnd/16.8.0_m3il3u2zkyh55i2vrix3m3uu7i:
-    resolution: {integrity: sha512-0OyDs/CbsWdz7WgrjVqNrrIxKLUDBxT478+HPDytcbJIYaKoexaOwN0IhUmFzy/XZSp8XnfoJMxuVLV43TSFKA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dnd: '>=14.0.0'
-      react-dnd-html5-backend: '>=14.0.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@react-hook/merged-ref': 1.3.2_react@17.0.2
-      '@tippyjs/react': 4.2.6_sfoxds7t5ydpegc3knd667wn6m
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      react: 17.0.2
-      react-dnd: 15.1.2_smc5esni47gpbltvxzeziduyte
-      react-dnd-html5-backend: 15.1.3
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9508,42 +7108,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-find-replace/16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy:
-    resolution: {integrity: sha512-oM+RjCQkzakFdXHJhkXSGtAPIldLkxoUSUAsSqYAa1jg6O0nMNHeD53di++0VhlGwlmqYikk+NAj4uysdZiy9A==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-find-replace': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-toolbar': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-find-replace/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-kY22kVp0k6vfLM5nwX2n1Vp3+Hu5lquhYKhgoWYFK/Xk/No5E99LRXnUCbAgstkQcvxcIM4RtcwHuCSICArvVA==}
     peerDependencies:
@@ -9600,43 +7164,6 @@ packages:
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-ui-font/16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy:
-    resolution: {integrity: sha512-9hWHNnBxZLgWYsOaWsu7bqS/a8v5r1jgCnNqqoxfYLZVKTQtheS9/fuOIgfi5koiHklfii+fZ8punaNE/yElSg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-font': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-button': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-toolbar': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9727,42 +7254,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-line-height/16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy:
-    resolution: {integrity: sha512-mjdaM8eG289hxwA6U2b92BCVSI9LtpGYBndX9GzXLYRqPXvEkBTDOlMAXalOwZj/tUulxdni5P+4GmM2RKSu1A==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-line-height': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-toolbar': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-line-height/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-+Jno1fb8uOKhwCCC8/p3TXH4wkZqHx5gtA/IcyC3YER96zh4fEANL47/VLMNW+1xuSPHOaBGl/bCTowD+PpyAg==}
     peerDependencies:
@@ -9819,43 +7310,6 @@ packages:
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-ui-link/16.9.1_jbz7ghep6wjhxqiau5fvi2yqxy:
-    resolution: {integrity: sha512-iHzT3CeHGd9xE2zYmeTBaTRIw7UQbihaV+nnXHWwF/TumCtWfvungGySB55n9P0zJUy71Ye2U++N2M1AYQJBwg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-link': 16.9.1_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-button': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-toolbar': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9946,42 +7400,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-list/16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy:
-    resolution: {integrity: sha512-hTXIiNkGhFgcbobJG/gai4kuKXIQAmtkDnACilmq0BKHQ2lzWs6y6qjei+KH3Ku5SSYbYxzX74SyyPv71wrYEw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-list': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-toolbar': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-list/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-pmIWF1eknZLyn46Eke+qk7O9CzNiAiS4Bpq4ypXiz8gNTX2O05/9sUQfj9twRvFAYwxNDmPXuxa+DPdICTzgRA==}
     peerDependencies:
@@ -10038,46 +7456,6 @@ packages:
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-ui-media/16.9.1_jbz7ghep6wjhxqiau5fvi2yqxy:
-    resolution: {integrity: sha512-nuclGmLFJ2wV4nJJ9njhH9zHOGLVU+6Ce96NbjJ2yXF3vw5i4kADsFXXQymvnkbtZ/FPQa4aTi54PMJJ6QTc7Q==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-floating': 16.8.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-link': 16.9.1_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-media': 16.8.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-link': 16.9.1_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-toolbar': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      js-video-url-parser: 0.5.1
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -10174,43 +7552,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-mention/16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy:
-    resolution: {integrity: sha512-wtAt8OHsygQlt1zN7cTJZExeeKbuDXU2PR0stnmUbHw7hpqozvL29MAH3I1ZkcFv7RA5507fKsDawwzbOO2rQA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-combobox': 16.8.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-mention': 16.8.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-combobox': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-mention/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-Zknjk+lUMtkkrgXy10CZgobQOhHDZLQqGHPjD3CWDteawxLUflE3a5I4+EBlA295jtUz3aTH3lIE3+MglvJKcw==}
     peerDependencies:
@@ -10285,39 +7626,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-placeholder/16.8.0_3u2a2wscqng4lreiczswztzzfe:
-    resolution: {integrity: sha512-9zM5PE1BtHMLlcRc174YZeMxfvyevQ0VO+PQan29D35gCfiK5BajztznGirhYsJ7Bd/ruHdHeCXq5BnZ6d1KxQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-placeholder/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-muT67OFdkDTNeUWB94hLWXrz49iKzrXHZXRn0ubHansv0z6IuR9STaAElis5y/YvBZSDe8O0b0qsiEHdhgtEGA==}
     peerDependencies:
@@ -10373,45 +7681,6 @@ packages:
       - '@babel/core'
       - '@babel/template'
       - '@tanstack/query-core'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-ui-table/16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy:
-    resolution: {integrity: sha512-VH1Cu+txBQxbhhSoVsf6BC+fw6SKd3IzrT1tPgCVhJsaHnxqzJWoqX/9HZXd+a3vSdH7bQCo7A4VLBRIYVdGqQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-floating': 16.8.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-table': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-ui-button': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-toolbar': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      re-resizable: 6.9.9_sfoxds7t5ydpegc3knd667wn6m
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
       - '@urql/core'
       - immer
       - optics-ts
@@ -10501,44 +7770,6 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-ui-toolbar/16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy:
-    resolution: {integrity: sha512-KbUwxVUeFYJGmbVBBoLRv9VJxoveWZS7x6u9+RO7e8F0Yim5Szlg+A1yeF8kHcHNeBbv+4LyAPJOoL94EUkiOg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@tippyjs/react': 4.2.6_sfoxds7t5ydpegc3knd667wn6m
-      '@udecode/plate-core': 16.8.0_lzld3l452jl7ai3c5z6wescmva
-      '@udecode/plate-floating': 16.8.0_l2ob6amovedmgdotpsyjqhcc6q
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-button': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      react-use: 17.3.2_sfoxds7t5ydpegc3knd667wn6m
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
   /@udecode/plate-ui-toolbar/18.9.0_boq2e7lx2l7gagjs37x4idb7yy:
     resolution: {integrity: sha512-qUwHWnYddJG0Cmtw/dIi+hqe6FlXt2Y4gPd3fB1VpWEYKjBV9jqvqZdMFjpVfOm2SvCPko/upp30aXH0ArtrDQ==}
     peerDependencies:
@@ -10610,64 +7841,6 @@ packages:
       - react-is
       - react-native
       - scheduler
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate-ui/16.9.1_3applnbcmonz6yjsxb2hv5truu:
-    resolution: {integrity: sha512-lxZw1EtfRd4vmcPm9bJgWCisIce4TJ4pPYKydM2r0XvQBpTw7epO2hjuMRaaeg30xf3JUmaTls5GhWjZ4q82nQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dnd: '>=14.0.0'
-      react-dnd-html5-backend: '>=14.0.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-headless': 16.9.1_m5fheiiqhtf5rhj4yydfkmxpb4
-      '@udecode/plate-styled-components': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-alignment': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-block-quote': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-button': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-code-block': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-combobox': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-cursor': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-dnd': 16.8.0_m3il3u2zkyh55i2vrix3m3uu7i
-      '@udecode/plate-ui-find-replace': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-font': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-line-height': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-link': 16.9.1_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-list': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-media': 16.9.1_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-mention': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-placeholder': 16.8.0_3u2a2wscqng4lreiczswztzzfe
-      '@udecode/plate-ui-table': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      '@udecode/plate-ui-toolbar': 16.8.0_jbz7ghep6wjhxqiau5fvi2yqxy
-      react: 17.0.2
-      react-dnd: 15.1.2_smc5esni47gpbltvxzeziduyte
-      react-dnd-html5-backend: 15.1.3
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-hyperscript: 0.77.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - supports-color
       - valtio
       - wonka
       - xstate
@@ -10780,45 +7953,6 @@ packages:
       - '@urql/core'
       - immer
       - optics-ts
-      - react-is
-      - react-native
-      - scheduler
-      - supports-color
-      - valtio
-      - wonka
-      - xstate
-    dev: false
-
-  /@udecode/plate/16.9.1_3applnbcmonz6yjsxb2hv5truu:
-    resolution: {integrity: sha512-Gs4atVprE+Y3xaY17fTkeN1SSjHAfowmoDbVR+jLLA8DpdG67/qNUVdIJNO81dLBsi9DMKffqi/eMwAuFf6GsQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.79.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-headless': 16.9.1_m5fheiiqhtf5rhj4yydfkmxpb4
-      '@udecode/plate-ui': 16.9.1_3applnbcmonz6yjsxb2hv5truu
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-hyperscript: 0.77.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@urql/core'
-      - immer
-      - optics-ts
-      - react-dnd
-      - react-dnd-html5-backend
       - react-is
       - react-native
       - scheduler
@@ -11215,36 +8349,6 @@ packages:
       xstate: 4.28.1
     dev: false
 
-  /@xstate/immer/0.3.1_immer@9.0.12+xstate@4.32.0:
-    resolution: {integrity: sha512-YE+KY08IjEEmXo6XKKpeSGW4j9LfcXw+5JVixLLUO3fWQ3M95joWJ40VtGzx0w0zQSzoCNk8NgfvwWBGSbIaTA==}
-    peerDependencies:
-      immer: ^9.0.6
-      xstate: ^4.29.0
-    dependencies:
-      immer: 9.0.12
-      xstate: 4.32.0
-    dev: false
-
-  /@xstate/react/1.6.3_3u7fm7vqjqg5ddhec34i275fya:
-    resolution: {integrity: sha512-NCUReRHPGvvCvj2yLZUTfR0qVp6+apc8G83oXSjN4rl89ZjyujiKrTff55bze/HrsvCsP/sUJASf2n0nzMF1KQ==}
-    peerDependencies:
-      '@xstate/fsm': ^1.0.0
-      react: ^16.8.0 || ^17.0.0
-      xstate: ^4.11.0
-    peerDependenciesMeta:
-      '@xstate/fsm':
-        optional: true
-      xstate:
-        optional: true
-    dependencies:
-      react: 17.0.2
-      use-isomorphic-layout-effect: 1.1.2_pxzommwrsowkd4kgag6q3sluym
-      use-subscription: 1.7.0_react@17.0.2
-      xstate: 4.32.0
-    transitivePeerDependencies:
-      - '@types/react'
-    dev: false
-
   /@xstate/react/1.6.3_gcyz5mxmyrgibkcjljkbjmosn4:
     resolution: {integrity: sha512-NCUReRHPGvvCvj2yLZUTfR0qVp6+apc8G83oXSjN4rl89ZjyujiKrTff55bze/HrsvCsP/sUJASf2n0nzMF1KQ==}
     peerDependencies:
@@ -11559,19 +8663,6 @@ packages:
   /axe-core/4.4.2:
     resolution: {integrity: sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==}
     engines: {node: '>=12'}
-    dev: false
-
-  /babel-plugin-styled-components/2.0.7_styled-components@5.3.5:
-    resolution: {integrity: sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==}
-    peerDependencies:
-      styled-components: '>= 2'
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-module-imports': 7.18.6
-      babel-plugin-syntax-jsx: 6.18.0
-      lodash: 4.17.21
-      picomatch: 2.3.1
-      styled-components: 5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um
     dev: false
 
   /babel-plugin-styled-components/2.0.7_styled-components@5.3.6:
@@ -11922,10 +9013,6 @@ packages:
       delayed-stream: 1.0.0
     dev: true
 
-  /comma-separated-tokens/1.0.8:
-    resolution: {integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==}
-    dev: false
-
   /commander/2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     requiresBuild: true
@@ -12127,11 +9214,6 @@ packages:
       assert-plus: 1.0.0
     dev: true
 
-  /date-fns/2.28.0:
-    resolution: {integrity: sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==}
-    engines: {node: '>=0.11'}
-    dev: false
-
   /date-fns/2.29.3:
     resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
     engines: {node: '>=0.11'}
@@ -12282,14 +9364,6 @@ packages:
       redux: 4.2.0
     dev: false
 
-  /dnd-core/15.1.2:
-    resolution: {integrity: sha512-EOec1LyJUuGRFg0LDa55rSRAUe97uNVKVkUo8iyvzQlcECYTuPblVQfRWXWj1OyPseFIeebWpNmKFy0h6BcF1A==}
-    dependencies:
-      '@react-dnd/asap': 4.0.1
-      '@react-dnd/invariant': 3.0.1
-      redux: 4.2.0
-    dev: false
-
   /dnd-core/16.0.1:
     resolution: {integrity: sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==}
     dependencies:
@@ -12315,7 +9389,7 @@ packages:
   /dom-helpers/3.4.0:
     resolution: {integrity: sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==}
     dependencies:
-      '@babel/runtime': 7.17.9
+      '@babel/runtime': 7.20.1
     dev: false
 
   /dom-serializer/1.4.1:
@@ -12377,7 +9451,7 @@ packages:
     peerDependencies:
       react: '>=16.12.0'
     dependencies:
-      '@babel/runtime': 7.17.9
+      '@babel/runtime': 7.20.1
       compute-scroll-into-view: 1.0.17
       prop-types: 15.8.1
       react: 17.0.2
@@ -13388,12 +10462,6 @@ packages:
     dependencies:
       reusify: 1.0.4
 
-  /fault/1.0.4:
-    resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
-    dependencies:
-      format: 0.2.2
-    dev: false
-
   /fd-slicer/1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
     dependencies:
@@ -13486,11 +10554,6 @@ packages:
       mime-types: 2.1.35
     dev: true
 
-  /format/0.2.2:
-    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
-    engines: {node: '>=0.4.x'}
-    dev: false
-
   /forwarded/0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -13502,24 +10565,6 @@ packages:
 
   /framer-motion/6.4.3_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-prcyOGFkGjwGEgbxObIWteVz1ihuWaDLdR03626cbA1GxTaPRpLb8ioJfWPmP5mwcWC7TlhMOjS5kBYnuiktFA==}
-    peerDependencies:
-      react: '>=16.8 || ^17.0.0 || ^18.0.0'
-      react-dom: '>=16.8 || ^17.0.0 || ^18.0.0'
-    dependencies:
-      '@motionone/dom': 10.12.0
-      framesync: 6.0.1
-      hey-listen: 1.0.8
-      popmotion: 11.0.3
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      style-value-types: 5.0.0
-      tslib: 2.4.0
-    optionalDependencies:
-      '@emotion/is-prop-valid': 0.8.8
-    dev: false
-
-  /framer-motion/6.5.1_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==}
     peerDependencies:
       react: '>=16.8 || ^17.0.0 || ^18.0.0'
       react-dom: '>=16.8 || ^17.0.0 || ^18.0.0'
@@ -13781,20 +10826,6 @@ packages:
     dependencies:
       function-bind: 1.1.1
 
-  /hast-util-parse-selector/2.2.5:
-    resolution: {integrity: sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==}
-    dev: false
-
-  /hastscript/6.0.0:
-    resolution: {integrity: sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==}
-    dependencies:
-      '@types/hast': 2.3.4
-      comma-separated-tokens: 1.0.8
-      hast-util-parse-selector: 2.2.5
-      property-information: 5.6.0
-      space-separated-tokens: 1.1.5
-    dev: false
-
   /he/1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
@@ -13806,10 +10837,6 @@ packages:
 
   /hey-listen/1.0.8:
     resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
-    dev: false
-
-  /highlight.js/10.7.3:
-    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
     dev: false
 
   /hoist-non-react-statics/3.3.2:
@@ -13979,15 +11006,6 @@ packages:
       '@formatjs/ecma402-abstract': 1.13.0
       '@formatjs/fast-memoize': 1.2.6
       '@formatjs/icu-messageformat-parser': 2.1.10
-      tslib: 2.4.0
-    dev: false
-
-  /intl-messageformat/9.13.0:
-    resolution: {integrity: sha512-7sGC7QnSQGa5LZP7bXLDhVDtQOeKGeBFGHF2Y8LVBwYZoQZCgWeKoPGTa5GMG8g/TzDgeXuYJQis7Ggiw2xTOw==}
-    dependencies:
-      '@formatjs/ecma402-abstract': 1.11.4
-      '@formatjs/fast-memoize': 1.2.1
-      '@formatjs/icu-messageformat-parser': 2.1.0
       tslib: 2.4.0
     dev: false
 
@@ -14299,46 +11317,6 @@ packages:
       xstate: 4.28.1
     dev: false
 
-  /jotai/1.8.4_bbxtl6ryvenc2jc6uyz5mlvgwe:
-    resolution: {integrity: sha512-bkHDHNxm7bU4+bJL4z96fTlJYN34UDRTu3ghEajJrDepayON9YEaxPrXr7xhLnIRntoFC6eDYYhMNA/ilbj2RQ==}
-    engines: {node: '>=12.7.0'}
-    peerDependencies:
-      '@babel/core': '*'
-      '@babel/template': '*'
-      '@tanstack/query-core': '*'
-      '@urql/core': '*'
-      immer: '*'
-      optics-ts: '*'
-      react: '>=16.8'
-      valtio: '*'
-      wonka: '*'
-      xstate: '*'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@babel/template':
-        optional: true
-      '@tanstack/query-core':
-        optional: true
-      '@urql/core':
-        optional: true
-      immer:
-        optional: true
-      optics-ts:
-        optional: true
-      valtio:
-        optional: true
-      wonka:
-        optional: true
-      xstate:
-        optional: true
-    dependencies:
-      '@babel/core': 7.20.2
-      immer: 9.0.12
-      react: 17.0.2
-      xstate: 4.32.0
-    dev: false
-
   /jotai/1.8.4_iskeb5babgxc5jvzp4zlrgistu:
     resolution: {integrity: sha512-bkHDHNxm7bU4+bJL4z96fTlJYN34UDRTu3ghEajJrDepayON9YEaxPrXr7xhLnIRntoFC6eDYYhMNA/ilbj2RQ==}
     engines: {node: '>=12.7.0'}
@@ -14633,13 +11611,6 @@ packages:
     dependencies:
       get-func-name: 2.0.0
     dev: true
-
-  /lowlight/1.20.0:
-    resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
-    dependencies:
-      fault: 1.0.4
-      highlight.js: 10.7.3
-    dev: false
 
   /lru-cache/6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -15707,11 +12678,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /prismjs/1.27.0:
-    resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
-    engines: {node: '>=6'}
-    dev: false
-
   /prismjs/1.28.0:
     resolution: {integrity: sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==}
     engines: {node: '>=6'}
@@ -15742,12 +12708,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-
-  /property-information/5.6.0:
-    resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
-    dependencies:
-      xtend: 4.0.2
-    dev: false
 
   /proxy-addr/2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -15820,16 +12780,6 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /react-colorful/5.5.1_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-    dependencies:
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-    dev: false
-
   /react-colorful/5.6.1_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
     peerDependencies:
@@ -15838,22 +12788,6 @@ packages:
     dependencies:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-    dev: false
-
-  /react-datepicker/4.7.0_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-FS8KgbwqpxmJBv/bUdA42MYqYZa+fEYcpc746DZiHvVE2nhjrW/dg7c5B5fIUuI8gZET6FOzuDgezNcj568Czw==}
-    peerDependencies:
-      react: ^16.9.0 || ^17
-      react-dom: ^16.9.0 || ^17
-    dependencies:
-      '@popperjs/core': 2.11.5
-      classnames: 2.3.1
-      date-fns: 2.28.0
-      prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      react-onclickoutside: 6.12.1_sfoxds7t5ydpegc3knd667wn6m
-      react-popper: 2.3.0_kz2vxbzpsgxv356x2ucg6oykdm
     dev: false
 
   /react-datepicker/4.8.0_sfoxds7t5ydpegc3knd667wn6m:
@@ -15878,41 +12812,10 @@ packages:
       dnd-core: 15.1.1
     dev: false
 
-  /react-dnd-html5-backend/15.1.3:
-    resolution: {integrity: sha512-HH/8nOEmrrcRGHMqJR91FOwhnLlx5SRLXmsQwZT3IPcBjx88WT+0pWC5A4tDOYDdoooh9k+KMPvWfxooR5TcOA==}
-    dependencies:
-      dnd-core: 15.1.2
-    dev: false
-
   /react-dnd-html5-backend/16.0.1:
     resolution: {integrity: sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==}
     dependencies:
       dnd-core: 16.0.1
-    dev: false
-
-  /react-dnd/15.1.2_smc5esni47gpbltvxzeziduyte:
-    resolution: {integrity: sha512-EaSbMD9iFJDY/o48T3c8wn3uWU+2uxfFojhesZN3LhigJoAIvH2iOjxofSA9KbqhAKP6V9P853G6XG8JngKVtA==}
-    peerDependencies:
-      '@types/hoist-non-react-statics': '>= 3.3.1'
-      '@types/node': '>= 12'
-      '@types/react': '>= 16'
-      react: '>= 16.14'
-    peerDependenciesMeta:
-      '@types/hoist-non-react-statics':
-        optional: true
-      '@types/node':
-        optional: true
-      '@types/react':
-        optional: true
-    dependencies:
-      '@react-dnd/invariant': 3.0.1
-      '@react-dnd/shallowequal': 3.0.1
-      '@types/node': 18.7.21
-      '@types/react': 17.0.50
-      dnd-core: 15.1.2
-      fast-deep-equal: 3.1.3
-      hoist-non-react-statics: 3.3.2
-      react: 17.0.2
     dev: false
 
   /react-dnd/16.0.1_pxzommwrsowkd4kgag6q3sluym:
@@ -16029,10 +12932,6 @@ packages:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
     dev: false
 
-  /react-is/18.1.0:
-    resolution: {integrity: sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==}
-    dev: false
-
   /react-is/18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: false
@@ -16045,20 +12944,6 @@ packages:
     dependencies:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-    dev: false
-
-  /react-popper/2.3.0_kz2vxbzpsgxv356x2ucg6oykdm:
-    resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
-    peerDependencies:
-      '@popperjs/core': ^2.0.0
-      react: ^16.8.0 || ^17 || ^18
-      react-dom: ^16.8.0 || ^17 || ^18
-    dependencies:
-      '@popperjs/core': 2.11.5
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      react-fast-compare: 3.2.0
-      warning: 4.0.3
     dev: false
 
   /react-popper/2.3.0_vov5yimr6vvxyufd6uigwwkst4:
@@ -16087,33 +12972,6 @@ packages:
       invariant: 2.2.4
       shallowequal: 1.1.0
       throttle-debounce: 3.0.1
-    dev: false
-
-  /react-syntax-highlighter/15.5.0_react@17.0.2:
-    resolution: {integrity: sha512-+zq2myprEnQmH5yw6Gqc8lD55QHnpKaU8TOcFeC/Lg/MQSs8UknEA0JC4nTZGFAXC2J2Hyj/ijJ7NlabyPi2gg==}
-    peerDependencies:
-      react: '>= 0.14.0'
-    dependencies:
-      '@babel/runtime': 7.17.9
-      highlight.js: 10.7.3
-      lowlight: 1.20.0
-      prismjs: 1.28.0
-      react: 17.0.2
-      refractor: 3.6.0
-    dev: false
-
-  /react-textarea-autosize/8.3.4_pxzommwrsowkd4kgag6q3sluym:
-    resolution: {integrity: sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.17.9
-      react: 17.0.2
-      use-composed-ref: 1.3.0_react@17.0.2
-      use-latest: 1.2.1_pxzommwrsowkd4kgag6q3sluym
-    transitivePeerDependencies:
-      - '@types/react'
     dev: false
 
   /react-textarea-autosize/8.4.0_pxzommwrsowkd4kgag6q3sluym:
@@ -16271,15 +13129,7 @@ packages:
   /redux/4.2.0:
     resolution: {integrity: sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==}
     dependencies:
-      '@babel/runtime': 7.17.9
-    dev: false
-
-  /refractor/3.6.0:
-    resolution: {integrity: sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==}
-    dependencies:
-      hastscript: 6.0.0
-      parse-entities: 2.0.0
-      prismjs: 1.27.0
+      '@babel/runtime': 7.20.1
     dev: false
 
   /regenerator-runtime/0.13.10:
@@ -16436,7 +13286,7 @@ packages:
   /rtl-css-js/1.15.0:
     resolution: {integrity: sha512-99Cu4wNNIhrI10xxUaABHsdDqzalrSRTie4GeCmbGVuehm4oj+fIy8fTzB+16pmKe8Bv9rl+hxIBez6KxExTew==}
     dependencies:
-      '@babel/runtime': 7.17.9
+      '@babel/runtime': 7.20.1
     dev: false
 
   /run-async/2.4.1:
@@ -16681,10 +13531,6 @@ packages:
   /sourcemap-codec/1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
 
-  /space-separated-tokens/1.1.5:
-    resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
-    dev: false
-
   /spdx-correct/3.1.1:
     resolution: {integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==}
     dependencies:
@@ -16866,30 +13712,6 @@ packages:
     dependencies:
       hey-listen: 1.0.8
       tslib: 2.4.0
-    dev: false
-
-  /styled-components/5.3.5_ukrbqhh2t6r2q67fyfhmpyy5um:
-    resolution: {integrity: sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==}
-    engines: {node: '>=10'}
-    requiresBuild: true
-    peerDependencies:
-      react: '>= 16.8.0'
-      react-dom: '>= 16.8.0'
-      react-is: '>= 16.8.0'
-    dependencies:
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/traverse': 7.20.1_supports-color@5.5.0
-      '@emotion/is-prop-valid': 1.1.2
-      '@emotion/stylis': 0.8.5
-      '@emotion/unitless': 0.7.5
-      babel-plugin-styled-components: 2.0.7_styled-components@5.3.5
-      css-to-react-native: 3.0.0
-      hoist-non-react-statics: 3.3.2
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      react-is: 18.1.0
-      shallowequal: 1.1.0
-      supports-color: 5.5.0
     dev: false
 
   /styled-components/5.3.6_v5ja746gkdtknuc6tj46sve3be:
@@ -17145,7 +13967,7 @@ packages:
   /tippy.js/6.3.7:
     resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
     dependencies:
-      '@popperjs/core': 2.11.5
+      '@popperjs/core': 2.11.6
     dev: false
 
   /tmp/0.0.33:
@@ -17886,10 +14708,6 @@ packages:
 
   /xstate/4.28.1:
     resolution: {integrity: sha512-0xvaegeZNeHJAJvpjznyNr91qB1xy1PqeYMDyknh5S23TBPQJUHS81hk8W3UcvnB9uNs0YmOU2daoqb3WegzYQ==}
-    dev: false
-
-  /xstate/4.32.0:
-    resolution: {integrity: sha512-62gETqwnw4pBRe+tVWMt8hLgWEU8lq2qO8VN5PWmTELceRVt3I1bu1cwdraVRHUn4Bb2lnhNzn1A73oShuC+8g==}
     dev: false
 
   /xtend/4.0.2:


### PR DESCRIPTION
- Update all packages to fondue beta 25
- Quote block: replace deprecated `actions` with `plugins` in RTE