### PR TITLE
feat(QuoteBlock): only save changed setting

### DIFF
--- a/packages/quote-block/src/QuoteBlock.tsx
+++ b/packages/quote-block/src/QuoteBlock.tsx
@@ -68,7 +68,7 @@ export const QuoteBlock: FC<Props> = ({ appBridge }) => {
     const showAuthor = blockSettings.showAuthor && blockSettings.authorName;
     const sizeValue = blockSettings.sizeValue || quoteSizeMap[QuoteSize.LargeSize];
 
-    const onChangeContent = (value: string) => setBlockSettings({ ...blockSettings, content: value });
+    const onChangeContent = (value: string) => setBlockSettings({ content: value });
 
     const getWrapperClasses = () => {
         if (isFullWidth) {


### PR DESCRIPTION
Only save `content` instead of all settings.

Related PRs:
- https://github.com/Frontify/clarify/pull/12413
- https://github.com/Frontify/app-bridge/pull/262