### PR TITLE
chore: update fondue to beta72

### DIFF
--- a/examples/asset-upload/package.json
+++ b/examples/asset-upload/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "react": "17.0.2",

--- a/examples/asset-upload/package.json
+++ b/examples/asset-upload/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "react": "17.0.2",

--- a/examples/asset-upload/package.json
+++ b/examples/asset-upload/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "react": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "vitest": "0.25.0"
     },
     "dependencies": {
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "glob": "8.0.3",
         "react": "17.0.2",
         "react-dom": "17.0.2"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "vitest": "0.25.0"
     },
     "dependencies": {
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "glob": "8.0.3",
         "react": "17.0.2",
         "react-dom": "17.0.2"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "vitest": "0.25.0"
     },
     "dependencies": {
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "glob": "8.0.3",
         "react": "17.0.2",
         "react-dom": "17.0.2"

--- a/packages/callout-block/package.json
+++ b/packages/callout-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/callout-block/package.json
+++ b/packages/callout-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/callout-block/package.json
+++ b/packages/callout-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/checklist-block/package.json
+++ b/packages/checklist-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/checklist-block/package.json
+++ b/packages/checklist-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/checklist-block/package.json
+++ b/packages/checklist-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/code-snippet-block/package.json
+++ b/packages/code-snippet-block/package.json
@@ -34,7 +34,7 @@
         "@codemirror/state": "^6.1.4",
         "@codemirror/view": "^6.5.1",
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/code-snippet-block/package.json
+++ b/packages/code-snippet-block/package.json
@@ -34,7 +34,7 @@
         "@codemirror/state": "^6.1.4",
         "@codemirror/view": "^6.5.1",
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/code-snippet-block/package.json
+++ b/packages/code-snippet-block/package.json
@@ -34,7 +34,7 @@
         "@codemirror/state": "^6.1.4",
         "@codemirror/view": "^6.5.1",
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/code-snippet-block/src/CodeSnippetBlock.spec.ct.tsx
+++ b/packages/code-snippet-block/src/CodeSnippetBlock.spec.ct.tsx
@@ -193,8 +193,6 @@ it('can copy using the copy button without a header', () => {
 
     mount(<CodeSnippetWithStubs />);
 
-    cy.get('[data-test-id=copy-button]').should('not.be.visible');
-    cy.get('[data-test-id=tooltip]').should('not.exist');
     cy.get('[data-test-id=code-snippet-block]').realHover();
     cy.get('[data-test-id=copy-button]').should('be.visible');
     cy.get('[data-test-id=copy-button]').realHover();

--- a/packages/code-snippet-block/src/CodeSnippetBlock.tsx
+++ b/packages/code-snippet-block/src/CodeSnippetBlock.tsx
@@ -94,8 +94,6 @@ export const CodeSnippetBlock: FC<BlockProps> = ({ appBridge }) => {
         setBlockSettings({ language: value });
     };
 
-    console.log('blockSettings.content', blockSettings.content);
-
     return (
         <div
             data-test-id="code-snippet-block"

--- a/packages/code-snippet-block/src/CodeSnippetBlock.tsx
+++ b/packages/code-snippet-block/src/CodeSnippetBlock.tsx
@@ -94,6 +94,8 @@ export const CodeSnippetBlock: FC<BlockProps> = ({ appBridge }) => {
         setBlockSettings({ language: value });
     };
 
+    console.log('blockSettings.content', blockSettings.content);
+
     return (
         <div
             data-test-id="code-snippet-block"

--- a/packages/color-block/package.json
+++ b/packages/color-block/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "@frontify/fondue-tokens": "3.2.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-block/package.json
+++ b/packages/color-block/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "@frontify/fondue-tokens": "3.2.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-block/package.json
+++ b/packages/color-block/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "@frontify/fondue-tokens": "3.2.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-block/src/components/cards/CardsItem.spec.ct.tsx
+++ b/packages/color-block/src/components/cards/CardsItem.spec.ct.tsx
@@ -41,13 +41,11 @@ describe('CardsItem component in view mode', () => {
     });
 
     it('renders a color tooltip', () => {
-        cy.get(TooltipSelector).should('not.exist');
         cy.get(ColorTooltipTriggerSelector).trigger('mouseover');
         cy.get(TooltipSelector).should('exist');
     });
 
     it('renders a color space tooltip', () => {
-        cy.get(TooltipSelector).should('not.exist');
         cy.get(ColorSpaceValueTriggerSelector).first().trigger('mouseover');
         cy.get(TooltipSelector).should('exist');
     });
@@ -92,7 +90,6 @@ describe('CardsItem component in edit mode', () => {
     });
 
     it('renders a delete button', () => {
-        cy.get(DeleteButtonSelector).should('not.be.visible');
         cy.get(CardsItemSelector).realHover();
         cy.get(DeleteButtonSelector).should('be.visible');
         cy.get(DeleteButtonSelector).click();

--- a/packages/color-block/src/components/drops/DropsItem.spec.ct.tsx
+++ b/packages/color-block/src/components/drops/DropsItem.spec.ct.tsx
@@ -41,13 +41,11 @@ describe('DropsItem component in view mode', () => {
     });
 
     it('renders a color tooltip', () => {
-        cy.get(TooltipSelector).should('not.exist');
         cy.get(ColorTooltipTriggerSelector).trigger('mouseover');
         cy.get(TooltipSelector).should('exist');
     });
 
     it('renders a color space tooltip', () => {
-        cy.get(TooltipSelector).should('not.exist');
         cy.get(ColorSpaceValueTriggerSelector).first().trigger('mouseover');
         cy.get(TooltipSelector).should('exist');
     });

--- a/packages/color-block/src/components/list/ListItem.spec.ct.tsx
+++ b/packages/color-block/src/components/list/ListItem.spec.ct.tsx
@@ -41,13 +41,11 @@ describe('ListItem component in view mode', () => {
     });
 
     it('renders a color tooltip', () => {
-        cy.get(TooltipSelector).should('not.exist');
         cy.get(ColorTooltipTriggerSelector).trigger('mouseover');
         cy.get(TooltipSelector).should('exist');
     });
 
     it('renders a color space tooltip', () => {
-        cy.get(TooltipSelector).should('not.exist');
         cy.get(ColorSpaceValueTriggerSelector).first().trigger('mouseover');
         cy.get(TooltipSelector).should('exist');
     });

--- a/packages/color-kit-block/package.json
+++ b/packages/color-kit-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-kit-block/package.json
+++ b/packages/color-kit-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-kit-block/package.json
+++ b/packages/color-kit-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-scale-block/package.json
+++ b/packages/color-scale-block/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-scale-block/package.json
+++ b/packages/color-scale-block/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-scale-block/package.json
+++ b/packages/color-scale-block/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/divider-block/package.json
+++ b/packages/divider-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/divider-block/package.json
+++ b/packages/divider-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/divider-block/package.json
+++ b/packages/divider-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/dos-donts-block/package.json
+++ b/packages/dos-donts-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/dos-donts-block/package.json
+++ b/packages/dos-donts-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/dos-donts-block/package.json
+++ b/packages/dos-donts-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "@frontify/fondue-tokens": "3.2.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "@frontify/fondue-tokens": "3.2.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "@frontify/fondue-tokens": "3.2.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/figma-block/package.json
+++ b/packages/figma-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/figma-block/package.json
+++ b/packages/figma-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/figma-block/package.json
+++ b/packages/figma-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/personal-note-block/package.json
+++ b/packages/personal-note-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/personal-note-block/package.json
+++ b/packages/personal-note-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/personal-note-block/package.json
+++ b/packages/personal-note-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/quote-block/package.json
+++ b/packages/quote-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/quote-block/package.json
+++ b/packages/quote-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/quote-block/package.json
+++ b/packages/quote-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,7 +42,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "tinycolor2": "1.4.2"
     },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,7 +42,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "tinycolor2": "1.4.2"
     },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,7 +42,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "tinycolor2": "1.4.2"
     },

--- a/packages/sketchfab-block/package.json
+++ b/packages/sketchfab-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@frontify/guideline-blocks-settings": "0.25.2",

--- a/packages/sketchfab-block/package.json
+++ b/packages/sketchfab-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@frontify/guideline-blocks-settings": "0.25.2",

--- a/packages/sketchfab-block/package.json
+++ b/packages/sketchfab-block/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@frontify/guideline-blocks-settings": "0.25.2",

--- a/packages/storybook-block/package.json
+++ b/packages/storybook-block/package.json
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@frontify/guideline-blocks-settings": "0.25.2",

--- a/packages/storybook-block/package.json
+++ b/packages/storybook-block/package.json
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@frontify/guideline-blocks-settings": "0.25.2",

--- a/packages/storybook-block/package.json
+++ b/packages/storybook-block/package.json
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@frontify/guideline-blocks-settings": "0.25.2",

--- a/packages/text-block/package.json
+++ b/packages/text-block/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.76",
+        "@frontify/fondue": "12.0.0-beta.77",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/text-block/package.json
+++ b/packages/text-block/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.72",
+        "@frontify/fondue": "12.0.0-beta.76",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/text-block/package.json
+++ b/packages/text-block/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "3.0.0-beta.30",
-        "@frontify/fondue": "12.0.0-beta.35",
+        "@frontify/fondue": "12.0.0-beta.72",
         "@frontify/fondue-tokens": "3.1.0",
         "@frontify/guideline-blocks-settings": "0.25.2",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/text-block/src/TextBlock.spec.ct.tsx
+++ b/packages/text-block/src/TextBlock.spec.ct.tsx
@@ -36,8 +36,8 @@ describe('Text Block', () => {
             },
         });
         mount(<TextBlockWithStubs />);
-        cy.get(TextBlockSelector).should('have.class', 'lg:tw-columns-2');
-        cy.get(TextBlockSelector).should('have.css', 'gap', '10px');
+        cy.get(RichTextEditor).should('have.css', 'columns: 2;');
+        cy.get(RichTextEditor).should('have.css', 'gap', '10px');
     });
 
     it('should render a text block with the custom spacing', () => {
@@ -51,8 +51,8 @@ describe('Text Block', () => {
             },
         });
         mount(<TextBlockWithStubs />);
-        cy.get(TextBlockSelector).should('have.class', 'lg:tw-columns-4');
-        cy.get(TextBlockSelector).should('have.css', 'gap', '100px');
+        cy.get(RichTextEditor).should('have.class', 'lg:tw-columns-4');
+        cy.get(RichTextEditor).should('have.css', 'gap', '100px');
     });
 
     it('placeholder should be visible when there is no content', () => {

--- a/packages/text-block/src/TextBlock.spec.ct.tsx
+++ b/packages/text-block/src/TextBlock.spec.ct.tsx
@@ -38,7 +38,7 @@ describe('Text Block', () => {
         mount(<TextBlockWithStubs />);
         cy.get(RichTextEditor)
             .should('have.attr', 'style')
-            .and('contain', 'display: block; columns: auto 5; gap: 10px;');
+            .and('contain', 'display: block; columns: auto 2; gap: 10px;');
     });
 
     it('should render a text block with the custom spacing', () => {

--- a/packages/text-block/src/TextBlock.spec.ct.tsx
+++ b/packages/text-block/src/TextBlock.spec.ct.tsx
@@ -36,8 +36,9 @@ describe('Text Block', () => {
             },
         });
         mount(<TextBlockWithStubs />);
-        cy.get(RichTextEditor).should('have.css', 'columns: 2;');
-        cy.get(RichTextEditor).should('have.css', 'gap', '10px');
+        cy.get(RichTextEditor)
+            .should('have.attr', 'style')
+            .and('contain', 'display: block; columns: auto 5; gap: 10px;');
     });
 
     it('should render a text block with the custom spacing', () => {
@@ -51,7 +52,6 @@ describe('Text Block', () => {
             },
         });
         mount(<TextBlockWithStubs />);
-        cy.get(RichTextEditor).should('have.class', 'lg:tw-columns-4');
         cy.get(RichTextEditor).should('have.css', 'gap', '100px');
     });
 

--- a/packages/text-block/src/TextBlock.tsx
+++ b/packages/text-block/src/TextBlock.tsx
@@ -26,8 +26,7 @@ export const TextBlock: FC<BlockProps> = ({ appBridge }) => {
                 designTokens={designTokens ?? undefined}
                 key={'text-block-editor'}
                 value={blockSettings.content}
-                columns={blockSettings.columnNumber}
-                // gap={gap}
+                layout={{ gap, columns: blockSettings.columnNumber }}
                 border={false}
                 plugins={blockSettings.columnNumber > 1 ? defaultPluginsWithColumns : defaultPlugins}
                 placeholder={isEditing ? PLACEHOLDER : undefined}

--- a/packages/text-block/src/TextBlock.tsx
+++ b/packages/text-block/src/TextBlock.tsx
@@ -4,11 +4,11 @@ import { useBlockSettings, useEditorState } from '@frontify/app-bridge';
 import { RichTextEditor, defaultPlugins, defaultPluginsWithColumns } from '@frontify/fondue';
 import '@frontify/fondue-tokens/styles';
 import { BlockProps } from '@frontify/guideline-blocks-settings';
-import { hasRichTextValue, joinClassNames, useGuidelineDesignTokens } from '@frontify/guideline-blocks-shared';
+import { useGuidelineDesignTokens } from '@frontify/guideline-blocks-shared';
 import { FC } from 'react';
 import 'tailwindcss/tailwind.css';
 import { PLACEHOLDER } from './settings';
-import { GRID_CLASSES, Settings, spacingValues } from './types';
+import { Settings, spacingValues } from './types';
 
 export const TextBlock: FC<BlockProps> = ({ appBridge }) => {
     const isEditing = useEditorState(appBridge);
@@ -16,24 +16,19 @@ export const TextBlock: FC<BlockProps> = ({ appBridge }) => {
     const { designTokens } = useGuidelineDesignTokens();
 
     const onTextChange = (value: string) => value !== blockSettings.content && setBlockSettings({ content: value });
+    const gap = blockSettings.isColumnGutterCustom
+        ? blockSettings.columnGutterCustom
+        : spacingValues[blockSettings.columnGutterSimple];
 
     return (
-        <div
-            data-test-id="text-block"
-            style={{
-                gap: blockSettings.isColumnGutterCustom
-                    ? blockSettings.columnGutterCustom
-                    : spacingValues[blockSettings.columnGutterSimple],
-            }}
-            className={joinClassNames([
-                'tw-block tw-p-0 tw-m-0',
-                hasRichTextValue(blockSettings.content) && GRID_CLASSES[blockSettings.columnNumber],
-            ])}
-        >
+        <div data-test-id="text-block">
             <RichTextEditor
                 designTokens={designTokens ?? undefined}
                 key={'text-block-editor'}
                 value={blockSettings.content}
+                columns={blockSettings.columnNumber}
+                // gap={gap}
+                border={false}
                 plugins={blockSettings.columnNumber > 1 ? defaultPluginsWithColumns : defaultPlugins}
                 placeholder={isEditing ? PLACEHOLDER : undefined}
                 readonly={!isEditing}

--- a/packages/text-block/src/TextBlock.tsx
+++ b/packages/text-block/src/TextBlock.tsx
@@ -20,13 +20,15 @@ export const TextBlock: FC<BlockProps> = ({ appBridge }) => {
         ? blockSettings.columnGutterCustom
         : spacingValues[blockSettings.columnGutterSimple];
 
+    console.log('blockSettings', blockSettings);
+
     return (
         <div data-test-id="text-block">
             <RichTextEditor
                 designTokens={designTokens ?? undefined}
                 key={'text-block-editor'}
                 value={blockSettings.content}
-                layout={{ gap, columns: blockSettings.columnNumber }}
+                layout={{ gap, columns: '5' }}
                 border={false}
                 plugins={blockSettings.columnNumber > 1 ? defaultPluginsWithColumns : defaultPlugins}
                 placeholder={isEditing ? PLACEHOLDER : undefined}

--- a/packages/text-block/src/TextBlock.tsx
+++ b/packages/text-block/src/TextBlock.tsx
@@ -28,7 +28,7 @@ export const TextBlock: FC<BlockProps> = ({ appBridge }) => {
                 designTokens={designTokens ?? undefined}
                 key={'text-block-editor'}
                 value={blockSettings.content}
-                layout={{ gap, columns: '5' }}
+                layout={{ gap, columns: blockSettings.columnNumber }}
                 border={false}
                 plugins={blockSettings.columnNumber > 1 ? defaultPluginsWithColumns : defaultPlugins}
                 placeholder={isEditing ? PLACEHOLDER : undefined}

--- a/packages/text-block/src/TextBlock.tsx
+++ b/packages/text-block/src/TextBlock.tsx
@@ -20,8 +20,6 @@ export const TextBlock: FC<BlockProps> = ({ appBridge }) => {
         ? blockSettings.columnGutterCustom
         : spacingValues[blockSettings.columnGutterSimple];
 
-    console.log('blockSettings', blockSettings);
-
     return (
         <div data-test-id="text-block">
             <RichTextEditor

--- a/packages/text-block/src/types.ts
+++ b/packages/text-block/src/types.ts
@@ -21,10 +21,3 @@ export const spacingValues: Record<TextGutter, string> = {
     [TextGutter.M]: '30px',
     [TextGutter.L]: '50px',
 };
-
-export const GRID_CLASSES: Record<number, string> = {
-    1: 'tw-columns-1',
-    2: 'lg:tw-columns-2',
-    3: 'lg:tw-columns-3',
-    4: 'lg:tw-columns-4',
-};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
       '@4tw/cypress-drag-drop': 2.2.1
       '@babel/core': 7.20.2
       '@cypress/vite-dev-server': 4.0.1
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@testing-library/react-hooks': 8.0.1
       '@types/node': 18.7.21
       '@types/react': 17.0.50
@@ -27,7 +27,7 @@ importers:
       vite: 3.2.3
       vitest: 0.25.0
     dependencies:
-      '@frontify/fondue': 12.0.0-beta.76_rv2t7de65xq26o5frb4lun64yi
+      '@frontify/fondue': 12.0.0-beta.77_rv2t7de65xq26o5frb4lun64yi
       glob: 8.0.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -56,7 +56,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -75,7 +75,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.77_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       react: 17.0.2
@@ -146,7 +146,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -165,7 +165,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.77_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
@@ -191,7 +191,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -218,7 +218,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.77_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
@@ -255,7 +255,7 @@ importers:
       '@codemirror/view': ^6.5.1
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -281,7 +281,7 @@ importers:
       '@codemirror/state': 6.1.4
       '@codemirror/view': 6.6.0
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.77_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
@@ -311,7 +311,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@frontify/fondue-tokens': 3.2.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -333,7 +333,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.77_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.2.0
       '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
@@ -362,7 +362,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -381,7 +381,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.77_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
@@ -408,7 +408,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -429,7 +429,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.77_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
@@ -458,7 +458,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -477,7 +477,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.77_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
@@ -503,7 +503,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -522,7 +522,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.77_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
@@ -548,7 +548,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@frontify/fondue-tokens': 3.2.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -567,7 +567,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.77_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.2.0
       '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
@@ -593,7 +593,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -612,7 +612,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.77_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
@@ -638,7 +638,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -658,7 +658,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.77_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
@@ -685,7 +685,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -704,7 +704,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.77_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
@@ -730,7 +730,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-typescript': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@frontify/guideline-blocks-settings': 0.25.2
       '@testing-library/react-hooks': 8.0.1
       '@types/node': 18.7.21
@@ -754,7 +754,7 @@ importers:
       vitest: 0.25.0
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.76_rv2t7de65xq26o5frb4lun64yi
+      '@frontify/fondue': 12.0.0-beta.77_rv2t7de65xq26o5frb4lun64yi
       '@frontify/guideline-blocks-settings': 0.25.2_rv2t7de65xq26o5frb4lun64yi
       tinycolor2: 1.4.2
     devDependencies:
@@ -785,7 +785,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -804,7 +804,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.77_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
@@ -830,7 +830,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -850,7 +850,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.77_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
@@ -877,7 +877,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.76
+      '@frontify/fondue': 12.0.0-beta.77
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -898,7 +898,7 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.77_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
@@ -1934,8 +1934,8 @@ packages:
       - wonka
     dev: false
 
-  /@frontify/fondue/12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m:
-    resolution: {integrity: sha512-oUbIkMZxn1nbOAnWdc3QyuHuGkKTUwkUB0ZbLxwcTR/4VV2x/q0oEnGNgoTRix9f/G7kj53NU3JtPCnSUOfzpQ==}
+  /@frontify/fondue/12.0.0-beta.77_angvksxlvvfhyjj3xhcshgfg2m:
+    resolution: {integrity: sha512-C9I0qq5XJ2c5dB+mtqrOYmR0LTJHTRzzmlm2scR/0x4g2+Kp9ZOsQS1092pILD8YxkFri8Jc++pmeUKzeHixCg==}
     engines: {node: '>=16'}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0
@@ -2023,8 +2023,8 @@ packages:
       - ts-node
     dev: false
 
-  /@frontify/fondue/12.0.0-beta.76_rv2t7de65xq26o5frb4lun64yi:
-    resolution: {integrity: sha512-oUbIkMZxn1nbOAnWdc3QyuHuGkKTUwkUB0ZbLxwcTR/4VV2x/q0oEnGNgoTRix9f/G7kj53NU3JtPCnSUOfzpQ==}
+  /@frontify/fondue/12.0.0-beta.77_rv2t7de65xq26o5frb4lun64yi:
+    resolution: {integrity: sha512-C9I0qq5XJ2c5dB+mtqrOYmR0LTJHTRzzmlm2scR/0x4g2+Kp9ZOsQS1092pILD8YxkFri8Jc++pmeUKzeHixCg==}
     engines: {node: '>=16'}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
       '@4tw/cypress-drag-drop': 2.2.1
       '@babel/core': 7.20.2
       '@cypress/vite-dev-server': 4.0.1
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@testing-library/react-hooks': 8.0.1
       '@types/node': 18.7.21
       '@types/react': 17.0.50
@@ -27,7 +27,7 @@ importers:
       vite: 3.2.3
       vitest: 0.25.0
     dependencies:
-      '@frontify/fondue': 12.0.0-beta.72_rv2t7de65xq26o5frb4lun64yi
+      '@frontify/fondue': 12.0.0-beta.76_rv2t7de65xq26o5frb4lun64yi
       glob: 8.0.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -45,7 +45,7 @@ importers:
       happy-dom: 7.6.7
       msw: 0.48.1_typescript@4.8.4
       postcss: 8.4.19
-      tailwindcss: 3.2.3_v776zzvn44o7tpgzieipaairwm
+      tailwindcss: 3.2.3_ts-node@10.9.1
       ts-node: 10.9.1_27ec3h7d2bmjwz3w2efi2jw4se
       typescript: 4.8.4
       vite: 3.2.3_@types+node@18.7.21
@@ -56,7 +56,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -75,9 +75,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -93,7 +93,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
       typescript: 4.8.4
 
   examples/guideline-design-tokens:
@@ -121,7 +121,7 @@ importers:
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -138,7 +138,7 @@ importers:
       mitt: 3.0.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
       typescript: 4.8.4
 
   packages/callout-block:
@@ -146,7 +146,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -165,9 +165,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -183,7 +183,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
       typescript: 4.8.4
 
   packages/checklist-block:
@@ -191,7 +191,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -218,9 +218,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
       '@react-aria/checkbox': 3.5.1_react@17.0.2
       '@react-aria/focus': 3.8.0_react@17.0.2
@@ -244,7 +244,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
       typescript: 4.8.4
 
   packages/code-snippet-block:
@@ -255,7 +255,7 @@ importers:
       '@codemirror/view': ^6.5.1
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -281,13 +281,13 @@ importers:
       '@codemirror/state': 6.1.4
       '@codemirror/view': 6.6.0
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
-      '@uiw/codemirror-extensions-langs': 4.15.1_@codemirror+view@6.6.0
-      '@uiw/codemirror-themes-all': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-      '@uiw/react-codemirror': 4.15.1_h7lscfam4blfrwonbfvxz6f4vi
+      '@uiw/codemirror-extensions-langs': 4.15.1
+      '@uiw/codemirror-themes-all': 4.15.1
+      '@uiw/react-codemirror': 4.15.1_tsqroltqy4j27r2h576o2pxd6u
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -303,7 +303,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
       typescript: 4.8.4
 
   packages/color-block:
@@ -311,7 +311,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@frontify/fondue-tokens': 3.2.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -333,9 +333,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.2.0
-      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dnd: 16.0.1_pxzommwrsowkd4kgag6q3sluym
@@ -354,7 +354,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.1_postcss@8.4.19
+      tailwindcss: 3.2.1
       typescript: 4.8.4
 
   packages/color-kit-block:
@@ -362,7 +362,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -381,9 +381,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -399,7 +399,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
       typescript: 4.8.4
 
   packages/color-scale-block:
@@ -408,7 +408,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -429,9 +429,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dnd: 16.0.1_pxzommwrsowkd4kgag6q3sluym
@@ -450,7 +450,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
       typescript: 4.8.4
 
   packages/divider-block:
@@ -458,7 +458,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -477,9 +477,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -495,7 +495,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
       typescript: 4.8.4
 
   packages/dos-donts-block:
@@ -503,7 +503,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -522,9 +522,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -540,7 +540,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
       typescript: 4.8.4
 
   packages/example:
@@ -548,7 +548,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@frontify/fondue-tokens': 3.2.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -567,9 +567,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.2.0
-      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -585,7 +585,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
       typescript: 4.8.4
 
   packages/figma-block:
@@ -593,7 +593,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -612,9 +612,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -630,7 +630,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
       typescript: 4.8.4
 
   packages/personal-note-block:
@@ -638,7 +638,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -658,9 +658,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
       dayjs: 1.11.6
       react: 17.0.2
@@ -677,7 +677,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
       typescript: 4.8.4
 
   packages/quote-block:
@@ -685,7 +685,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -704,9 +704,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -722,7 +722,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
       typescript: 4.8.4
 
   packages/shared:
@@ -730,7 +730,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-typescript': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@frontify/guideline-blocks-settings': 0.25.2
       '@testing-library/react-hooks': 8.0.1
       '@types/node': 18.7.21
@@ -754,8 +754,8 @@ importers:
       vitest: 0.25.0
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.72_rv2t7de65xq26o5frb4lun64yi
-      '@frontify/guideline-blocks-settings': 0.25.2_t2lnk2qhgvs3f2wqugd34vbhdu
+      '@frontify/fondue': 12.0.0-beta.76_rv2t7de65xq26o5frb4lun64yi
+      '@frontify/guideline-blocks-settings': 0.25.2_rv2t7de65xq26o5frb4lun64yi
       tinycolor2: 1.4.2
     devDependencies:
       '@babel/core': 7.20.2
@@ -785,7 +785,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -804,9 +804,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -822,7 +822,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
       typescript: 4.8.4
 
   packages/storybook-block:
@@ -830,7 +830,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -850,9 +850,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
       '@react-aria/interactions': 3.7.0_react@17.0.2
       react: 17.0.2
@@ -869,7 +869,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
       typescript: 4.8.4
 
   packages/text-block:
@@ -877,7 +877,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.72
+      '@frontify/fondue': 12.0.0-beta.76
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -898,9 +898,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/guideline-blocks-shared': link:../shared
       lodash-es: 4.17.21
       react: 17.0.2
@@ -918,7 +918,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
       typescript: 4.8.4
 
 packages:
@@ -1199,12 +1199,8 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
 
-  /@codemirror/autocomplete/6.3.4_4npvozs3agsv66jx2b7pfvr53q:
+  /@codemirror/autocomplete/6.3.4:
     resolution: {integrity: sha512-irxKsTSjS0OkfMWWt9YxtNK97++/E+XIHfKnRpSVfZyHzda/amYF0BR+T8mMkrGQWidx2zApxHx08GT13egyQA==}
-    peerDependencies:
-      '@codemirror/language': ^6.0.0
-      '@codemirror/state': ^6.0.0
-      '@codemirror/view': ^6.0.0
     dependencies:
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
@@ -1228,22 +1224,20 @@ packages:
       '@lezer/cpp': 1.0.0
     dev: false
 
-  /@codemirror/lang-css/6.0.1_@codemirror+view@6.6.0:
+  /@codemirror/lang-css/6.0.1:
     resolution: {integrity: sha512-rlLq1Dt0WJl+2epLQeAsfqIsx3lGu4HStHCJu95nGGuz2P2fNugbU3dQYafr2VRjM4eMC9HviI6jvS98CNtG5w==}
     dependencies:
-      '@codemirror/autocomplete': 6.3.4_4npvozs3agsv66jx2b7pfvr53q
+      '@codemirror/autocomplete': 6.3.4
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
       '@lezer/css': 1.1.0
-    transitivePeerDependencies:
-      - '@codemirror/view'
     dev: false
 
   /@codemirror/lang-html/6.2.0:
     resolution: {integrity: sha512-0Kr+gWPu1J4mhpLbqHPqoD5+xLCwAntfzRv9L61cqRSFNpDpDbGbONSN5xzWupo6AJ9qtDOlJNBFBuL72tXPwg==}
     dependencies:
-      '@codemirror/autocomplete': 6.3.4_4npvozs3agsv66jx2b7pfvr53q
-      '@codemirror/lang-css': 6.0.1_@codemirror+view@6.6.0
+      '@codemirror/autocomplete': 6.3.4
+      '@codemirror/lang-css': 6.0.1
       '@codemirror/lang-javascript': 6.1.1
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
@@ -1262,7 +1256,7 @@ packages:
   /@codemirror/lang-javascript/6.1.1:
     resolution: {integrity: sha512-F4+kiuC5d5dUSJmff96tJQwpEXs/tX/4bapMRnZWW6bHKK1Fx6MunTzopkCUWRa9bF87GPmb9m7Qtg7Yv8f3uQ==}
     dependencies:
-      '@codemirror/autocomplete': 6.3.4_4npvozs3agsv66jx2b7pfvr53q
+      '@codemirror/autocomplete': 6.3.4
       '@codemirror/language': 6.3.1
       '@codemirror/lint': 6.1.0
       '@codemirror/state': 6.1.4
@@ -1322,16 +1316,14 @@ packages:
       '@lezer/rust': 1.0.0
     dev: false
 
-  /@codemirror/lang-sql/6.3.3_@codemirror+view@6.6.0:
+  /@codemirror/lang-sql/6.3.3:
     resolution: {integrity: sha512-VNsHju8500fkiDyDU8jZyGQ8M0iXU0SmfeCoCeAYkACcEFlX63BOT8311pICXyw43VYRbS23w54RgSEQmixGjQ==}
     dependencies:
-      '@codemirror/autocomplete': 6.3.4_4npvozs3agsv66jx2b7pfvr53q
+      '@codemirror/autocomplete': 6.3.4
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
       '@lezer/highlight': 1.1.3
       '@lezer/lr': 1.2.5
-    transitivePeerDependencies:
-      - '@codemirror/view'
     dev: false
 
   /@codemirror/lang-wast/6.0.1:
@@ -1342,23 +1334,21 @@ packages:
       '@lezer/lr': 1.2.5
     dev: false
 
-  /@codemirror/lang-xml/6.0.1_@codemirror+view@6.6.0:
+  /@codemirror/lang-xml/6.0.1:
     resolution: {integrity: sha512-0tvycUTElajCcRKgsszhKjWX+uuOogdu5+enpfqYA+j0gnP8ek7LRxujh2/XMPRdXt/hwOML4slJLE7r2eX3yQ==}
     dependencies:
-      '@codemirror/autocomplete': 6.3.4_4npvozs3agsv66jx2b7pfvr53q
+      '@codemirror/autocomplete': 6.3.4
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
       '@lezer/common': 1.0.2
       '@lezer/xml': 1.0.0
-    transitivePeerDependencies:
-      - '@codemirror/view'
     dev: false
 
-  /@codemirror/language-data/6.1.0_@codemirror+view@6.6.0:
+  /@codemirror/language-data/6.1.0:
     resolution: {integrity: sha512-g9V23fuLRI9AEbpM6bDy1oquqgpFlIDHTihUhL21NPmxp+x67ZJbsKk+V71W7/Bj8SCqEO1PtqQA/tDGgt1nfw==}
     dependencies:
       '@codemirror/lang-cpp': 6.0.2
-      '@codemirror/lang-css': 6.0.1_@codemirror+view@6.6.0
+      '@codemirror/lang-css': 6.0.1
       '@codemirror/lang-html': 6.2.0
       '@codemirror/lang-java': 6.0.1
       '@codemirror/lang-javascript': 6.1.1
@@ -1367,13 +1357,11 @@ packages:
       '@codemirror/lang-php': 6.0.1
       '@codemirror/lang-python': 6.0.4
       '@codemirror/lang-rust': 6.0.1
-      '@codemirror/lang-sql': 6.3.3_@codemirror+view@6.6.0
+      '@codemirror/lang-sql': 6.3.3
       '@codemirror/lang-wast': 6.0.1
-      '@codemirror/lang-xml': 6.0.1_@codemirror+view@6.6.0
+      '@codemirror/lang-xml': 6.0.1
       '@codemirror/language': 6.3.1
       '@codemirror/legacy-modes': 6.3.1
-    transitivePeerDependencies:
-      - '@codemirror/view'
     dev: false
 
   /@codemirror/language/6.3.1:
@@ -1736,7 +1724,7 @@ packages:
     resolution: {integrity: sha512-/Dc8fPFtMbIjRBSPHi4oX7jLixbY8WR0k/Zp/NLZ+XSoXOZES2fD4RfEzqGm5d9FihetVqoHvlw9rDJWQRj7xg==}
     dependencies:
       postcss: 8.4.19
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
     transitivePeerDependencies:
       - ts-node
     dev: false
@@ -1745,7 +1733,7 @@ packages:
     resolution: {integrity: sha512-GR2neBdz4bKlqxN+WdBWYHLpJRP+ERGonP97jdekeS/Rxgji6u6ddP4Gwgeu8vZQOorOX9c8bD6IBgKeGg4GCw==}
     dependencies:
       postcss: 8.4.19
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
     transitivePeerDependencies:
       - ts-node
     dev: false
@@ -1754,7 +1742,7 @@ packages:
     resolution: {integrity: sha512-EAXgbiy1+Yg2panx4XVOUvJ97wyOe0HeRiqGujDdxa2c4nACkK2Q+dQmSAe/aEiZupRGIjkmpiMFcKHbNFlnew==}
     dependencies:
       postcss: 8.4.19
-      tailwindcss: 3.2.3_postcss@8.4.19
+      tailwindcss: 3.2.3
     transitivePeerDependencies:
       - ts-node
     dev: false
@@ -1763,7 +1751,7 @@ packages:
     resolution: {integrity: sha512-EAXgbiy1+Yg2panx4XVOUvJ97wyOe0HeRiqGujDdxa2c4nACkK2Q+dQmSAe/aEiZupRGIjkmpiMFcKHbNFlnew==}
     dependencies:
       postcss: 8.4.19
-      tailwindcss: 3.2.3_v776zzvn44o7tpgzieipaairwm
+      tailwindcss: 3.2.3_ts-node@10.9.1
     transitivePeerDependencies:
       - ts-node
     dev: false
@@ -1946,8 +1934,8 @@ packages:
       - wonka
     dev: false
 
-  /@frontify/fondue/12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m:
-    resolution: {integrity: sha512-HMSqNmRGnUv6BhfCg+XtcVDq/ivkxWDLjdQ/CkBOhOxX8Dwclaoo9tYgOtPaD4BVjPetIdJJhfFWOVlqe+FOKg==}
+  /@frontify/fondue/12.0.0-beta.76_angvksxlvvfhyjj3xhcshgfg2m:
+    resolution: {integrity: sha512-oUbIkMZxn1nbOAnWdc3QyuHuGkKTUwkUB0ZbLxwcTR/4VV2x/q0oEnGNgoTRix9f/G7kj53NU3JtPCnSUOfzpQ==}
     engines: {node: '>=16'}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0
@@ -2035,8 +2023,8 @@ packages:
       - ts-node
     dev: false
 
-  /@frontify/fondue/12.0.0-beta.72_rv2t7de65xq26o5frb4lun64yi:
-    resolution: {integrity: sha512-HMSqNmRGnUv6BhfCg+XtcVDq/ivkxWDLjdQ/CkBOhOxX8Dwclaoo9tYgOtPaD4BVjPetIdJJhfFWOVlqe+FOKg==}
+  /@frontify/fondue/12.0.0-beta.76_rv2t7de65xq26o5frb4lun64yi:
+    resolution: {integrity: sha512-oUbIkMZxn1nbOAnWdc3QyuHuGkKTUwkUB0ZbLxwcTR/4VV2x/q0oEnGNgoTRix9f/G7kj53NU3JtPCnSUOfzpQ==}
     engines: {node: '>=16'}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0
@@ -2153,49 +2141,12 @@ packages:
       - terser
     dev: true
 
-  /@frontify/guideline-blocks-settings/0.25.2_t2lnk2qhgvs3f2wqugd34vbhdu:
+  /@frontify/guideline-blocks-settings/0.25.2_angvksxlvvfhyjj3xhcshgfg2m:
     resolution: {integrity: sha512-sVSHLZxoTpsRJ8OJ+NcqsoWmedRvP0puTEcJcc8fb4l4kdJ9fqAvk9oT2aMfid+RJzqFcK55kq/lGK4glXpaGA==}
-    peerDependencies:
-      '@frontify/app-bridge': '*'
-    dependencies:
-      '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 11.3.0_rv2t7de65xq26o5frb4lun64yi
-      '@frontify/sidebar-settings': 0.0.6_t2lnk2qhgvs3f2wqugd34vbhdu
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/hoist-non-react-statics'
-      - '@types/node'
-      - '@types/react'
-      - '@urql/core'
-      - '@xstate/fsm'
-      - encoding
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - optics-ts
-      - react
-      - react-dom
-      - react-query
-      - supports-color
-      - ts-node
-      - valtio
-      - wonka
-    dev: false
-
-  /@frontify/guideline-blocks-settings/0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe:
-    resolution: {integrity: sha512-sVSHLZxoTpsRJ8OJ+NcqsoWmedRvP0puTEcJcc8fb4l4kdJ9fqAvk9oT2aMfid+RJzqFcK55kq/lGK4glXpaGA==}
-    peerDependencies:
-      '@frontify/app-bridge': '*'
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
       '@frontify/fondue': 11.3.0_angvksxlvvfhyjj3xhcshgfg2m
-      '@frontify/sidebar-settings': 0.0.6_vv7cpewgmcw25x4o2lxdmrwwxe
+      '@frontify/sidebar-settings': 0.0.6_angvksxlvvfhyjj3xhcshgfg2m
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -2223,13 +2174,12 @@ packages:
       - wonka
     dev: false
 
-  /@frontify/sidebar-settings/0.0.6_t2lnk2qhgvs3f2wqugd34vbhdu:
-    resolution: {integrity: sha512-PD1hDFpqyz3+HXDhE1G4pnsCgd+yi2gJaaibEzBqSnmBPd0z4r9fJ6xC/nFGT6obsSK/6KDYm524M/ln90ZGfA==}
-    peerDependencies:
-      '@frontify/app-bridge': '*'
+  /@frontify/guideline-blocks-settings/0.25.2_rv2t7de65xq26o5frb4lun64yi:
+    resolution: {integrity: sha512-sVSHLZxoTpsRJ8OJ+NcqsoWmedRvP0puTEcJcc8fb4l4kdJ9fqAvk9oT2aMfid+RJzqFcK55kq/lGK4glXpaGA==}
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
       '@frontify/fondue': 11.3.0_rv2t7de65xq26o5frb4lun64yi
+      '@frontify/sidebar-settings': 0.0.6_rv2t7de65xq26o5frb4lun64yi
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -2257,13 +2207,43 @@ packages:
       - wonka
     dev: false
 
-  /@frontify/sidebar-settings/0.0.6_vv7cpewgmcw25x4o2lxdmrwwxe:
+  /@frontify/sidebar-settings/0.0.6_angvksxlvvfhyjj3xhcshgfg2m:
     resolution: {integrity: sha512-PD1hDFpqyz3+HXDhE1G4pnsCgd+yi2gJaaibEzBqSnmBPd0z4r9fJ6xC/nFGT6obsSK/6KDYm524M/ln90ZGfA==}
-    peerDependencies:
-      '@frontify/app-bridge': '*'
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
       '@frontify/fondue': 11.3.0_angvksxlvvfhyjj3xhcshgfg2m
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/hoist-non-react-statics'
+      - '@types/node'
+      - '@types/react'
+      - '@urql/core'
+      - '@xstate/fsm'
+      - encoding
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - optics-ts
+      - react
+      - react-dom
+      - react-query
+      - supports-color
+      - ts-node
+      - valtio
+      - wonka
+    dev: false
+
+  /@frontify/sidebar-settings/0.0.6_rv2t7de65xq26o5frb4lun64yi:
+    resolution: {integrity: sha512-PD1hDFpqyz3+HXDhE1G4pnsCgd+yi2gJaaibEzBqSnmBPd0z4r9fJ6xC/nFGT6obsSK/6KDYm524M/ln90ZGfA==}
+    dependencies:
+      '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
+      '@frontify/fondue': 11.3.0_rv2t7de65xq26o5frb4lun64yi
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8385,14 +8365,10 @@ packages:
       - scheduler
     dev: false
 
-  /@uiw/codemirror-extensions-basic-setup/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-extensions-basic-setup/4.15.1:
     resolution: {integrity: sha512-LP2LHyPQm6ikYyXxT+1Odz+kiVLzzUmHSwBapSF4JgUE4b5QaBA7KCiTfwIWJPC528QVP2qWk1DEBNstPMiUdg==}
-    peerDependencies:
-      '@codemirror/language': '>=6.0.0'
-      '@codemirror/state': '>=6.0.0'
-      '@codemirror/view': '>=6.0.0'
     dependencies:
-      '@codemirror/autocomplete': 6.3.4_4npvozs3agsv66jx2b7pfvr53q
+      '@codemirror/autocomplete': 6.3.4
       '@codemirror/commands': 6.1.2
       '@codemirror/language': 6.3.1
       '@codemirror/lint': 6.1.0
@@ -8401,7 +8377,7 @@ packages:
       '@codemirror/view': 6.6.0
     dev: false
 
-  /@uiw/codemirror-extensions-langs/4.15.1_@codemirror+view@6.6.0:
+  /@uiw/codemirror-extensions-langs/4.15.1:
     resolution: {integrity: sha512-osDz7cTs8fVvLcnZNn9+gE9qrH4eErWqIaaeS090px99KHbDTXfqre906Q+UmPFTDnO5JdlISno5MMlpBLdNaQ==}
     dependencies:
       '@codemirror/lang-cpp': 6.0.2
@@ -8414,206 +8390,135 @@ packages:
       '@codemirror/lang-php': 6.0.1
       '@codemirror/lang-python': 6.0.4
       '@codemirror/lang-rust': 6.0.1
-      '@codemirror/lang-sql': 6.3.3_@codemirror+view@6.6.0
+      '@codemirror/lang-sql': 6.3.3
       '@codemirror/lang-wast': 6.0.1
-      '@codemirror/lang-xml': 6.0.1_@codemirror+view@6.6.0
-      '@codemirror/language-data': 6.1.0_@codemirror+view@6.6.0
+      '@codemirror/lang-xml': 6.0.1
+      '@codemirror/language-data': 6.1.0
       '@codemirror/legacy-modes': 6.3.1
-    transitivePeerDependencies:
-      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-abcdef/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-theme-abcdef/4.15.1:
     resolution: {integrity: sha512-DjdNJN0paKAS5wx2/ggSs0Fiobufa+UKlIKK/NmGCv1yzv1Xe1ffRzgaZauwVr3WnTc6s1HKA9gA/fqgXYuJaA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-    transitivePeerDependencies:
-      - '@codemirror/language'
-      - '@codemirror/state'
-      - '@codemirror/view'
+      '@uiw/codemirror-themes': 4.15.1
     dev: false
 
-  /@uiw/codemirror-theme-androidstudio/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-theme-androidstudio/4.15.1:
     resolution: {integrity: sha512-cmQWDmS9XyGv1oYLp4CRh/VunWTDI7d1Nx4/PVOyVGdDz7J3rAEllVoh2iHNRhMgX2esjb0GYqWZJsIHqVp3Gg==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-    transitivePeerDependencies:
-      - '@codemirror/language'
-      - '@codemirror/state'
-      - '@codemirror/view'
+      '@uiw/codemirror-themes': 4.15.1
     dev: false
 
-  /@uiw/codemirror-theme-atomone/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-theme-atomone/4.15.1:
     resolution: {integrity: sha512-/5O0+rWAz+7as59Sy5nTX1P5l+jihKzt+99OpzGUuda4AMS3Q8SP3WGLv3v+ySTTuvjMHFMgOObzb5uWjVF/ww==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-    transitivePeerDependencies:
-      - '@codemirror/language'
-      - '@codemirror/state'
-      - '@codemirror/view'
+      '@uiw/codemirror-themes': 4.15.1
     dev: false
 
-  /@uiw/codemirror-theme-bbedit/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-theme-bbedit/4.15.1:
     resolution: {integrity: sha512-1K3vQDt+pnyipdKGSBrYiyOZay1Q+XgI9TrdxgZdnPiAkDbbpjqOxO5ND+JC5+uBx9U93rpzjWPIqdr7uBHGzA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-    transitivePeerDependencies:
-      - '@codemirror/language'
-      - '@codemirror/state'
-      - '@codemirror/view'
+      '@uiw/codemirror-themes': 4.15.1
     dev: false
 
-  /@uiw/codemirror-theme-bespin/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-theme-bespin/4.15.1:
     resolution: {integrity: sha512-eFB1/BAbYoeaQbspUbShyKueWLmdP/xcvxJYiLNEFrcbzO9j/+lIvGl3M+R0OK3rhzo9pK896aB8Rz5/G3gBTA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-    transitivePeerDependencies:
-      - '@codemirror/language'
-      - '@codemirror/state'
-      - '@codemirror/view'
+      '@uiw/codemirror-themes': 4.15.1
     dev: false
 
-  /@uiw/codemirror-theme-darcula/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-theme-darcula/4.15.1:
     resolution: {integrity: sha512-rgbqNmMbTShFSYUyy5iXCq8+BcFdZ8CJGJazTYnvRjV8TPm6huX2ukYiFxgitNShRsNrLHMx49CAiriKDwSnYA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-    transitivePeerDependencies:
-      - '@codemirror/language'
-      - '@codemirror/state'
-      - '@codemirror/view'
+      '@uiw/codemirror-themes': 4.15.1
     dev: false
 
-  /@uiw/codemirror-theme-dracula/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-theme-dracula/4.15.1:
     resolution: {integrity: sha512-Qs4H5Uva5Z0EuX2NHl8soZEaQU0P5E2WBvGHl3jSwQA3LofrpFcL7x46V/cu8il0lmc977TD5A0M2xYKv8yvtg==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-    transitivePeerDependencies:
-      - '@codemirror/language'
-      - '@codemirror/state'
-      - '@codemirror/view'
+      '@uiw/codemirror-themes': 4.15.1
     dev: false
 
-  /@uiw/codemirror-theme-duotone/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-theme-duotone/4.15.1:
     resolution: {integrity: sha512-LeG3gGpkKS0vy4zMfLqAxqHBtPsgC+4Q3MIRHcinoRaDGcdHZC8teX5W4E3fGntMZ/7DTUMj+Q4Um2NnGskHXg==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-    transitivePeerDependencies:
-      - '@codemirror/language'
-      - '@codemirror/state'
-      - '@codemirror/view'
+      '@uiw/codemirror-themes': 4.15.1
     dev: false
 
-  /@uiw/codemirror-theme-eclipse/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-theme-eclipse/4.15.1:
     resolution: {integrity: sha512-LyYq3/T4GtaSH7EEwZiQjq6fefM6q9l0f7wtGpgTeR5Ogtf5b1Do3PM6BT12CfSjGtUzZUKnSZhx87vClSYyGg==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-    transitivePeerDependencies:
-      - '@codemirror/language'
-      - '@codemirror/state'
-      - '@codemirror/view'
+      '@uiw/codemirror-themes': 4.15.1
     dev: false
 
-  /@uiw/codemirror-theme-github/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-theme-github/4.15.1:
     resolution: {integrity: sha512-8Q4V3kbHw/jgD35ry8mxyViN2LHWRFcMRIjY+IbTya0ehVb29bugSmJIAn1eHb/rk1hMQ6ZvDTseNBg+Abdl3Q==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-    transitivePeerDependencies:
-      - '@codemirror/language'
-      - '@codemirror/state'
-      - '@codemirror/view'
+      '@uiw/codemirror-themes': 4.15.1
     dev: false
 
-  /@uiw/codemirror-theme-gruvbox-dark/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-theme-gruvbox-dark/4.15.1:
     resolution: {integrity: sha512-35dxs0eb19hJTWQc3yEXAM01s/mY0PcA/Cb1I0Z6yBWa7Vm63Mu+9F2hPQ9ldOG2QAKkM6x3p0xI18WH4JfahA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-    transitivePeerDependencies:
-      - '@codemirror/language'
-      - '@codemirror/state'
-      - '@codemirror/view'
+      '@uiw/codemirror-themes': 4.15.1
     dev: false
 
-  /@uiw/codemirror-theme-okaidia/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-theme-okaidia/4.15.1:
     resolution: {integrity: sha512-Jw9u6BoG3cUvf1AWk696Z4EdwMeKbMcgsxCwm6tQBAEDo7nUqTedUIPAZChTxxviA3hmUKdlxVvZnXsey0q1EQ==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-    transitivePeerDependencies:
-      - '@codemirror/language'
-      - '@codemirror/state'
-      - '@codemirror/view'
+      '@uiw/codemirror-themes': 4.15.1
     dev: false
 
-  /@uiw/codemirror-theme-sublime/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-theme-sublime/4.15.1:
     resolution: {integrity: sha512-A73SewRROBYyIgRjx5UiQ0YBKkUmJVMg/mqGNoDwQLVn2zN4/oEYlshznN4g32Tnp8ifMVI60d8f3fFwhC2ICQ==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-    transitivePeerDependencies:
-      - '@codemirror/language'
-      - '@codemirror/state'
-      - '@codemirror/view'
+      '@uiw/codemirror-themes': 4.15.1
     dev: false
 
-  /@uiw/codemirror-theme-vscode/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-theme-vscode/4.15.1:
     resolution: {integrity: sha512-ypW95f2TU7udMrtoJWygcnf0trTPlZflM0s8/MJQrA6/fqxzWa0HyLwcMAUKySCxkmy6SY6/iJ2AivQVVXCJfQ==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-    transitivePeerDependencies:
-      - '@codemirror/language'
-      - '@codemirror/state'
-      - '@codemirror/view'
+      '@uiw/codemirror-themes': 4.15.1
     dev: false
 
-  /@uiw/codemirror-theme-xcode/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-theme-xcode/4.15.1:
     resolution: {integrity: sha512-2Vr4/p34HACi9bjtl9VXgIKBsF/ObIDVzqtosq+BdJUhMnwo+z1kLX9mK17mCVvx+GNSfMR/TfWhN28UVY38Kw==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-    transitivePeerDependencies:
-      - '@codemirror/language'
-      - '@codemirror/state'
-      - '@codemirror/view'
+      '@uiw/codemirror-themes': 4.15.1
     dev: false
 
-  /@uiw/codemirror-themes-all/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-themes-all/4.15.1:
     resolution: {integrity: sha512-MTxkIxHKcaQn0D6vjDShBY6OnXS3Zi6TqYC+5s9GEHNzaG2Lw90NOpislbFKG3llwr/BFIVAk5IToNPq1jJukg==}
     dependencies:
-      '@uiw/codemirror-theme-abcdef': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-      '@uiw/codemirror-theme-androidstudio': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-      '@uiw/codemirror-theme-atomone': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-      '@uiw/codemirror-theme-bbedit': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-      '@uiw/codemirror-theme-bespin': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-      '@uiw/codemirror-theme-darcula': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-      '@uiw/codemirror-theme-dracula': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-      '@uiw/codemirror-theme-duotone': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-      '@uiw/codemirror-theme-eclipse': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-      '@uiw/codemirror-theme-github': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-      '@uiw/codemirror-theme-gruvbox-dark': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-      '@uiw/codemirror-theme-okaidia': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-      '@uiw/codemirror-theme-sublime': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-      '@uiw/codemirror-theme-vscode': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-      '@uiw/codemirror-theme-xcode': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
-    transitivePeerDependencies:
-      - '@codemirror/language'
-      - '@codemirror/state'
-      - '@codemirror/view'
+      '@uiw/codemirror-theme-abcdef': 4.15.1
+      '@uiw/codemirror-theme-androidstudio': 4.15.1
+      '@uiw/codemirror-theme-atomone': 4.15.1
+      '@uiw/codemirror-theme-bbedit': 4.15.1
+      '@uiw/codemirror-theme-bespin': 4.15.1
+      '@uiw/codemirror-theme-darcula': 4.15.1
+      '@uiw/codemirror-theme-dracula': 4.15.1
+      '@uiw/codemirror-theme-duotone': 4.15.1
+      '@uiw/codemirror-theme-eclipse': 4.15.1
+      '@uiw/codemirror-theme-github': 4.15.1
+      '@uiw/codemirror-theme-gruvbox-dark': 4.15.1
+      '@uiw/codemirror-theme-okaidia': 4.15.1
+      '@uiw/codemirror-theme-sublime': 4.15.1
+      '@uiw/codemirror-theme-vscode': 4.15.1
+      '@uiw/codemirror-theme-xcode': 4.15.1
+      '@uiw/codemirror-themes': 4.15.1
     dev: false
 
-  /@uiw/codemirror-themes/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
+  /@uiw/codemirror-themes/4.15.1:
     resolution: {integrity: sha512-+3NKdmptuZTGE56LQ3j8daOAKer2STEDklkJS9AGHAGoN1o7IdA+s2Pbp3hf5oGxukNb29UA+gskfb5grszWMg==}
-    peerDependencies:
-      '@codemirror/language': '>=6.0.0'
-      '@codemirror/state': '>=6.0.0'
-      '@codemirror/view': '>=6.0.0'
     dependencies:
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
       '@codemirror/view': 6.6.0
     dev: false
 
-  /@uiw/react-codemirror/4.15.1_h7lscfam4blfrwonbfvxz6f4vi:
+  /@uiw/react-codemirror/4.15.1_tsqroltqy4j27r2h576o2pxd6u:
     resolution: {integrity: sha512-lgtMFS8D2t9ri3ug3kgWoLPPdxDkqkYBWm3dVU9Z7GRs4R1iN2WSr2Z/biQ8KbdyLygRT5isi1k3Ud9ZY6j+YA==}
     peerDependencies:
-      '@codemirror/state': '>=6.0.0'
       '@codemirror/view': '>=6.0.0'
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -8623,12 +8528,10 @@ packages:
       '@codemirror/state': 6.1.4
       '@codemirror/theme-one-dark': 6.1.0
       '@codemirror/view': 6.6.0
-      '@uiw/codemirror-extensions-basic-setup': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+      '@uiw/codemirror-extensions-basic-setup': 4.15.1
       codemirror: 6.0.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-    transitivePeerDependencies:
-      - '@codemirror/language'
     dev: false
 
   /@vitejs/plugin-react/2.2.0_vite@3.2.3:
@@ -9379,7 +9282,7 @@ packages:
   /codemirror/6.0.1:
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
     dependencies:
-      '@codemirror/autocomplete': 6.3.4_4npvozs3agsv66jx2b7pfvr53q
+      '@codemirror/autocomplete': 6.3.4
       '@codemirror/commands': 6.1.2
       '@codemirror/language': 6.3.1
       '@codemirror/lint': 6.1.0
@@ -14434,12 +14337,10 @@ packages:
       get-port: 3.2.0
     dev: true
 
-  /tailwindcss/3.2.1_postcss@8.4.19:
+  /tailwindcss/3.2.1:
     resolution: {integrity: sha512-Uw+GVSxp5CM48krnjHObqoOwlCt5Qo6nw1jlCRwfGy68dSYb/LwS9ZFidYGRiM+w6rMawkZiu1mEMAsHYAfoLg==}
     engines: {node: '>=12.13.0'}
     hasBin: true
-    peerDependencies:
-      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -14468,12 +14369,10 @@ packages:
       - ts-node
     dev: true
 
-  /tailwindcss/3.2.3_postcss@8.4.19:
+  /tailwindcss/3.2.3:
     resolution: {integrity: sha512-Xt9D4PK4zuuQCEB8bwK9JUCKmTgUwyac/6b0/42Vqhgl6YJkep+Wf5wq+5uXYfmrupdAD0YY2NY1hyZp1HjRrg==}
     engines: {node: '>=12.13.0'}
     hasBin: true
-    peerDependencies:
-      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -14501,12 +14400,10 @@ packages:
     transitivePeerDependencies:
       - ts-node
 
-  /tailwindcss/3.2.3_v776zzvn44o7tpgzieipaairwm:
+  /tailwindcss/3.2.3_ts-node@10.9.1:
     resolution: {integrity: sha512-Xt9D4PK4zuuQCEB8bwK9JUCKmTgUwyac/6b0/42Vqhgl6YJkep+Wf5wq+5uXYfmrupdAD0YY2NY1hyZp1HjRrg==}
     engines: {node: '>=12.13.0'}
     hasBin: true
-    peerDependencies:
-      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
       '@4tw/cypress-drag-drop': 2.2.1
       '@babel/core': 7.20.2
       '@cypress/vite-dev-server': 4.0.1
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@testing-library/react-hooks': 8.0.1
       '@types/node': 18.7.21
       '@types/react': 17.0.50
@@ -27,7 +27,7 @@ importers:
       vite: 3.2.3
       vitest: 0.25.0
     dependencies:
-      '@frontify/fondue': 12.0.0-beta.35_rv2t7de65xq26o5frb4lun64yi
+      '@frontify/fondue': 12.0.0-beta.72_rv2t7de65xq26o5frb4lun64yi
       glob: 8.0.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -45,7 +45,7 @@ importers:
       happy-dom: 7.6.7
       msw: 0.48.1_typescript@4.8.4
       postcss: 8.4.19
-      tailwindcss: 3.2.3_ts-node@10.9.1
+      tailwindcss: 3.2.3_v776zzvn44o7tpgzieipaairwm
       ts-node: 10.9.1_27ec3h7d2bmjwz3w2efi2jw4se
       typescript: 4.8.4
       vite: 3.2.3_@types+node@18.7.21
@@ -56,7 +56,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -75,9 +75,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -93,7 +93,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
       typescript: 4.8.4
 
   examples/guideline-design-tokens:
@@ -121,7 +121,7 @@ importers:
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -138,7 +138,7 @@ importers:
       mitt: 3.0.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
       typescript: 4.8.4
 
   packages/callout-block:
@@ -146,7 +146,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -165,9 +165,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -183,7 +183,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
       typescript: 4.8.4
 
   packages/checklist-block:
@@ -191,7 +191,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -218,9 +218,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
       '@frontify/guideline-blocks-shared': link:../shared
       '@react-aria/checkbox': 3.5.1_react@17.0.2
       '@react-aria/focus': 3.8.0_react@17.0.2
@@ -244,7 +244,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
       typescript: 4.8.4
 
   packages/code-snippet-block:
@@ -255,7 +255,7 @@ importers:
       '@codemirror/view': ^6.5.1
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -281,13 +281,13 @@ importers:
       '@codemirror/state': 6.1.4
       '@codemirror/view': 6.6.0
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
       '@frontify/guideline-blocks-shared': link:../shared
-      '@uiw/codemirror-extensions-langs': 4.15.1
-      '@uiw/codemirror-themes-all': 4.15.1
-      '@uiw/react-codemirror': 4.15.1_tsqroltqy4j27r2h576o2pxd6u
+      '@uiw/codemirror-extensions-langs': 4.15.1_@codemirror+view@6.6.0
+      '@uiw/codemirror-themes-all': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+      '@uiw/react-codemirror': 4.15.1_h7lscfam4blfrwonbfvxz6f4vi
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -303,7 +303,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
       typescript: 4.8.4
 
   packages/color-block:
@@ -311,7 +311,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@frontify/fondue-tokens': 3.2.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -333,9 +333,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.2.0
-      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dnd: 16.0.1_pxzommwrsowkd4kgag6q3sluym
@@ -354,7 +354,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.1
+      tailwindcss: 3.2.1_postcss@8.4.19
       typescript: 4.8.4
 
   packages/color-kit-block:
@@ -362,7 +362,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -381,9 +381,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -399,7 +399,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
       typescript: 4.8.4
 
   packages/color-scale-block:
@@ -408,7 +408,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -429,9 +429,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dnd: 16.0.1_pxzommwrsowkd4kgag6q3sluym
@@ -450,7 +450,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
       typescript: 4.8.4
 
   packages/divider-block:
@@ -458,7 +458,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -477,9 +477,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -495,7 +495,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
       typescript: 4.8.4
 
   packages/dos-donts-block:
@@ -503,7 +503,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -522,9 +522,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -540,7 +540,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
       typescript: 4.8.4
 
   packages/example:
@@ -548,7 +548,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@frontify/fondue-tokens': 3.2.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -567,9 +567,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.2.0
-      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -585,7 +585,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
       typescript: 4.8.4
 
   packages/figma-block:
@@ -593,7 +593,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -612,9 +612,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -630,7 +630,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
       typescript: 4.8.4
 
   packages/personal-note-block:
@@ -638,7 +638,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -658,9 +658,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
       '@frontify/guideline-blocks-shared': link:../shared
       dayjs: 1.11.6
       react: 17.0.2
@@ -677,7 +677,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
       typescript: 4.8.4
 
   packages/quote-block:
@@ -685,7 +685,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -704,9 +704,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -722,7 +722,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
       typescript: 4.8.4
 
   packages/shared:
@@ -730,7 +730,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-typescript': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@frontify/guideline-blocks-settings': 0.25.2
       '@testing-library/react-hooks': 8.0.1
       '@types/node': 18.7.21
@@ -754,8 +754,8 @@ importers:
       vitest: 0.25.0
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_rv2t7de65xq26o5frb4lun64yi
-      '@frontify/guideline-blocks-settings': 0.25.2_rv2t7de65xq26o5frb4lun64yi
+      '@frontify/fondue': 12.0.0-beta.72_rv2t7de65xq26o5frb4lun64yi
+      '@frontify/guideline-blocks-settings': 0.25.2_t2lnk2qhgvs3f2wqugd34vbhdu
       tinycolor2: 1.4.2
     devDependencies:
       '@babel/core': 7.20.2
@@ -785,7 +785,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -804,9 +804,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
       '@frontify/guideline-blocks-shared': link:../shared
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -822,7 +822,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
       typescript: 4.8.4
 
   packages/storybook-block:
@@ -830,7 +830,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -850,9 +850,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
       '@frontify/guideline-blocks-shared': link:../shared
       '@react-aria/interactions': 3.7.0_react@17.0.2
       react: 17.0.2
@@ -869,7 +869,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
       typescript: 4.8.4
 
   packages/text-block:
@@ -877,7 +877,7 @@ importers:
       '@babel/core': 7.20.2
       '@frontify/app-bridge': 3.0.0-beta.30
       '@frontify/eslint-config-react': 0.15.5
-      '@frontify/fondue': 12.0.0-beta.35
+      '@frontify/fondue': 12.0.0-beta.72
       '@frontify/fondue-tokens': 3.1.0
       '@frontify/frontify-cli': 5.3.1
       '@frontify/guideline-blocks-settings': 0.25.2
@@ -898,9 +898,9 @@ importers:
       typescript: 4.8.4
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m
       '@frontify/fondue-tokens': 3.1.0
-      '@frontify/guideline-blocks-settings': 0.25.2_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/guideline-blocks-settings': 0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe
       '@frontify/guideline-blocks-shared': link:../shared
       lodash-es: 4.17.21
       react: 17.0.2
@@ -918,7 +918,7 @@ importers:
       eslint-plugin-notice: 0.9.10_eslint@8.27.0
       postcss: 8.4.19
       prettier: 2.7.1
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
       typescript: 4.8.4
 
 packages:
@@ -1199,8 +1199,12 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
 
-  /@codemirror/autocomplete/6.3.4:
+  /@codemirror/autocomplete/6.3.4_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-irxKsTSjS0OkfMWWt9YxtNK97++/E+XIHfKnRpSVfZyHzda/amYF0BR+T8mMkrGQWidx2zApxHx08GT13egyQA==}
+    peerDependencies:
+      '@codemirror/language': ^6.0.0
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
     dependencies:
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
@@ -1224,20 +1228,22 @@ packages:
       '@lezer/cpp': 1.0.0
     dev: false
 
-  /@codemirror/lang-css/6.0.1:
+  /@codemirror/lang-css/6.0.1_@codemirror+view@6.6.0:
     resolution: {integrity: sha512-rlLq1Dt0WJl+2epLQeAsfqIsx3lGu4HStHCJu95nGGuz2P2fNugbU3dQYafr2VRjM4eMC9HviI6jvS98CNtG5w==}
     dependencies:
-      '@codemirror/autocomplete': 6.3.4
+      '@codemirror/autocomplete': 6.3.4_4npvozs3agsv66jx2b7pfvr53q
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
       '@lezer/css': 1.1.0
+    transitivePeerDependencies:
+      - '@codemirror/view'
     dev: false
 
   /@codemirror/lang-html/6.2.0:
     resolution: {integrity: sha512-0Kr+gWPu1J4mhpLbqHPqoD5+xLCwAntfzRv9L61cqRSFNpDpDbGbONSN5xzWupo6AJ9qtDOlJNBFBuL72tXPwg==}
     dependencies:
-      '@codemirror/autocomplete': 6.3.4
-      '@codemirror/lang-css': 6.0.1
+      '@codemirror/autocomplete': 6.3.4_4npvozs3agsv66jx2b7pfvr53q
+      '@codemirror/lang-css': 6.0.1_@codemirror+view@6.6.0
       '@codemirror/lang-javascript': 6.1.1
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
@@ -1256,7 +1262,7 @@ packages:
   /@codemirror/lang-javascript/6.1.1:
     resolution: {integrity: sha512-F4+kiuC5d5dUSJmff96tJQwpEXs/tX/4bapMRnZWW6bHKK1Fx6MunTzopkCUWRa9bF87GPmb9m7Qtg7Yv8f3uQ==}
     dependencies:
-      '@codemirror/autocomplete': 6.3.4
+      '@codemirror/autocomplete': 6.3.4_4npvozs3agsv66jx2b7pfvr53q
       '@codemirror/language': 6.3.1
       '@codemirror/lint': 6.1.0
       '@codemirror/state': 6.1.4
@@ -1316,14 +1322,16 @@ packages:
       '@lezer/rust': 1.0.0
     dev: false
 
-  /@codemirror/lang-sql/6.3.3:
+  /@codemirror/lang-sql/6.3.3_@codemirror+view@6.6.0:
     resolution: {integrity: sha512-VNsHju8500fkiDyDU8jZyGQ8M0iXU0SmfeCoCeAYkACcEFlX63BOT8311pICXyw43VYRbS23w54RgSEQmixGjQ==}
     dependencies:
-      '@codemirror/autocomplete': 6.3.4
+      '@codemirror/autocomplete': 6.3.4_4npvozs3agsv66jx2b7pfvr53q
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
       '@lezer/highlight': 1.1.3
       '@lezer/lr': 1.2.5
+    transitivePeerDependencies:
+      - '@codemirror/view'
     dev: false
 
   /@codemirror/lang-wast/6.0.1:
@@ -1334,21 +1342,23 @@ packages:
       '@lezer/lr': 1.2.5
     dev: false
 
-  /@codemirror/lang-xml/6.0.1:
+  /@codemirror/lang-xml/6.0.1_@codemirror+view@6.6.0:
     resolution: {integrity: sha512-0tvycUTElajCcRKgsszhKjWX+uuOogdu5+enpfqYA+j0gnP8ek7LRxujh2/XMPRdXt/hwOML4slJLE7r2eX3yQ==}
     dependencies:
-      '@codemirror/autocomplete': 6.3.4
+      '@codemirror/autocomplete': 6.3.4_4npvozs3agsv66jx2b7pfvr53q
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
       '@lezer/common': 1.0.2
       '@lezer/xml': 1.0.0
+    transitivePeerDependencies:
+      - '@codemirror/view'
     dev: false
 
-  /@codemirror/language-data/6.1.0:
+  /@codemirror/language-data/6.1.0_@codemirror+view@6.6.0:
     resolution: {integrity: sha512-g9V23fuLRI9AEbpM6bDy1oquqgpFlIDHTihUhL21NPmxp+x67ZJbsKk+V71W7/Bj8SCqEO1PtqQA/tDGgt1nfw==}
     dependencies:
       '@codemirror/lang-cpp': 6.0.2
-      '@codemirror/lang-css': 6.0.1
+      '@codemirror/lang-css': 6.0.1_@codemirror+view@6.6.0
       '@codemirror/lang-html': 6.2.0
       '@codemirror/lang-java': 6.0.1
       '@codemirror/lang-javascript': 6.1.1
@@ -1357,11 +1367,13 @@ packages:
       '@codemirror/lang-php': 6.0.1
       '@codemirror/lang-python': 6.0.4
       '@codemirror/lang-rust': 6.0.1
-      '@codemirror/lang-sql': 6.3.3
+      '@codemirror/lang-sql': 6.3.3_@codemirror+view@6.6.0
       '@codemirror/lang-wast': 6.0.1
-      '@codemirror/lang-xml': 6.0.1
+      '@codemirror/lang-xml': 6.0.1_@codemirror+view@6.6.0
       '@codemirror/language': 6.3.1
       '@codemirror/legacy-modes': 6.3.1
+    transitivePeerDependencies:
+      - '@codemirror/view'
     dev: false
 
   /@codemirror/language/6.3.1:
@@ -1585,6 +1597,7 @@ packages:
 
   /@floating-ui/react-dom-interactions/0.6.6_hiunvzosbwliizyirxfy6hjyim:
     resolution: {integrity: sha512-qnao6UPjSZNHnXrF+u4/n92qVroQkx0Umlhy3Avk1oIebm/5ee6yvDm4xbHob0OjY7ya8WmUnV3rQlPwX3Atwg==}
+    deprecated: Package renamed to @floating-ui/react
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -1723,7 +1736,7 @@ packages:
     resolution: {integrity: sha512-/Dc8fPFtMbIjRBSPHi4oX7jLixbY8WR0k/Zp/NLZ+XSoXOZES2fD4RfEzqGm5d9FihetVqoHvlw9rDJWQRj7xg==}
     dependencies:
       postcss: 8.4.19
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
     transitivePeerDependencies:
       - ts-node
     dev: false
@@ -1732,28 +1745,215 @@ packages:
     resolution: {integrity: sha512-GR2neBdz4bKlqxN+WdBWYHLpJRP+ERGonP97jdekeS/Rxgji6u6ddP4Gwgeu8vZQOorOX9c8bD6IBgKeGg4GCw==}
     dependencies:
       postcss: 8.4.19
-      tailwindcss: 3.2.3
+      tailwindcss: 3.2.3_postcss@8.4.19
     transitivePeerDependencies:
       - ts-node
     dev: false
 
-  /@frontify/fondue-tokens/3.2.0_ts-node@10.9.1:
-    resolution: {integrity: sha512-GR2neBdz4bKlqxN+WdBWYHLpJRP+ERGonP97jdekeS/Rxgji6u6ddP4Gwgeu8vZQOorOX9c8bD6IBgKeGg4GCw==}
+  /@frontify/fondue-tokens/3.2.1:
+    resolution: {integrity: sha512-EAXgbiy1+Yg2panx4XVOUvJ97wyOe0HeRiqGujDdxa2c4nACkK2Q+dQmSAe/aEiZupRGIjkmpiMFcKHbNFlnew==}
     dependencies:
       postcss: 8.4.19
-      tailwindcss: 3.2.3_ts-node@10.9.1
+      tailwindcss: 3.2.3_postcss@8.4.19
     transitivePeerDependencies:
       - ts-node
     dev: false
 
-  /@frontify/fondue/12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m:
-    resolution: {integrity: sha512-nmqv/nLsQ7gOjuL+McA8qO6oD/E8DIY5TaxKeBcP4uSqFQ1JL3tDsVPSXWDJNUouhx8jat0NDxhIQfVBb/rxng==}
+  /@frontify/fondue-tokens/3.2.1_ts-node@10.9.1:
+    resolution: {integrity: sha512-EAXgbiy1+Yg2panx4XVOUvJ97wyOe0HeRiqGujDdxa2c4nACkK2Q+dQmSAe/aEiZupRGIjkmpiMFcKHbNFlnew==}
+    dependencies:
+      postcss: 8.4.19
+      tailwindcss: 3.2.3_v776zzvn44o7tpgzieipaairwm
+    transitivePeerDependencies:
+      - ts-node
+    dev: false
+
+  /@frontify/fondue/11.3.0_angvksxlvvfhyjj3xhcshgfg2m:
+    resolution: {integrity: sha512-2aXHPOLvX3QTb9KX2kI0wPTI2qTnkcvDaAZ1Gp/VZpu2t+pvzK+TbfsrkS7eCF9Ffvh/xB8hNRhkEyE3lwbcww==}
+    peerDependencies:
+      react: ^17.0.2
+      react-dom: ^17.0.2
+    dependencies:
+      '@frontify/fondue-tokens': 3.2.1
+      '@popperjs/core': 2.11.6
+      '@react-aria/accordion': 3.0.0-alpha.9_react@17.0.2
+      '@react-aria/aria-modal-polyfill': 3.6.1_pxzommwrsowkd4kgag6q3sluym
+      '@react-aria/breadcrumbs': 3.4.0_react@17.0.2
+      '@react-aria/button': 3.6.3_react@17.0.2
+      '@react-aria/checkbox': 3.7.0_react@17.0.2
+      '@react-aria/combobox': 3.4.3_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/dialog': 3.4.1_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/link': 3.3.5_react@17.0.2
+      '@react-aria/listbox': 3.7.1_react@17.0.2
+      '@react-aria/menu': 3.7.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/overlays': 3.12.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/radio': 3.4.1_react@17.0.2
+      '@react-aria/select': 3.8.3_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/selection': 3.12.0_react@17.0.2
+      '@react-aria/table': 3.6.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/tooltip': 3.3.3_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-aria/visually-hidden': 3.6.0_react@17.0.2
+      '@react-stately/checkbox': 3.3.2_react@17.0.2
+      '@react-stately/collections': 3.5.0_react@17.0.2
+      '@react-stately/combobox': 3.3.0_react@17.0.2
+      '@react-stately/list': 3.6.0_react@17.0.2
+      '@react-stately/menu': 3.4.4_react@17.0.2
+      '@react-stately/overlays': 3.4.4_react@17.0.2
+      '@react-stately/radio': 3.6.1_react@17.0.2
+      '@react-stately/select': 3.3.3_react@17.0.2
+      '@react-stately/table': 3.6.0_react@17.0.2
+      '@react-stately/toggle': 3.4.4_react@17.0.2
+      '@react-stately/tooltip': 3.2.3_react@17.0.2
+      '@react-stately/tree': 3.4.0_react@17.0.2
+      '@storybook/addon-a11y': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
+      '@udecode/plate': 10.6.0_otptddp36c5zs4pbnen5htp4nu
+      '@xstate/immer': 0.3.1_immer@9.0.16+xstate@4.28.1
+      '@xstate/react': 1.6.3_gcyz5mxmyrgibkcjljkbjmosn4
+      date-fns: 2.29.3
+      framer-motion: 6.4.3_sfoxds7t5ydpegc3knd667wn6m
+      immer: 9.0.16
+      react: 17.0.2
+      react-colorful: 5.6.1_sfoxds7t5ydpegc3knd667wn6m
+      react-datepicker: 4.8.0_sfoxds7t5ydpegc3knd667wn6m
+      react-dnd: 15.1.2_pxzommwrsowkd4kgag6q3sluym
+      react-dnd-html5-backend: 15.1.2
+      react-dom: 17.0.2_react@17.0.2
+      react-is: 18.2.0
+      react-popper: 2.3.0_vov5yimr6vvxyufd6uigwwkst4
+      react-textarea-autosize: 8.4.0_pxzommwrsowkd4kgag6q3sluym
+      scheduler: 0.23.0
+      slate: 0.78.0
+      slate-history: 0.66.0_slate@0.78.0
+      slate-hyperscript: 0.77.0_slate@0.78.0
+      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+      tinycolor2: 1.4.2
+      xstate: 4.28.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/hoist-non-react-statics'
+      - '@types/node'
+      - '@types/react'
+      - '@urql/core'
+      - '@xstate/fsm'
+      - encoding
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - optics-ts
+      - react-query
+      - supports-color
+      - ts-node
+      - valtio
+      - wonka
+    dev: false
+
+  /@frontify/fondue/11.3.0_rv2t7de65xq26o5frb4lun64yi:
+    resolution: {integrity: sha512-2aXHPOLvX3QTb9KX2kI0wPTI2qTnkcvDaAZ1Gp/VZpu2t+pvzK+TbfsrkS7eCF9Ffvh/xB8hNRhkEyE3lwbcww==}
+    peerDependencies:
+      react: ^17.0.2
+      react-dom: ^17.0.2
+    dependencies:
+      '@frontify/fondue-tokens': 3.2.1_ts-node@10.9.1
+      '@popperjs/core': 2.11.6
+      '@react-aria/accordion': 3.0.0-alpha.9_react@17.0.2
+      '@react-aria/aria-modal-polyfill': 3.6.1_pxzommwrsowkd4kgag6q3sluym
+      '@react-aria/breadcrumbs': 3.4.0_react@17.0.2
+      '@react-aria/button': 3.6.3_react@17.0.2
+      '@react-aria/checkbox': 3.7.0_react@17.0.2
+      '@react-aria/combobox': 3.4.3_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/dialog': 3.4.1_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/focus': 3.10.0_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/link': 3.3.5_react@17.0.2
+      '@react-aria/listbox': 3.7.1_react@17.0.2
+      '@react-aria/menu': 3.7.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/overlays': 3.12.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/radio': 3.4.1_react@17.0.2
+      '@react-aria/select': 3.8.3_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/selection': 3.12.0_react@17.0.2
+      '@react-aria/table': 3.6.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-aria/tooltip': 3.3.3_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-aria/visually-hidden': 3.6.0_react@17.0.2
+      '@react-stately/checkbox': 3.3.2_react@17.0.2
+      '@react-stately/collections': 3.5.0_react@17.0.2
+      '@react-stately/combobox': 3.3.0_react@17.0.2
+      '@react-stately/list': 3.6.0_react@17.0.2
+      '@react-stately/menu': 3.4.4_react@17.0.2
+      '@react-stately/overlays': 3.4.4_react@17.0.2
+      '@react-stately/radio': 3.6.1_react@17.0.2
+      '@react-stately/select': 3.3.3_react@17.0.2
+      '@react-stately/table': 3.6.0_react@17.0.2
+      '@react-stately/toggle': 3.4.4_react@17.0.2
+      '@react-stately/tooltip': 3.2.3_react@17.0.2
+      '@react-stately/tree': 3.4.0_react@17.0.2
+      '@storybook/addon-a11y': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
+      '@udecode/plate': 10.6.0_f7z72tac26cjzqnfllstk4x5fq
+      '@xstate/immer': 0.3.1_immer@9.0.16+xstate@4.28.1
+      '@xstate/react': 1.6.3_gcyz5mxmyrgibkcjljkbjmosn4
+      date-fns: 2.29.3
+      framer-motion: 6.4.3_sfoxds7t5ydpegc3knd667wn6m
+      immer: 9.0.16
+      react: 17.0.2
+      react-colorful: 5.6.1_sfoxds7t5ydpegc3knd667wn6m
+      react-datepicker: 4.8.0_sfoxds7t5ydpegc3knd667wn6m
+      react-dnd: 15.1.2_smc5esni47gpbltvxzeziduyte
+      react-dnd-html5-backend: 15.1.2
+      react-dom: 17.0.2_react@17.0.2
+      react-is: 18.2.0
+      react-popper: 2.3.0_vov5yimr6vvxyufd6uigwwkst4
+      react-textarea-autosize: 8.4.0_pxzommwrsowkd4kgag6q3sluym
+      scheduler: 0.23.0
+      slate: 0.78.0
+      slate-history: 0.66.0_slate@0.78.0
+      slate-hyperscript: 0.77.0_slate@0.78.0
+      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+      tinycolor2: 1.4.2
+      xstate: 4.28.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/hoist-non-react-statics'
+      - '@types/node'
+      - '@types/react'
+      - '@urql/core'
+      - '@xstate/fsm'
+      - encoding
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - optics-ts
+      - react-query
+      - supports-color
+      - ts-node
+      - valtio
+      - wonka
+    dev: false
+
+  /@frontify/fondue/12.0.0-beta.72_angvksxlvvfhyjj3xhcshgfg2m:
+    resolution: {integrity: sha512-HMSqNmRGnUv6BhfCg+XtcVDq/ivkxWDLjdQ/CkBOhOxX8Dwclaoo9tYgOtPaD4BVjPetIdJJhfFWOVlqe+FOKg==}
     engines: {node: '>=16'}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
     dependencies:
-      '@frontify/fondue-tokens': 3.2.0
+      '@frontify/fondue-tokens': 3.2.1
       '@popperjs/core': 2.11.6
       '@react-aria/accordion': 3.0.0-alpha.13_react@17.0.2
       '@react-aria/aria-modal-polyfill': 3.6.1_pxzommwrsowkd4kgag6q3sluym
@@ -1775,11 +1975,11 @@ packages:
       '@react-aria/tooltip': 3.3.3_react@17.0.2
       '@react-aria/utils': 3.14.1_react@17.0.2
       '@react-aria/visually-hidden': 3.6.0_react@17.0.2
-      '@react-stately/checkbox': 3.3.0_react@17.0.2
+      '@react-stately/checkbox': 3.3.2_react@17.0.2
       '@react-stately/collections': 3.4.4_react@17.0.2
       '@react-stately/combobox': 3.2.2_react@17.0.2
       '@react-stately/list': 3.5.4_react@17.0.2
-      '@react-stately/menu': 3.4.2_react@17.0.2
+      '@react-stately/menu': 3.4.4_react@17.0.2
       '@react-stately/overlays': 3.4.2_react@17.0.2
       '@react-stately/radio': 3.6.0_react@17.0.2
       '@react-stately/select': 3.3.2_react@17.0.2
@@ -1787,7 +1987,7 @@ packages:
       '@react-stately/toggle': 3.4.2_react@17.0.2
       '@react-stately/tooltip': 3.2.2_react@17.0.2
       '@react-stately/tree': 3.3.4_react@17.0.2
-      '@udecode/plate': 18.11.2_6jhmma7zc7jn5whmtj2xi5zloy
+      '@udecode/plate': 19.0.5_46lb47almn5glegy4zpoj25ooe
       '@xstate/immer': 0.3.1_immer@9.0.12+xstate@4.28.1
       '@xstate/react': 1.6.3_gcyz5mxmyrgibkcjljkbjmosn4
       date-fns: 2.29.3
@@ -1806,13 +2006,14 @@ packages:
       remark-gfm: 3.0.1
       remark-parse: 10.0.1
       scheduler: 0.23.0
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-hyperscript: 0.77.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-hyperscript: 0.77.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
       tinycolor2: 1.4.2
       unified: 10.1.2
+      unist-util-visit: 4.1.1
       xstate: 4.28.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -1834,14 +2035,14 @@ packages:
       - ts-node
     dev: false
 
-  /@frontify/fondue/12.0.0-beta.35_rv2t7de65xq26o5frb4lun64yi:
-    resolution: {integrity: sha512-nmqv/nLsQ7gOjuL+McA8qO6oD/E8DIY5TaxKeBcP4uSqFQ1JL3tDsVPSXWDJNUouhx8jat0NDxhIQfVBb/rxng==}
+  /@frontify/fondue/12.0.0-beta.72_rv2t7de65xq26o5frb4lun64yi:
+    resolution: {integrity: sha512-HMSqNmRGnUv6BhfCg+XtcVDq/ivkxWDLjdQ/CkBOhOxX8Dwclaoo9tYgOtPaD4BVjPetIdJJhfFWOVlqe+FOKg==}
     engines: {node: '>=16'}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
     dependencies:
-      '@frontify/fondue-tokens': 3.2.0_ts-node@10.9.1
+      '@frontify/fondue-tokens': 3.2.1_ts-node@10.9.1
       '@popperjs/core': 2.11.6
       '@react-aria/accordion': 3.0.0-alpha.13_react@17.0.2
       '@react-aria/aria-modal-polyfill': 3.6.1_pxzommwrsowkd4kgag6q3sluym
@@ -1863,11 +2064,11 @@ packages:
       '@react-aria/tooltip': 3.3.3_react@17.0.2
       '@react-aria/utils': 3.14.1_react@17.0.2
       '@react-aria/visually-hidden': 3.6.0_react@17.0.2
-      '@react-stately/checkbox': 3.3.0_react@17.0.2
+      '@react-stately/checkbox': 3.3.2_react@17.0.2
       '@react-stately/collections': 3.4.4_react@17.0.2
       '@react-stately/combobox': 3.2.2_react@17.0.2
       '@react-stately/list': 3.5.4_react@17.0.2
-      '@react-stately/menu': 3.4.2_react@17.0.2
+      '@react-stately/menu': 3.4.4_react@17.0.2
       '@react-stately/overlays': 3.4.2_react@17.0.2
       '@react-stately/radio': 3.6.0_react@17.0.2
       '@react-stately/select': 3.3.2_react@17.0.2
@@ -1875,7 +2076,7 @@ packages:
       '@react-stately/toggle': 3.4.2_react@17.0.2
       '@react-stately/tooltip': 3.2.2_react@17.0.2
       '@react-stately/tree': 3.3.4_react@17.0.2
-      '@udecode/plate': 18.11.2_6jhmma7zc7jn5whmtj2xi5zloy
+      '@udecode/plate': 19.0.5_46lb47almn5glegy4zpoj25ooe
       '@xstate/immer': 0.3.1_immer@9.0.12+xstate@4.28.1
       '@xstate/react': 1.6.3_gcyz5mxmyrgibkcjljkbjmosn4
       date-fns: 2.29.3
@@ -1894,189 +2095,14 @@ packages:
       remark-gfm: 3.0.1
       remark-parse: 10.0.1
       scheduler: 0.23.0
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-hyperscript: 0.77.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-hyperscript: 0.77.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
       tinycolor2: 1.4.2
       unified: 10.1.2
-      xstate: 4.28.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/hoist-non-react-statics'
-      - '@types/node'
-      - '@types/react'
-      - '@xstate/fsm'
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-native
-      - supports-color
-      - ts-node
-    dev: false
-
-  /@frontify/fondue/12.0.0-beta.34_angvksxlvvfhyjj3xhcshgfg2m:
-    resolution: {integrity: sha512-a+dAJ7tRDaPOAhxCn+tCQ/jB6giF/UHzS7oaNsQ/56Z9dXIoFIlMEX029wyLoPc3Hcv66icLThiPHjXEvCtUsw==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      react: ^17.0.0 || ^18.0.0
-      react-dom: ^17.0.0 || ^18.0.0
-    dependencies:
-      '@frontify/fondue-tokens': 3.2.0
-      '@popperjs/core': 2.11.6
-      '@react-aria/accordion': 3.0.0-alpha.13_react@17.0.2
-      '@react-aria/aria-modal-polyfill': 3.6.1_pxzommwrsowkd4kgag6q3sluym
-      '@react-aria/breadcrumbs': 3.4.0_react@17.0.2
-      '@react-aria/button': 3.6.3_react@17.0.2
-      '@react-aria/checkbox': 3.7.0_react@17.0.2
-      '@react-aria/combobox': 3.4.3_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/dialog': 3.4.1_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/focus': 3.10.0_react@17.0.2
-      '@react-aria/interactions': 3.13.0_react@17.0.2
-      '@react-aria/link': 3.3.5_react@17.0.2
-      '@react-aria/listbox': 3.7.1_react@17.0.2
-      '@react-aria/menu': 3.7.0_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/overlays': 3.12.0_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/radio': 3.4.1_react@17.0.2
-      '@react-aria/select': 3.8.3_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/selection': 3.12.0_react@17.0.2
-      '@react-aria/table': 3.6.0_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/tooltip': 3.3.3_react@17.0.2
-      '@react-aria/utils': 3.14.1_react@17.0.2
-      '@react-aria/visually-hidden': 3.6.0_react@17.0.2
-      '@react-stately/checkbox': 3.3.0_react@17.0.2
-      '@react-stately/collections': 3.4.4_react@17.0.2
-      '@react-stately/combobox': 3.2.2_react@17.0.2
-      '@react-stately/list': 3.5.4_react@17.0.2
-      '@react-stately/menu': 3.4.2_react@17.0.2
-      '@react-stately/overlays': 3.4.2_react@17.0.2
-      '@react-stately/radio': 3.6.0_react@17.0.2
-      '@react-stately/select': 3.3.2_react@17.0.2
-      '@react-stately/table': 3.5.0_react@17.0.2
-      '@react-stately/toggle': 3.4.2_react@17.0.2
-      '@react-stately/tooltip': 3.2.2_react@17.0.2
-      '@react-stately/tree': 3.3.4_react@17.0.2
-      '@udecode/plate': 18.11.2_6jhmma7zc7jn5whmtj2xi5zloy
-      '@xstate/immer': 0.3.1_immer@9.0.12+xstate@4.28.1
-      '@xstate/react': 1.6.3_gcyz5mxmyrgibkcjljkbjmosn4
-      date-fns: 2.29.3
-      escape-html: 1.0.3
-      framer-motion: 6.4.3_sfoxds7t5ydpegc3knd667wn6m
-      immer: 9.0.12
-      react: 17.0.2
-      react-colorful: 5.6.1_sfoxds7t5ydpegc3knd667wn6m
-      react-datepicker: 4.8.0_sfoxds7t5ydpegc3knd667wn6m
-      react-dnd: 16.0.1_pxzommwrsowkd4kgag6q3sluym
-      react-dnd-html5-backend: 15.1.2
-      react-dom: 17.0.2_react@17.0.2
-      react-is: 18.2.0
-      react-popper: 2.3.0_vov5yimr6vvxyufd6uigwwkst4
-      react-textarea-autosize: 8.4.0_pxzommwrsowkd4kgag6q3sluym
-      remark-gfm: 3.0.1
-      remark-parse: 10.0.1
-      scheduler: 0.23.0
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-hyperscript: 0.77.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
-      tinycolor2: 1.4.2
-      unified: 10.1.2
-      xstate: 4.28.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/hoist-non-react-statics'
-      - '@types/node'
-      - '@types/react'
-      - '@xstate/fsm'
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-native
-      - supports-color
-      - ts-node
-    dev: false
-
-  /@frontify/fondue/12.0.0-beta.34_rv2t7de65xq26o5frb4lun64yi:
-    resolution: {integrity: sha512-a+dAJ7tRDaPOAhxCn+tCQ/jB6giF/UHzS7oaNsQ/56Z9dXIoFIlMEX029wyLoPc3Hcv66icLThiPHjXEvCtUsw==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      react: ^17.0.0 || ^18.0.0
-      react-dom: ^17.0.0 || ^18.0.0
-    dependencies:
-      '@frontify/fondue-tokens': 3.2.0_ts-node@10.9.1
-      '@popperjs/core': 2.11.6
-      '@react-aria/accordion': 3.0.0-alpha.13_react@17.0.2
-      '@react-aria/aria-modal-polyfill': 3.6.1_pxzommwrsowkd4kgag6q3sluym
-      '@react-aria/breadcrumbs': 3.4.0_react@17.0.2
-      '@react-aria/button': 3.6.3_react@17.0.2
-      '@react-aria/checkbox': 3.7.0_react@17.0.2
-      '@react-aria/combobox': 3.4.3_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/dialog': 3.4.1_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/focus': 3.10.0_react@17.0.2
-      '@react-aria/interactions': 3.13.0_react@17.0.2
-      '@react-aria/link': 3.3.5_react@17.0.2
-      '@react-aria/listbox': 3.7.1_react@17.0.2
-      '@react-aria/menu': 3.7.0_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/overlays': 3.12.0_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/radio': 3.4.1_react@17.0.2
-      '@react-aria/select': 3.8.3_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/selection': 3.12.0_react@17.0.2
-      '@react-aria/table': 3.6.0_sfoxds7t5ydpegc3knd667wn6m
-      '@react-aria/tooltip': 3.3.3_react@17.0.2
-      '@react-aria/utils': 3.14.1_react@17.0.2
-      '@react-aria/visually-hidden': 3.6.0_react@17.0.2
-      '@react-stately/checkbox': 3.3.0_react@17.0.2
-      '@react-stately/collections': 3.4.4_react@17.0.2
-      '@react-stately/combobox': 3.2.2_react@17.0.2
-      '@react-stately/list': 3.5.4_react@17.0.2
-      '@react-stately/menu': 3.4.2_react@17.0.2
-      '@react-stately/overlays': 3.4.2_react@17.0.2
-      '@react-stately/radio': 3.6.0_react@17.0.2
-      '@react-stately/select': 3.3.2_react@17.0.2
-      '@react-stately/table': 3.5.0_react@17.0.2
-      '@react-stately/toggle': 3.4.2_react@17.0.2
-      '@react-stately/tooltip': 3.2.2_react@17.0.2
-      '@react-stately/tree': 3.3.4_react@17.0.2
-      '@udecode/plate': 18.11.2_6jhmma7zc7jn5whmtj2xi5zloy
-      '@xstate/immer': 0.3.1_immer@9.0.12+xstate@4.28.1
-      '@xstate/react': 1.6.3_gcyz5mxmyrgibkcjljkbjmosn4
-      date-fns: 2.29.3
-      escape-html: 1.0.3
-      framer-motion: 6.4.3_sfoxds7t5ydpegc3knd667wn6m
-      immer: 9.0.12
-      react: 17.0.2
-      react-colorful: 5.6.1_sfoxds7t5ydpegc3knd667wn6m
-      react-datepicker: 4.8.0_sfoxds7t5ydpegc3knd667wn6m
-      react-dnd: 16.0.1_smc5esni47gpbltvxzeziduyte
-      react-dnd-html5-backend: 15.1.2
-      react-dom: 17.0.2_react@17.0.2
-      react-is: 18.2.0
-      react-popper: 2.3.0_vov5yimr6vvxyufd6uigwwkst4
-      react-textarea-autosize: 8.4.0_pxzommwrsowkd4kgag6q3sluym
-      remark-gfm: 3.0.1
-      remark-parse: 10.0.1
-      scheduler: 0.23.0
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-hyperscript: 0.77.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
-      tinycolor2: 1.4.2
-      unified: 10.1.2
+      unist-util-visit: 4.1.1
       xstate: 4.28.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -2127,19 +2153,23 @@ packages:
       - terser
     dev: true
 
-  /@frontify/guideline-blocks-settings/0.25.2_angvksxlvvfhyjj3xhcshgfg2m:
+  /@frontify/guideline-blocks-settings/0.25.2_t2lnk2qhgvs3f2wqugd34vbhdu:
     resolution: {integrity: sha512-sVSHLZxoTpsRJ8OJ+NcqsoWmedRvP0puTEcJcc8fb4l4kdJ9fqAvk9oT2aMfid+RJzqFcK55kq/lGK4glXpaGA==}
+    peerDependencies:
+      '@frontify/app-bridge': '*'
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
-      '@frontify/sidebar-settings': 0.0.6_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 11.3.0_rv2t7de65xq26o5frb4lun64yi
+      '@frontify/sidebar-settings': 0.0.6_t2lnk2qhgvs3f2wqugd34vbhdu
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
       - '@types/hoist-non-react-statics'
       - '@types/node'
       - '@types/react'
+      - '@urql/core'
       - '@xstate/fsm'
+      - encoding
       - jotai-immer
       - jotai-optics
       - jotai-redux
@@ -2148,26 +2178,33 @@ packages:
       - jotai-valtio
       - jotai-xstate
       - jotai-zustand
+      - optics-ts
       - react
       - react-dom
-      - react-native
+      - react-query
       - supports-color
       - ts-node
+      - valtio
+      - wonka
     dev: false
 
-  /@frontify/guideline-blocks-settings/0.25.2_rv2t7de65xq26o5frb4lun64yi:
+  /@frontify/guideline-blocks-settings/0.25.2_vv7cpewgmcw25x4o2lxdmrwwxe:
     resolution: {integrity: sha512-sVSHLZxoTpsRJ8OJ+NcqsoWmedRvP0puTEcJcc8fb4l4kdJ9fqAvk9oT2aMfid+RJzqFcK55kq/lGK4glXpaGA==}
+    peerDependencies:
+      '@frontify/app-bridge': '*'
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_rv2t7de65xq26o5frb4lun64yi
-      '@frontify/sidebar-settings': 0.0.6_rv2t7de65xq26o5frb4lun64yi
+      '@frontify/fondue': 11.3.0_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/sidebar-settings': 0.0.6_vv7cpewgmcw25x4o2lxdmrwwxe
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
       - '@types/hoist-non-react-statics'
       - '@types/node'
       - '@types/react'
+      - '@urql/core'
       - '@xstate/fsm'
+      - encoding
       - jotai-immer
       - jotai-optics
       - jotai-redux
@@ -2176,25 +2213,32 @@ packages:
       - jotai-valtio
       - jotai-xstate
       - jotai-zustand
+      - optics-ts
       - react
       - react-dom
-      - react-native
+      - react-query
       - supports-color
       - ts-node
+      - valtio
+      - wonka
     dev: false
 
-  /@frontify/sidebar-settings/0.0.6_angvksxlvvfhyjj3xhcshgfg2m:
+  /@frontify/sidebar-settings/0.0.6_t2lnk2qhgvs3f2wqugd34vbhdu:
     resolution: {integrity: sha512-PD1hDFpqyz3+HXDhE1G4pnsCgd+yi2gJaaibEzBqSnmBPd0z4r9fJ6xC/nFGT6obsSK/6KDYm524M/ln90ZGfA==}
+    peerDependencies:
+      '@frontify/app-bridge': '*'
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_angvksxlvvfhyjj3xhcshgfg2m
+      '@frontify/fondue': 11.3.0_rv2t7de65xq26o5frb4lun64yi
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
       - '@types/hoist-non-react-statics'
       - '@types/node'
       - '@types/react'
+      - '@urql/core'
       - '@xstate/fsm'
+      - encoding
       - jotai-immer
       - jotai-optics
       - jotai-redux
@@ -2203,25 +2247,32 @@ packages:
       - jotai-valtio
       - jotai-xstate
       - jotai-zustand
+      - optics-ts
       - react
       - react-dom
-      - react-native
+      - react-query
       - supports-color
       - ts-node
+      - valtio
+      - wonka
     dev: false
 
-  /@frontify/sidebar-settings/0.0.6_rv2t7de65xq26o5frb4lun64yi:
+  /@frontify/sidebar-settings/0.0.6_vv7cpewgmcw25x4o2lxdmrwwxe:
     resolution: {integrity: sha512-PD1hDFpqyz3+HXDhE1G4pnsCgd+yi2gJaaibEzBqSnmBPd0z4r9fJ6xC/nFGT6obsSK/6KDYm524M/ln90ZGfA==}
+    peerDependencies:
+      '@frontify/app-bridge': '*'
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.30_sfoxds7t5ydpegc3knd667wn6m
-      '@frontify/fondue': 12.0.0-beta.35_rv2t7de65xq26o5frb4lun64yi
+      '@frontify/fondue': 11.3.0_angvksxlvvfhyjj3xhcshgfg2m
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
       - '@types/hoist-non-react-statics'
       - '@types/node'
       - '@types/react'
+      - '@urql/core'
       - '@xstate/fsm'
+      - encoding
       - jotai-immer
       - jotai-optics
       - jotai-redux
@@ -2230,11 +2281,14 @@ packages:
       - jotai-valtio
       - jotai-xstate
       - jotai-zustand
+      - optics-ts
       - react
       - react-dom
-      - react-native
+      - react-query
       - supports-color
       - ts-node
+      - valtio
+      - wonka
     dev: false
 
   /@humanwhocodes/config-array/0.11.7:
@@ -2553,6 +2607,10 @@ packages:
     resolution: {integrity: sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==}
     dev: true
 
+  /@popperjs/core/2.10.2:
+    resolution: {integrity: sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==}
+    dev: false
+
   /@popperjs/core/2.11.6:
     resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
     dev: false
@@ -2588,6 +2646,23 @@ packages:
       '@react-aria/utils': 3.14.1_react@17.0.2
       '@react-stately/tree': 3.4.0_react@17.0.2
       '@react-types/accordion': 3.0.0-alpha.11_react@17.0.2
+      '@react-types/button': 3.7.0_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-aria/accordion/3.0.0-alpha.9_react@17.0.2:
+    resolution: {integrity: sha512-3n55HzOKu9/JWdbASSdNE0KI4vKH1zsWVeoLgE9M5MXfgHYsOb/c7KkHIrBkC1oD03KdKioDlNENEXzBoOiI4w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.6
+      '@react-aria/button': 3.6.3_react@17.0.2
+      '@react-aria/interactions': 3.13.0_react@17.0.2
+      '@react-aria/selection': 3.12.0_react@17.0.2
+      '@react-aria/utils': 3.14.1_react@17.0.2
+      '@react-stately/tree': 3.4.0_react@17.0.2
+      '@react-types/accordion': 3.0.0-alpha.7_react@17.0.2
       '@react-types/button': 3.7.0_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
@@ -2630,7 +2705,7 @@ packages:
       '@react-aria/focus': 3.10.0_react@17.0.2
       '@react-aria/interactions': 3.13.0_react@17.0.2
       '@react-aria/utils': 3.14.1_react@17.0.2
-      '@react-stately/toggle': 3.4.3_react@17.0.2
+      '@react-stately/toggle': 3.4.4_react@17.0.2
       '@react-types/button': 3.7.0_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
@@ -2661,8 +2736,8 @@ packages:
       '@react-aria/label': 3.4.3_react@17.0.2
       '@react-aria/toggle': 3.4.1_react@17.0.2
       '@react-aria/utils': 3.14.1_react@17.0.2
-      '@react-stately/checkbox': 3.3.1_react@17.0.2
-      '@react-stately/toggle': 3.4.3_react@17.0.2
+      '@react-stately/checkbox': 3.3.2_react@17.0.2
+      '@react-stately/toggle': 3.4.4_react@17.0.2
       '@react-types/checkbox': 3.4.1_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
@@ -2703,7 +2778,7 @@ packages:
       '@react-aria/focus': 3.10.0_react@17.0.2
       '@react-aria/overlays': 3.12.0_sfoxds7t5ydpegc3knd667wn6m
       '@react-aria/utils': 3.14.1_react@17.0.2
-      '@react-stately/overlays': 3.4.3_react@17.0.2
+      '@react-stately/overlays': 3.4.4_react@17.0.2
       '@react-types/dialog': 3.4.5_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
@@ -2872,7 +2947,7 @@ packages:
       '@react-aria/selection': 3.12.0_react@17.0.2
       '@react-aria/utils': 3.14.1_react@17.0.2
       '@react-stately/collections': 3.5.0_react@17.0.2
-      '@react-stately/menu': 3.4.3_react@17.0.2
+      '@react-stately/menu': 3.4.4_react@17.0.2
       '@react-stately/tree': 3.4.0_react@17.0.2
       '@react-types/button': 3.7.0_react@17.0.2
       '@react-types/menu': 3.7.3_react@17.0.2
@@ -2894,7 +2969,7 @@ packages:
       '@react-aria/ssr': 3.4.0_react@17.0.2
       '@react-aria/utils': 3.14.1_react@17.0.2
       '@react-aria/visually-hidden': 3.6.0_react@17.0.2
-      '@react-stately/overlays': 3.4.3_react@17.0.2
+      '@react-stately/overlays': 3.4.4_react@17.0.2
       '@react-types/button': 3.7.0_react@17.0.2
       '@react-types/overlays': 3.6.5_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
@@ -3014,7 +3089,7 @@ packages:
       '@react-aria/focus': 3.10.0_react@17.0.2
       '@react-aria/interactions': 3.13.0_react@17.0.2
       '@react-aria/utils': 3.14.1_react@17.0.2
-      '@react-stately/toggle': 3.4.3_react@17.0.2
+      '@react-stately/toggle': 3.4.4_react@17.0.2
       '@react-types/checkbox': 3.4.1_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       '@react-types/switch': 3.2.5_react@17.0.2
@@ -3056,7 +3131,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.6
       '@react-aria/ssr': 3.4.0_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       clsx: 1.2.1
       react: 17.0.2
@@ -3079,16 +3154,36 @@ packages:
     resolution: {integrity: sha512-0XhqJSc6pPoNnf8DhdsPHtUhRzZALVzYMTzRwV4VI6DJNJ/5xxfL9OQUwb8IH5/2x7lSf7nAZrnzUD+16VyOVQ==}
     dev: false
 
+  /@react-dnd/asap/4.0.1:
+    resolution: {integrity: sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==}
+    dev: false
+
   /@react-dnd/asap/5.0.2:
     resolution: {integrity: sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==}
+    dev: false
+
+  /@react-dnd/invariant/2.0.0:
+    resolution: {integrity: sha512-xL4RCQBCBDJ+GRwKTFhGUW8GXa4yoDfJrPbLblc3U09ciS+9ZJXJ3Qrcs/x2IODOdIE5kQxvMmE2UKyqUictUw==}
     dev: false
 
   /@react-dnd/invariant/3.0.0:
     resolution: {integrity: sha512-keberJRIqPX15IK3SWS/iO1t/kGETiL1oczKrDitAaMnQ+kpHf81l3MrRmFjvfqcnApE+izEvwM6GsyoIcpsVA==}
     dev: false
 
+  /@react-dnd/invariant/3.0.1:
+    resolution: {integrity: sha512-blqduwV86oiKw2Gr44wbe3pj3Z/OsXirc7ybCv9F/pLAR+Aih8F3rjeJzK0ANgtYKv5lCpkGVoZAeKitKDaD/g==}
+    dev: false
+
   /@react-dnd/invariant/4.0.2:
     resolution: {integrity: sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==}
+    dev: false
+
+  /@react-dnd/shallowequal/2.0.0:
+    resolution: {integrity: sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==}
+    dev: false
+
+  /@react-dnd/shallowequal/3.0.1:
+    resolution: {integrity: sha512-XjDVbs3ZU16CO1h5Q3Ew2RPJqmZBDE/EVf1LYp6ePEffs3V/MX9ZbL5bJr8qiK5SbGmUMuDoaFgyKacYz8prRA==}
     dev: false
 
   /@react-dnd/shallowequal/4.0.2:
@@ -3103,29 +3198,29 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@react-stately/checkbox/3.3.0_react@17.0.2:
-    resolution: {integrity: sha512-hYFJzEoreAmUKkcgd3ErDXtEqp65pfawfcygOr/3pe7MUGzl+MaauVUOg6Dh02Bxt+mdSX4mQXbJSfvm+8bmfA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.20.6
-      '@react-stately/toggle': 3.4.3_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
-      '@react-types/checkbox': 3.4.1_react@17.0.2
-      '@react-types/shared': 3.16.0_react@17.0.2
-      react: 17.0.2
-    dev: false
-
   /@react-stately/checkbox/3.3.1_react@17.0.2:
     resolution: {integrity: sha512-r2hL11GF9r2ztUFEhpiVgiXgE+W99tyL1Kt7rOiTZ8/aMBGWwBxOHAdHeqcWFeBgOztXuJsKiDu82necEG4xhA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.20.6
-      '@react-stately/toggle': 3.4.3_react@17.0.2
+      '@react-stately/toggle': 3.4.4_react@17.0.2
       '@react-stately/utils': 3.5.1_react@17.0.2
       '@react-types/checkbox': 3.4.1_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-stately/checkbox/3.3.2_react@17.0.2:
+    resolution: {integrity: sha512-eU3zvWgQrcqS8UK8ZVkb3fMP816PeuN9N0/dOJKuOXXhkoLPuxtuja1oEqKU3sFMa5+bx3czZhhNIRpr60NAdw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-stately/toggle': 3.4.4_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
+      '@react-types/checkbox': 3.4.1_react@17.0.2
+      '@react-types/shared': 3.16.0_react@17.0.2
+      '@swc/helpers': 0.4.14
       react: 17.0.2
     dev: false
 
@@ -3156,9 +3251,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.6
       '@react-stately/list': 3.6.0_react@17.0.2
-      '@react-stately/menu': 3.4.3_react@17.0.2
+      '@react-stately/menu': 3.4.4_react@17.0.2
       '@react-stately/select': 3.3.3_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/combobox': 3.5.5_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
@@ -3171,9 +3266,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.6
       '@react-stately/list': 3.6.0_react@17.0.2
-      '@react-stately/menu': 3.4.3_react@17.0.2
+      '@react-stately/menu': 3.4.4_react@17.0.2
       '@react-stately/select': 3.3.3_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/combobox': 3.5.5_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
@@ -3212,7 +3307,7 @@ packages:
       '@babel/runtime': 7.20.6
       '@react-stately/collections': 3.5.0_react@17.0.2
       '@react-stately/selection': 3.11.1_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
@@ -3225,34 +3320,21 @@ packages:
       '@babel/runtime': 7.20.6
       '@react-stately/collections': 3.5.0_react@17.0.2
       '@react-stately/selection': 3.11.1_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
-  /@react-stately/menu/3.4.2_react@17.0.2:
-    resolution: {integrity: sha512-vFC8EloVEcqf6sgiP6ABIkC41ytjoJiGtj7Ws5OS7PvZNyxxDgJr4V0O3Pxd1T0AjlHCloBbojnvoTRwZiSr/A==}
+  /@react-stately/menu/3.4.4_react@17.0.2:
+    resolution: {integrity: sha512-WKak1NSV9yDY0tDB4mzsbj0FboTtR06gekio0VmKb1+FmnrC07mef8eGKUn974F0WhTNUy5A1iI5eM0W2YNynA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.20.6
-      '@react-stately/overlays': 3.4.3_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/overlays': 3.4.4_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/menu': 3.7.3_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
-      react: 17.0.2
-    dev: false
-
-  /@react-stately/menu/3.4.3_react@17.0.2:
-    resolution: {integrity: sha512-ZWym6XQSLaC5uFUTZl6+mreEgzc8EUG6ElcnvdXYcH4DWUfswhLxCi3IdnG0lusWEi4NcHbZ2prEUxpT8VKqrg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.20.6
-      '@react-stately/overlays': 3.4.3_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
-      '@react-types/menu': 3.7.3_react@17.0.2
-      '@react-types/shared': 3.16.0_react@17.0.2
+      '@swc/helpers': 0.4.14
       react: 17.0.2
     dev: false
 
@@ -3262,19 +3344,19 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.20.6
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/overlays': 3.6.5_react@17.0.2
       react: 17.0.2
     dev: false
 
-  /@react-stately/overlays/3.4.3_react@17.0.2:
-    resolution: {integrity: sha512-WZCr3J8hj0cplQki1OVBR3MXg2l9V017h15Y2h+TNduWvnKH0yYOE/XfWviAT4KUP0LYoQfCnZ7XMHv+UI+8JA==}
+  /@react-stately/overlays/3.4.4_react@17.0.2:
+    resolution: {integrity: sha512-IIlx+VXtXS4snDXrocUOls8QZ5XBQ4SNonaz1ox8/5W7Nsvq4VtdKsIaXsUP4agOudswaimlpj3pTDO/KuF5tQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.20.6
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/overlays': 3.6.5_react@17.0.2
+      '@swc/helpers': 0.4.14
       react: 17.0.2
     dev: false
 
@@ -3284,7 +3366,7 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.20.6
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/radio': 3.3.1_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
@@ -3296,7 +3378,7 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.20.6
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/radio': 3.3.1_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
@@ -3310,9 +3392,9 @@ packages:
       '@babel/runtime': 7.20.6
       '@react-stately/collections': 3.5.0_react@17.0.2
       '@react-stately/list': 3.6.0_react@17.0.2
-      '@react-stately/menu': 3.4.3_react@17.0.2
+      '@react-stately/menu': 3.4.4_react@17.0.2
       '@react-stately/selection': 3.11.1_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/select': 3.6.5_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
@@ -3326,9 +3408,9 @@ packages:
       '@babel/runtime': 7.20.6
       '@react-stately/collections': 3.5.0_react@17.0.2
       '@react-stately/list': 3.6.0_react@17.0.2
-      '@react-stately/menu': 3.4.3_react@17.0.2
+      '@react-stately/menu': 3.4.4_react@17.0.2
       '@react-stately/selection': 3.11.1_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/select': 3.6.5_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
@@ -3341,7 +3423,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.6
       '@react-stately/collections': 3.5.0_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
@@ -3394,21 +3476,21 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.20.6
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/checkbox': 3.4.1_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
 
-  /@react-stately/toggle/3.4.3_react@17.0.2:
-    resolution: {integrity: sha512-HsJLMa5d9i6SWyDIahkJExkanXZek86//hirsgSU0IvY7YJx33Wek8UwHE5Vskp39DAOu18QMz2GrAngnUErYQ==}
+  /@react-stately/toggle/3.4.4_react@17.0.2:
+    resolution: {integrity: sha512-OwVJpd2M7P7fekTWpl3TUdD3Brq+Z/xElOCJYP5QuVytXCa5seKsk40YPld8JQnA5dRKojpbUxMDOJpb6hOOfw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.20.6
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/checkbox': 3.4.1_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
+      '@swc/helpers': 0.4.14
       react: 17.0.2
     dev: false
 
@@ -3418,8 +3500,8 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.20.6
-      '@react-stately/overlays': 3.4.3_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/overlays': 3.4.4_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/tooltip': 3.2.5_react@17.0.2
       react: 17.0.2
     dev: false
@@ -3430,8 +3512,8 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.20.6
-      '@react-stately/overlays': 3.4.3_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/overlays': 3.4.4_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/tooltip': 3.2.5_react@17.0.2
       react: 17.0.2
     dev: false
@@ -3444,7 +3526,7 @@ packages:
       '@babel/runtime': 7.20.6
       '@react-stately/collections': 3.5.0_react@17.0.2
       '@react-stately/selection': 3.11.1_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
@@ -3457,7 +3539,7 @@ packages:
       '@babel/runtime': 7.20.6
       '@react-stately/collections': 3.5.0_react@17.0.2
       '@react-stately/selection': 3.11.1_react@17.0.2
-      '@react-stately/utils': 3.5.1_react@17.0.2
+      '@react-stately/utils': 3.5.2_react@17.0.2
       '@react-types/shared': 3.16.0_react@17.0.2
       react: 17.0.2
     dev: false
@@ -3468,6 +3550,15 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.20.6
+      react: 17.0.2
+    dev: false
+
+  /@react-stately/utils/3.5.2_react@17.0.2:
+    resolution: {integrity: sha512-639gSKqamPHIEPaApb9ahVJS0HgAqNdVF3tQRoh+Ky6759Mbk6i3HqG4zk4IGQ1tVlYSYZvCckwehF7b2zndMg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@swc/helpers': 0.4.14
       react: 17.0.2
     dev: false
 
@@ -3484,6 +3575,15 @@ packages:
 
   /@react-types/accordion/3.0.0-alpha.11_react@17.0.2:
     resolution: {integrity: sha512-7TAvvMnfSWtX4gkmRg3pE31y/E/oTWfUAIi9WT4hPJBbE/8zItjD2P5cQ5tLizXT87fnm+4s8jvci7gZcN2/pw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/shared': 3.16.0_react@17.0.2
+      react: 17.0.2
+    dev: false
+
+  /@react-types/accordion/3.0.0-alpha.7_react@17.0.2:
+    resolution: {integrity: sha512-h5Nvf/+O+Cl/Vw6m3RNGD3hv7VwKX0ilJe1a473iJgjruzMQybSgpcCdWES31QZdEE+rkjpqTGoG22MusEOE+Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
@@ -3732,6 +3832,174 @@ packages:
     resolution: {integrity: sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==}
     dev: false
 
+  /@storybook/addon-a11y/6.5.16_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-/e9s34o+TmEhy+Q3/YzbRJ5AJ/Sy0gjZXlvsCrcRpiQLdt5JRbN8s+Lbn/FWxy8U1Tb1wlLYlqjJ+fYi5RrS3A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@storybook/addons': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/api': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/channels': 6.5.16
+      '@storybook/client-logger': 6.5.16
+      '@storybook/components': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/core-events': 6.5.16
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/theming': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
+      axe-core: 4.6.3
+      core-js: 3.27.2
+      global: 4.4.0
+      lodash: 4.17.21
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-sizeme: 3.0.2
+      regenerator-runtime: 0.13.11
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    dev: false
+
+  /@storybook/addons/6.5.16_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-p3DqQi+8QRL5k7jXhXmJZLsE/GqHqyY6PcoA1oNTJr0try48uhTGUOYkgzmqtDaa/qPFO5LP+xCPzZXckGtquQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/api': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/channels': 6.5.16
+      '@storybook/client-logger': 6.5.16
+      '@storybook/core-events': 6.5.16
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/router': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/theming': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
+      '@types/webpack-env': 1.18.0
+      core-js: 3.27.2
+      global: 4.4.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      regenerator-runtime: 0.13.11
+    dev: false
+
+  /@storybook/api/6.5.16_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-HOsuT8iomqeTMQJrRx5U8nsC7lJTwRr1DhdD0SzlqL4c80S/7uuCy4IZvOt4sYQjOzW5fOo/kamcoBXyLproTA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/channels': 6.5.16
+      '@storybook/client-logger': 6.5.16
+      '@storybook/core-events': 6.5.16
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/router': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/semver': 7.3.2
+      '@storybook/theming': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
+      core-js: 3.27.2
+      fast-deep-equal: 3.1.3
+      global: 4.4.0
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      regenerator-runtime: 0.13.11
+      store2: 2.14.2
+      telejson: 6.0.8
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    dev: false
+
+  /@storybook/channels/6.5.16:
+    resolution: {integrity: sha512-VylzaWQZaMozEwZPJdyJoz+0jpDa8GRyaqu9TGG6QGv+KU5POoZaGLDkRE7TzWkyyP0KQLo80K99MssZCpgSeg==}
+    dependencies:
+      core-js: 3.27.2
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    dev: false
+
+  /@storybook/client-logger/6.5.16:
+    resolution: {integrity: sha512-pxcNaCj3ItDdicPTXTtmYJE3YC1SjxFrBmHcyrN+nffeNyiMuViJdOOZzzzucTUG0wcOOX8jaSyak+nnHg5H1Q==}
+    dependencies:
+      core-js: 3.27.2
+      global: 4.4.0
+    dev: false
+
+  /@storybook/components/6.5.16_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-LzBOFJKITLtDcbW9jXl0/PaG+4xAz25PK8JxPZpIALbmOpYWOAPcO6V9C2heX6e6NgWFMUxjplkULEk9RCQMNA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/client-logger': 6.5.16
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/theming': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
+      core-js: 3.27.2
+      memoizerific: 1.11.3
+      qs: 6.11.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      regenerator-runtime: 0.13.11
+      util-deprecate: 1.0.2
+    dev: false
+
+  /@storybook/core-events/6.5.16:
+    resolution: {integrity: sha512-qMZQwmvzpH5F2uwNUllTPg6eZXr2OaYZQRRN8VZJiuorZzDNdAFmiVWMWdkThwmyLEJuQKXxqCL8lMj/7PPM+g==}
+    dependencies:
+      core-js: 3.27.2
+    dev: false
+
+  /@storybook/csf/0.0.2--canary.4566f4d.1:
+    resolution: {integrity: sha512-9OVvMVh3t9znYZwb0Svf/YQoxX2gVOeQTGe2bses2yj+a3+OJnCrUF3/hGv6Em7KujtOdL2LL+JnG49oMVGFgQ==}
+    dependencies:
+      lodash: 4.17.21
+    dev: false
+
+  /@storybook/router/6.5.16_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-ZgeP8a5YV/iuKbv31V8DjPxlV4AzorRiR8OuSt/KqaiYXNXlOoQDz/qMmiNcrshrfLpmkzoq7fSo4T8lWo2UwQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/client-logger': 6.5.16
+      core-js: 3.27.2
+      memoizerific: 1.11.3
+      qs: 6.11.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      regenerator-runtime: 0.13.11
+    dev: false
+
+  /@storybook/semver/7.3.2:
+    resolution: {integrity: sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      core-js: 3.27.2
+      find-up: 4.1.0
+    dev: false
+
+  /@storybook/theming/6.5.16_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-hNLctkjaYLRdk1+xYTkC1mg4dYz2wSv6SqbLpcKMbkPHTE0ElhddGPHQqB362md/w9emYXNkt1LSMD8Xk9JzVQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/client-logger': 6.5.16
+      core-js: 3.27.2
+      memoizerific: 1.11.3
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      regenerator-runtime: 0.13.11
+    dev: false
+
+  /@swc/helpers/0.4.14:
+    resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
+    dependencies:
+      tslib: 2.4.1
+    dev: false
+
   /@testing-library/react-hooks/8.0.1_hiunvzosbwliizyirxfy6hjyim:
     resolution: {integrity: sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==}
     engines: {node: '>=12'}
@@ -3825,6 +4093,10 @@ packages:
     dependencies:
       '@types/node': 18.7.21
     dev: true
+
+  /@types/is-function/1.0.1:
+    resolution: {integrity: sha512-A79HEEiwXTFtfY+Bcbo58M2GRYzCr9itHWzbzHVFNEYCcoU/MMGwYYf721gBrnhpj1s6RGVVha/IgNFnR0Iw/Q==}
+    dev: false
 
   /@types/is-hotkey/0.1.7:
     resolution: {integrity: sha512-yB5C7zcOM7idwYZZ1wKQ3pTfjA9BbvFqRWvKB46GFddxnJtHwi/b9y84ykQtxQPg5qhdpg4Q/kWU3EGoCTmLzQ==}
@@ -3929,6 +4201,10 @@ packages:
 
   /@types/unist/2.0.6:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
+
+  /@types/webpack-env/1.18.0:
+    resolution: {integrity: sha512-56/MAlX5WMsPVbOg7tAxnYvNYMMWr/QJiIp6BxVSW3JJXUVzzOn64qW8TzQyMSqSUFM2+PVI4aUHcHOzIz/1tg==}
+    dev: false
 
   /@types/yauzl/2.10.0:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
@@ -4067,21 +4343,48 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
-  /@udecode/plate-alignment/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-ZeKANQVJZDHjBZTH73YQtBh952p8u4R6G3cX7JnfM9TbbIdEBCeW3JfADL72JMv0m++AwXRUbGvYirMX/RQ8Eg==}
+  /@udecode/plate-alignment/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-3edw9HIgKds72dxgfl3IaBA0dUOFZlDUoBvqWOp4UFxA0eMq32VZz8SIfgmmjt+9XF7bVzBv+VOwRIWpFZVP1g==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-alignment/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-mwq0OvAv0FxplK0e1AkQ3WbCvMtBqEOYSOPKwz5/UjvltwAOHHypZbI28iIAzQd9pNAclD5GnIDxqh0eGlLYKg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4097,21 +4400,48 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-autoformat/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-hr/zLsdSvXoEGD8Xm8Uv45lNAcGeovQ9gOeb5eMlIIaPUPW27HvrX8MYDpstUS4RVwMV2w9kLdXpgHpbhL1nJg==}
+  /@udecode/plate-autoformat/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-7rG9jRysWtCVZoyx/4LbOc/nwTyN7rrV177PzoY5EY4TNRR2tydsMxWtUriNL3+HBnNNvsUq+OQHU6h1h6rV9Q==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-autoformat/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-6jb5C0Vthy/xzXq2gQ1w/oy/if+g+Fw1LVEM4hzvwi50F6b4jOdhl8vWID+XflOf6yfAV1TzQj+QVdEyVHbE6g==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4127,25 +4457,56 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-basic-elements/18.10.1_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-hVggC2dFsvDOt90OkqJywlHoJ+sKNJbgsX4O5wNcEC+uJ87XVYfUuzNx6jKef2Q/ThTVcBXNric73VHmPjcOFw==}
+  /@udecode/plate-basic-elements/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-2SACTm0qKTHiNESfEwa4cScx242Mk1y+qg5+x+03DAT3Y8e11P5tjAYhnBlKA6no1rVlkkCCLlt4Uzg3h4ciHA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-block-quote': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-code-block': 18.10.1_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-heading': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-paragraph': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-block-quote': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-code-block': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-heading': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-paragraph': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-basic-elements/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-Dl5pAfyQ9iOe7O84hp9PosX46c3GUkZNhDLp705UkVxjLTvbZt++4kyInUN79kvN6lHUji/OXxjqPaIJNPS0CA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-block-quote': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-code-block': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-heading': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-paragraph': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4161,21 +4522,48 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-basic-marks/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-L/n0fBGr8GsN+TTSLWLSddCP4QlDDNYOzGzReb9YAiF1AvzSTE8gTgic+T2rfk7uv04Gig/MiBcnK6uU/iekMQ==}
+  /@udecode/plate-basic-marks/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-HQlHt+kdmtR+jz5VEOmj0bwZTY102vA3m4/tAWWlcgAvxiFH1GlN/+z6U8b6cCFK81d/AneklOnL8QRkkhnJDA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-basic-marks/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-e1C1yKRis+V1RsEirbQ5+mQ5iwbNKEWMXKVmGBkIcVHu5vbXjf3s31Upe4qyaETSfXoqkQenTqIJhBvfOgjjSg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4191,21 +4579,48 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-block-quote/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-MgfwBwj2fKaPvIy66ElnIZCeiBtSDJEiY640IOodslyFEJinsrKdq4YmD8iPifsYWoVAkveGYmsiOHvSgESzTQ==}
+  /@udecode/plate-block-quote/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-z90pBVH6o5TMGeLdtc/n7p8gZTKrgOTIeANP2Cc1lZbgnOVzSnbasqrP43beOczvJMRub1QiGNhhYGAnmjrHYA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-block-quote/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-3F6TEBEkoTEfwrV5p+7zCOyDn4wq5zUjFwbPz4Dua0ZcKLEcBQT2wzXws8Z94dqdSguCy619E2ep0jQKXPq1RQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4221,21 +4636,48 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-break/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-spYxIpVj+A82DDj7eE13zXT7H0PUFjXvKkHG+uUUbdvj2H8kreGFWnjuK38QP17/m2lvSwgK1EqUMbQ7qmsw1g==}
+  /@udecode/plate-break/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-C7VfPFEAFeNMkmZAYIwkJ9mmDUw3gWQ6ebI8AH8qRnhfWnpM7Q1z2gUq3aMQTVtsaFLryxmV57LyXSZBP4e24A==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-break/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-UvAd/pmVNFZ+0sV2MU9xiPy/hL3z88Ol8C4DqKR/uYLU4mjFksAu3gtAVxzVe8mgqVugTLb4ppnB1/d3BZ7UOg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4251,21 +4693,21 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-button/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-USgJNBUPb9dAyxK9EmlsX6xA8aCI5DcQNo7SzIFG0P2xlXWCu6dgoVCEUSr+1qkVGD5UUGGKG+2b3rEwdgwfgw==}
+  /@udecode/plate-button/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-99B5aTr63WrP4bfv2OCQLnVQ6tqLNIJFkHy9hXDJw/c4Ar5gMpsOPvP/KpztGG0V3SlyBm62xGxZk8pXhvgTuw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4281,16 +4723,16 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-code-block/18.10.1_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-E9Y49//guut/XnCG4lBGQh5Zn2kTWnrUxex+GJ8BVmOvnjJuOBDQIttw+NOPvDOKyyfj2hvMz1L1As3oJ117kw==}
+  /@udecode/plate-code-block/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-J3M0HDVpzoYRHfIlXoSZgzfCFoSEOZJUxsZZKVnCMHEWKCB6UFYCoG5HGlQCMkUbquqHNRe/AJXJPIu8bf3+9A==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       prismjs: 1.29.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -4300,6 +4742,34 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-code-block/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-8Vr7Dx5M4r/tYEO2Lw04Chhw5fvE2Cq+wRv+4jJAcpLPqhXXPam8nyHCi23UVshP2h2jPK4zabzHhEVbageejg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      prismjs: 1.29.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
       - jotai-immer
       - jotai-optics
       - jotai-redux
@@ -4312,23 +4782,53 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-combobox/18.9.0_wgehzp42gx63lvcvbao2qouxoq:
-    resolution: {integrity: sha512-MHscNBBE6Mwz1uaBfiTVL/bExUIFff4dIOAH2/b5Lmpqp5jyKic3BK1GrP3r6eSflh40JoE/6XKNHGAnTngIFQ==}
+  /@udecode/plate-combobox/10.6.0_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-4wZpUqnAaf9M7nT6oNX5lJBoZ60q5cWwgBXDUmuoULgV9d8JdmA3JnKUoc3uXXU1cbmSlIBroT6PkOY6A1Oz3Q==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-floating': 18.9.0_wgehzp42gx63lvcvbao2qouxoq
-      downshift: 6.1.12_react@17.0.2
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/zustood': 0.4.4_zustand@3.7.0
+      downshift: 6.1.7_react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      zustand: 3.7.0_react@17.0.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-combobox/19.0.3_qtly5dcswxon57yu7bqc3bfm3i:
+    resolution: {integrity: sha512-2Rg0GW+ySgqV5T4tBF8hlVFggWyaJxMnUxiHSG8untpugXTnksLVugN0kzTEcykXg3BSk7orwRIaFhE9C4aCNA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-floating': 19.0.3_qtly5dcswxon57yu7bqc3bfm3i
+      downshift: 6.1.12_react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4345,14 +4845,77 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-core/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-QYOB/+Y0OGELf426bigwloMBg8K+d+nNL7lmxdLj9ios4FiF0aVidVcP75uyHDC7Vy/9bpiF5Ti8lda4d/n4wQ==}
+  /@udecode/plate-comments/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-zWss+zlXnX6tUF2iptcwPNITmJPHKZHjxD4SZc406WNr8Pm7vdyq26W4YpkeHD0ceNJQT4px3M3+5/ldmKlDwg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-button': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-core/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-OBu02wPV80AC55GmFUtB8WAWKDEYLzLiV8M9FODZjQXpp5QkVkE5947nEZR6qwnTwIzYNm41oY8YrJF3PcmjoA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
+    dependencies:
+      '@udecode/zustood': 0.4.4_zustand@3.7.0
+      clsx: 1.1.1
+      jotai: 1.5.3_rry5ecjlappe67zcdjx5wnrgka
+      lodash: 4.17.21
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.78.0
+      slate-history: 0.66.0_slate@0.78.0
+      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      use-deep-compare: 1.1.0_react@17.0.2
+      zustand: 3.7.0_react@17.0.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-core/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-DFWC6qGsCHdteAabiTVoaTNAP8BhbR3IdocJAyQju9GdQmfQjAF2gwVTSBGyhkdCFbOAEocsNJo1n0FcqENn5w==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
     dependencies:
       '@radix-ui/react-slot': 1.0.1_react@17.0.2
       '@udecode/zustood': 1.1.3_j4l4zfucqqy5rkq7yejc6ewt2u
@@ -4363,9 +4926,9 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-hotkeys-hook: 3.4.7_sfoxds7t5ydpegc3knd667wn6m
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       use-deep-compare: 1.1.0_react@17.0.2
       zustand: 3.7.2_react@17.0.2
     transitivePeerDependencies:
@@ -4383,23 +4946,23 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-emoji/18.11.2_wgehzp42gx63lvcvbao2qouxoq:
-    resolution: {integrity: sha512-s1ggX+l2EYUXlni5xGhbvRbbxORvThIThNUxosysl2IN8AE8f4Lo32uNyHVUrGiLFhav9687W4i3JWefP0JMaQ==}
+  /@udecode/plate-emoji/19.0.5_qtly5dcswxon57yu7bqc3bfm3i:
+    resolution: {integrity: sha512-Gd/A9QYXNIRfY6Mxex7jgeQvVjtF6tWYjcT/zyhO9s5c+X1IhzjB1gGSje983EZ17F+b2ZfAMVBL0goDsMJs3g==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
     dependencies:
       '@emoji-mart/data': 1.0.8
-      '@udecode/plate-combobox': 18.9.0_wgehzp42gx63lvcvbao2qouxoq
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-combobox': 19.0.3_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4416,21 +4979,48 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-find-replace/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-HUZGDQ/A7HmioBAH5Aa+6X1zyPTxax0vkMbfaazP87isuQPIYdsR4iHtLHB2NBxImxOk1AK5ZJxBNsSEt0lb7A==}
+  /@udecode/plate-find-replace/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-aJWrjzi6vCAEiqVDTj+qhjm5qB4BmQzB4Lxov3Dl1fen4P/lQH05BNYIFTrTz3Vn4V7ERvUFB73aXwRElBNArQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-find-replace/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-eDuLpr5xUVij32qWsBHSa3Dywdpz3lOQOaYKlVIwLiJEGz5DfYXqIAf7UtTHCGcqwJl9faSl5gVVGAe7VFJ5UQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4446,22 +5036,22 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-floating/18.9.0_wgehzp42gx63lvcvbao2qouxoq:
-    resolution: {integrity: sha512-X0Df7D+/DZxs3l6KuhvXPNcL0izHbQ5L0VD2XxJTETgPRvI036k7lWgnTM0ZtoRD2XLtMqk1OMoeiwQzhLwBpw==}
+  /@udecode/plate-floating/19.0.3_qtly5dcswxon57yu7bqc3bfm3i:
+    resolution: {integrity: sha512-yY1axG4rfNPDZ/dqI9W/czXE8gL1zh8VY0egc3ObdfIAKi506oiLqbe98wBphI19pBKihF70Cg4Wnjn1+IviSQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
     dependencies:
       '@floating-ui/react-dom-interactions': 0.6.6_hiunvzosbwliizyirxfy6hjyim
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4478,21 +5068,48 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-font/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-HaXJ78NYHp5bCFdZtAlOJBAf5TzkQuN5YL3OAG6ld7SIi6GDgPvnfAwzON+WrpAT1zjBGgghxHFqaLo+/9CasQ==}
+  /@udecode/plate-font/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-ryZfztmL9/sm7HfqOXtEIIX7A5ziO4BbEKMEFmIH1Gpq9oD2adRm1GfigvBJyWa/Shv55mZ48CctFbnrWydzmw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-font/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-mAP7uB50nxh892TNPVjJWqlM3pnT5sMt2/Ao/YfVJdqK5OnLcUrWl+bos+Yqd2a7tCQ0oljChCoZCn5FaeX+sw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4508,21 +5125,48 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-heading/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-4MoGcG7IiZcSRRKM87aKj1EFo55HIwA2S8wjsX2coh3YjAJPjf64ZqlX6ArXjH4W9xtoxRk1kquxI0nFp79spg==}
+  /@udecode/plate-heading/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-mOPA86HMkwQ1cCxVnKq5BnLhr3rburHc9u/5iIfsc9kDQsCqTw83OBEDncJ1WD1JAqcRSf2kD7gbkOONdwSguw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-heading/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-VYzAGlqSkh7bJq6YpaG6NEUUYZN3Tz9dPlByzqZkXUl99p/iHIZWChsU6cREBUbjQ5nV0GrKnYLCaGRxVM+v8Q==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4538,59 +5182,123 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-headless/18.11.2_apsly3itnks4vinztrxz3j36ey:
-    resolution: {integrity: sha512-HvuDdaXqMr402qcDyA2aLA4HYCaxMOnTOlbd4ML9F6U3BkPVTxmos4cilFxDJZ+9sOiMa8BWPrlIF7Q1BSd56g==}
+  /@udecode/plate-headless/10.6.0_cqokrydfgvnsbtmsouizrlndxm:
+    resolution: {integrity: sha512-JgZypic3z5dfAPbSxwg3hoQiOqF4kgugc4c8a0SLR3ooIAvf5XGJZdvd/5KBu9qD8bRFA7tEFVmeKWUJloEdQA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
       slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-alignment': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-autoformat': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-basic-elements': 18.10.1_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-basic-marks': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-block-quote': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-break': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-button': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-code-block': 18.10.1_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-combobox': 18.9.0_wgehzp42gx63lvcvbao2qouxoq
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-emoji': 18.11.2_wgehzp42gx63lvcvbao2qouxoq
-      '@udecode/plate-find-replace': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-floating': 18.9.0_wgehzp42gx63lvcvbao2qouxoq
-      '@udecode/plate-font': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-heading': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-highlight': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-horizontal-rule': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-indent': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-indent-list': 18.9.2_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-kbd': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-line-height': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-link': 18.11.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-list': 18.9.2_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-media': 18.9.0_wgehzp42gx63lvcvbao2qouxoq
-      '@udecode/plate-mention': 18.10.3_wgehzp42gx63lvcvbao2qouxoq
-      '@udecode/plate-node-id': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-normalizers': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-paragraph': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-reset-node': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-select': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-selection': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-serializer-csv': 18.11.0_yaj5njjgkl3zcwcfy656sml5ym
-      '@udecode/plate-serializer-docx': 18.11.0_apsly3itnks4vinztrxz3j36ey
-      '@udecode/plate-serializer-html': 18.9.0_yaj5njjgkl3zcwcfy656sml5ym
-      '@udecode/plate-serializer-md': 18.11.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-table': 18.11.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-trailing-block': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-alignment': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-autoformat': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-basic-elements': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-basic-marks': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-block-quote': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-break': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-code-block': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-combobox': 10.6.0_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-find-replace': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-font': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-heading': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-highlight': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-horizontal-rule': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-image': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-indent': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-indent-list': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-juice': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-kbd': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-line-height': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-link': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-list': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-media-embed': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-mention': 10.6.0_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-node-id': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-normalizers': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-paragraph': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-reset-node': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-select': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-serializer-csv': 10.5.3_cqokrydfgvnsbtmsouizrlndxm
+      '@udecode/plate-serializer-docx': 10.5.3_cqokrydfgvnsbtmsouizrlndxm
+      '@udecode/plate-serializer-md': 10.6.0_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-table': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-trailing-block': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-hyperscript: 0.77.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - encoding
+      - immer
+      - optics-ts
+      - react-query
+      - supports-color
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-headless/19.0.5_g7qlm2w3kkyqioasdjobnxofre:
+    resolution: {integrity: sha512-nwSPMQA73SHki22boXojfnXu9f5ADtxoYNJ8VOGVgpCSO7t/fvihl+MjTAU4les9BjxeuukIVVilr5wrttjcuQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-hyperscript: '>=0.66.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-alignment': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-autoformat': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-basic-elements': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-basic-marks': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-block-quote': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-break': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-button': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-code-block': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-combobox': 19.0.3_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-comments': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-emoji': 19.0.5_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-find-replace': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-floating': 19.0.3_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-font': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-heading': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-highlight': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-horizontal-rule': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-indent': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-indent-list': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-kbd': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-line-height': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-link': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-list': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-media': 19.0.3_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-mention': 19.0.3_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-node-id': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-normalizers': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-paragraph': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-reset-node': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-select': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-serializer-csv': 19.0.3_b5hiuuif63vy3qcrt6qkppa7ue
+      '@udecode/plate-serializer-docx': 19.0.3_g7qlm2w3kkyqioasdjobnxofre
+      '@udecode/plate-serializer-html': 19.0.3_b5hiuuif63vy3qcrt6qkppa7ue
+      '@udecode/plate-serializer-md': 19.0.5_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-table': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-trailing-block': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-hyperscript: 0.77.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4608,21 +5316,48 @@ packages:
       - supports-color
     dev: false
 
-  /@udecode/plate-highlight/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-3d7tU6y2ImyMoB+qda5mjp1t/qekuoSiTQTj88f8gMG+RZnDMdLaeEbfqoYHZ5J1GYLsCdd0XYf9qUAcmbNhKA==}
+  /@udecode/plate-highlight/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-HS0tz2XT2eQHq+nEcR6Icm/oZmg3Jtrp34nRY44H/cyExdI70ddXE1ju22b4wwNi2cooo4FhhkGBm3kgd/JNVA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-highlight/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-hcOoARFlBjXz2G9BPk1zZhfDnHJeXtrL7uqlHljh9Q6tQxGPDfJmqB3aTFchBX+Z1ax6tAc/P+N6lYTy61n90A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4638,21 +5373,48 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-horizontal-rule/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-gEt50b891FelP8U9bZZs2C2bJHg6ur1Ba/qfN+2QvIkR2QSbOoXnFaoUccnAAk0ntl3NxSfQebKEwSrjzuLIVg==}
+  /@udecode/plate-horizontal-rule/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-UMeGEG1eDEBa8frkkDYkALixDw7n4upR6Sd9feSw++RpiiLaGnFJOTze5Fv0YcFjkRGEG/fhTw53LFyA4uaiAg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-horizontal-rule/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-A3VCM/L62vndZzkPPrZ+iF9+b4eGb7EmXjcd02lBFdbelKOs4uUzNj30H9ywWEtvSCGo3VpgtzevO/Pv/lw/xQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4668,23 +5430,79 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-indent-list/18.9.2_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-L9vj+nXTuTmtYOYyJ5q/0JakzInlZ5Vu2oe+86MqVuiDmQfUBmQ1pTvsa0zEcBocb9v8MmupKXtxnhBDHaMBgg==}
+  /@udecode/plate-image/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-C3y7zcU6Ze83BjYmb5gzgMmAlVNWyf1MhwKpGI2J4CSY6WyJXofo/WH/KJo+0pz/zddHcfF92siGP4CNnzEEEQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-indent': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-list': 18.9.2_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-indent-list/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-g3VVeUkaYfMg/TuwC74NPCDVh79kp0GkOp+6c00AH7Y9oL82V0VAlu96J377Z2HrTs/dl8CMIqQQ1ZHe3wM9Wg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.66.1'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.74.2'
+    dependencies:
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-indent': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-list': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.78.0
+      slate-history: 0.66.0_slate@0.78.0
+      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-indent-list/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-gkPZ8eWeKkGMZD96TiMxFoieNxODSjK8lnOW8m8BSBilBqZOSfB7vlHJ3SwajUrdH+PcHQRt2+HMxaFeOgBncQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-indent': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-list': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4700,21 +5518,48 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-indent/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-Vah3amIkW3akFlbE3nd+7x5vog6i4wEx0YyC1TcG8BXaCjPgIEUrM7OmRBIX6C2E2xeZmI4J6UphValsBBMYvA==}
+  /@udecode/plate-indent/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-oyFIKIOBl6npBP6B3h1KVyaeKnsgYAmq/9QDScTcQQXEjRssvZGI37wgftkCW15Gr9dgHqL7EGt4u1lqI5xrzA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-indent/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-2o34QyACCkZTAYVu8duRqq5YjA8hlhiT/B6W9bE2l4skLdMTwX5G92OL2eB76M9R2zDMQcgErouAbqDVonv/Mw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4730,21 +5575,77 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-kbd/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-cAipn4b0UypT3Qtk7Travt578Oyh8Rkmg6rgIgSKAKsMVVr1Y+RZ9ZP5bmHOkAVsHP6dPL0k68rnKMeerv8Tdg==}
+  /@udecode/plate-juice/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-MWZNhYUk6V1CMEumoU2h5yC6FDWLm7c9r8NGtUIBsH1G7Fwv3rnruSN7VZfPeKjR7buSeSsriTybtsJlK+WZHQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      juice: 8.0.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - encoding
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-kbd/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-6zPMj//Ie0zulplVUKpauUnpRd9gwfvo0YFvf0gchHGsqjtao0eqj9jF6qriX3o1DCWbtH8bPmWyPenh13rXuw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.66.1'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.74.2'
+    dependencies:
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.78.0
+      slate-history: 0.66.0_slate@0.78.0
+      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-kbd/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-8ZXAP0SEpAaJfslLePLNx8sJBH+te+yhdYn7H3bWz2Ew4UjOBS3xuXtJtE0mX1Ecr+JCrnTLu5c+ig1+0u+ZgA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4760,21 +5661,48 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-line-height/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-cQO6Pq3ysYVA6J7yTxF2JgJ4Ov/yvEK9uG7T5zgPjGoZJFxW9USdw5b0JfgN1EO3si2Iw4Q9vzAZRrgcTIP8Zw==}
+  /@udecode/plate-line-height/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-YT9O9GWeP8M7iLCb/527OjnsrL5YD078ogzy31LYWUvg5tdxVha1dBgkSZhpIjT5uGCI2CARN2ekpwIbaLvJhg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-line-height/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-SLvslD0TpaTT731JY/PepaBzgDNTSXPjcKLjW0hYgeTVvXVIax4k0vuD66sMJqj1LoD0ag/5ZNu53TQBw2SBXw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4790,23 +5718,51 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-link/18.11.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-XLTraRUH3VtjNFbNLt3geb+6VtlWILhsngsUPnlxL1IRIsM0lYHo1hSgK/Ro2weYH7YAgZ/qlXt7y2lgX6gVrQ==}
+  /@udecode/plate-link/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-2nbu7pcBXGWor1Jau2ED0dHSd64bftJ9aCd7LuBzAmrH74Szvw19Zvub1B2z27EhtrwYCTplV7XTTwtl3KQC6g==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-button': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-normalizers': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-normalizers': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-link/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-7PmlJ1PCIJHPIoiDi68FzbBNmpvKEVkvl/FXVKjMH5cP6euZvuBYXq5u2aiFjFUjQf6mML3O2bweRD55ZuLShA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-button': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-normalizers': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4822,22 +5778,50 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-list/18.9.2_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-eJqkK/PTKxpvj6xz2zE/vqmEHeY3h3LQDUDFvWNhyi+jiEQoAU8Ugr72SVyzUpUWfUvFwZta2KPABXLq+g1hng==}
+  /@udecode/plate-list/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-Qhh8m2PuafA1X6dMuUojtp+yruGMFUJLUtd8tp9xHOzyxurqwR3oFz39f5CQfRfewAlpehZ+Lz/RjW3+zf8H8A==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-reset-node': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-reset-node': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-list/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-CHrvoDge+u9LUC4ZW7dYaOVNe+HixGQSHVmTxgz5HSvmGSH+g7QvmTyQns3KS5aOCs/HJRZKH3TUIaweiYOSBw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-reset-node': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4853,25 +5837,52 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-media/18.9.0_wgehzp42gx63lvcvbao2qouxoq:
-    resolution: {integrity: sha512-RIlXwPz5gcVh4e/xk5HMeN7RGAxhwPnTU/EWJqhWL2wmyJsY6m3evqX8FTZYyNhMP0CQDXCahUbU1AQ3+Vxudw==}
+  /@udecode/plate-media-embed/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-T1+7MVz4HiaIjtaf8seSdFgj7ZP0d+jiIiyM2GEC4vX+ytYCdXUyNFdyFxoxFDa14IorbtVPjfuMw/L5xHKQVQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.78.0
+      slate-history: 0.66.0_slate@0.78.0
+      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-media/19.0.3_qtly5dcswxon57yu7bqc3bfm3i:
+    resolution: {integrity: sha512-IoMcwiSJdedzNQCJrJdpyAM3Ww9jNhz4e66595qLFgAmVggej+5PsNasvvFC1PUu+fSC0dH2KU3h06V4zNxOYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
       js-video-url-parser: 0.5.1
       re-resizable: 6.9.9_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-textarea-autosize: 8.4.0_pxzommwrsowkd4kgag6q3sluym
       scriptjs: 2.5.9
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4888,22 +5899,50 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-mention/18.10.3_wgehzp42gx63lvcvbao2qouxoq:
-    resolution: {integrity: sha512-5TgsLaumTMLCeo4g6DadR6MqctJ+NMBVG17Hz72cZG8+vhSzPSEpMB/A+Kx5CooEU+si8mXApuDyYzFYp7LXqg==}
+  /@udecode/plate-mention/10.6.0_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-WISiAhkNri6sJ+/EDGwTh4iocPhQhBRHgxc5WrnKqnN+FNn0cWN8XYZSQf2tX9gP1sPi14ryUioyhdRLQdtXUw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-combobox': 18.9.0_wgehzp42gx63lvcvbao2qouxoq
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-combobox': 10.6.0_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-mention/19.0.3_qtly5dcswxon57yu7bqc3bfm3i:
+    resolution: {integrity: sha512-Tndlpex7nTj8dvPQ8catn5lRgNt3RQAncKkg6ehnUApInUhWIKPfjr5wo3ehMnNBQeUkm9/vK0zm+LlvEvDT2Q==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-combobox': 19.0.3_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4920,21 +5959,48 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-node-id/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-0LhstU9Cto5RQ9QqbIwApChnxT6kz/6GT1mSG6WSWTuzYLCyg/7JDr2hMo55cjKFqj7o5KdEXaGxV4/y5X/62A==}
+  /@udecode/plate-node-id/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-V3w9cMyrZ25DbV9dNJjlpWQ3HvCfhLVEE4IY+nEzuIdok0GQ/bRzXOJ5T9DQC7hk18qw2Nd+MR7VbqpWhqphRw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-node-id/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-zg17bjjC7xlweT54f5rExlaPACwqMLuP9QVoQMqeUtA8Mfc2Mx1kuxCKn51q3TTi9fOR4hUMbgrsObCKDizSQA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4950,21 +6016,48 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-normalizers/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-oMnInl7UYyPiDxuVA5NS9lefMizoNDfYbbUbAb4zdDlv4DEA7wZGD7TA4HxzljtMPZqkaLVZ9fsATUbBrvcV4Q==}
+  /@udecode/plate-normalizers/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-8AgUMx6sVPXzA20Yg0psvU0DD/5x/3a+iSVJ8ROCG21qL4+VH/7GV5VlRpD0NvXw3jTVosVmPH3XBw20c14/mg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-normalizers/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-w617vrKo8cCZqqj6d+255fDWJK2lvIBCKDRYeyfKosj4TpT8pv8icVzTS/1dcVipUmPrDNZuytUXjDaDte7aTw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -4980,21 +6073,48 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-paragraph/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-+lXx40p8sT7+AIOzbyrnx0TNtnFcOexf7HKKvy1Sz0rrXyP+1BUfe+Lihj+krBWamY5cAuBEysEcRgJ6PohS8Q==}
+  /@udecode/plate-paragraph/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-89VV0tRIQtSh4uYxUsqrqdVQYkOmc0yx8t5BNPRrd/3D9h6IiX4UGpwUlo6AaGH4gyLAXF0AWEai5iccwS90gw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-paragraph/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-gQBmCwH7lqDaH8VG1zLZSDSnlj7YEjiIIdZf4OaVNusdwrQhiOCgJkMgCxEiLjQMwCYUZHOA5/m//CD8SH/C4A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -5010,21 +6130,48 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-reset-node/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-li9w3r3OsPQOh13v52Th5RVLUX3kwh/RC+VFrRwf3IjkqiMn4ctBNagujjO4fMbMYnBEBPouig2tHUw66JYy7w==}
+  /@udecode/plate-reset-node/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-Jmh0COs2a5NtB4eNU3vbZdB+dcG/jIjsme51eqbaZjiCslCNU95bBP/UCXnu8Wny6Sx11chnpxQxi/RfgTnXPg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-reset-node/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-VWb/g0rXI2Mi8dznBxWF2LH+8/u5ziU2D7F1WhHYG6U22H1EIbXXlBIU3oOTMbJTcGzLmGHrxgwCvy2uKV7KKA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -5040,21 +6187,48 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-select/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-pjhzD/jEvSW2PKgfm8NSIERQZ7NwI4lMK8lheuCDNXdwoY7ziMBvjsL9vmtcAArh08z4a5lFdqs09Guq9BK2TA==}
+  /@udecode/plate-select/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-t/yMkcBA5AghIXv/Mppyu4OmHAQhP7bXrbAthVbS20Gza0qCYA/Zc2mWF9CBHkLNx378KJOXIj0AhcII0J0IxA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-select/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-FmtlR2Jc1D5johnP9gZ9C/TDJlmTa9DYY2tpvnODZBgYWVpNws+zcyZJ9QxaqvIgls27u8Gmdsesfwhl9dYwnw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -5070,55 +6244,53 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-selection/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-+xvi7xe0wIMjjGZa2dkhE45llnWwdczNvzcWI2rGy1kcvj+xoJ+PfDJcUD9++79MVb1wAivm6oPt0eTQ5C5smg==}
+  /@udecode/plate-serializer-csv/10.5.3_cqokrydfgvnsbtmsouizrlndxm:
+    resolution: {integrity: sha512-AuxguCW944S7o6yMuilL/HmMPfHaMEeZqD7Vd/81qftACEYUouAzTIiRdYAZ8Ohx9anpn1/swDFvoEDmKsUJkg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@viselect/vanilla': 3.2.2
-      copy-to-clipboard: 3.3.3
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-serializer-csv/18.11.0_yaj5njjgkl3zcwcfy656sml5ym:
-    resolution: {integrity: sha512-/TAC3/xdr3IowEUqnzY3BhZOKTtWZ6GwqW+kII8CUG3nEjRekUuiJiLgfFr8WZla9xeZzYNU39QJYA1RI3CxNg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-table': 18.11.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-table': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       papaparse: 5.3.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-hyperscript: 0.77.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - slate-history
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-serializer-csv/19.0.3_b5hiuuif63vy3qcrt6qkppa7ue:
+    resolution: {integrity: sha512-Wdkk2W5poGmEBAzdtrY2Kn2IhJcgSBSv6RGWplyiRrj/P9c61gMh1VtQCHpg3VA6AR4dBHMCAw83C+X1RwzTSA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-hyperscript: '>=0.66.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-table': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      papaparse: 5.3.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-hyperscript: 0.77.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -5135,29 +6307,65 @@ packages:
       - slate-history
     dev: false
 
-  /@udecode/plate-serializer-docx/18.11.0_apsly3itnks4vinztrxz3j36ey:
-    resolution: {integrity: sha512-Fezlt8EV8reZI+5TUiOO/uHc25YyNrUZGey2L2UXl81LckniG5kUNZJKczeU4Z9XvlD3HWiIhI2due0nccLnFw==}
+  /@udecode/plate-serializer-docx/10.5.3_cqokrydfgvnsbtmsouizrlndxm:
+    resolution: {integrity: sha512-1k5f6RR+0raxiCY35vkTm5evfOt0iggTcxh08xoq0Rjij8NhdXBfBrBpKlJCp2bRRLRd3B3y21sbF5FGW89nzA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
       slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-heading': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-indent': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-indent-list': 18.9.2_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-media': 18.9.0_wgehzp42gx63lvcvbao2qouxoq
-      '@udecode/plate-paragraph': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-table': 18.11.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-heading': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-image': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-indent': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-indent-list': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-paragraph': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-table': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-hyperscript: 0.77.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      validator: 13.7.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-serializer-docx/19.0.3_g7qlm2w3kkyqioasdjobnxofre:
+    resolution: {integrity: sha512-yPrzsebm6Aq8v+FM8fpln4fQgmi8+hOA0TkvHrUKDTYDmra46AjOn+smuf1/X2akH2+aOFOQL6XFXXoWgx0vTg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-hyperscript: '>=0.66.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-heading': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-indent': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-indent-list': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-media': 19.0.3_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-paragraph': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-table': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-hyperscript: 0.77.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       validator: 13.7.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -5175,24 +6383,24 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-serializer-html/18.9.0_yaj5njjgkl3zcwcfy656sml5ym:
-    resolution: {integrity: sha512-pEkIv+Gw4HcACSHT0mQk5iRFXv/hfNwLQMqhOuPBMNSdq5VgVna4ieiASNCUxNsDNcrHVB4WLZ0x/I+DY5ivTQ==}
+  /@udecode/plate-serializer-html/19.0.3_b5hiuuif63vy3qcrt6qkppa7ue:
+    resolution: {integrity: sha512-oA/68wU8C6OFNe2jWrCs5Gunl5gHnInax8biWU4yQL2kUXBCViZCl0MHMKElQb30QcFEIa9pdrqqNEJ+CZlUyQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
       slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.88.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
       html-entities: 2.3.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-hyperscript: 0.77.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-hyperscript: 0.77.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -5208,22 +6416,22 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-serializer-md/18.11.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-j58oEJGLQ169vy8sa4j+fDhC6L1QhUslCPz01hWM+pFjNiIcJZaZmnjXv7NypGxOVhbGoaMqo88pYCZZOFaKYA==}
+  /@udecode/plate-serializer-md/10.6.0_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-d5ISdZKYVHQ+YXwR7ai3lKrxuwDm7RiBsh7RbXliISxWPYfY7NheKBvj83p53PD28/vcObmXfKl7He+vfaqfLA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-block-quote': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-code-block': 18.10.1_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-heading': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-link': 18.11.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-list': 18.9.2_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-paragraph': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-block-quote': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-code-block': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-heading': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-link': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-list': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-paragraph': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       remark-parse: 9.0.0
@@ -5231,6 +6439,43 @@ packages:
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      unified: 9.2.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - supports-color
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-serializer-md/19.0.5_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-ItQI9pCgcGaqxhGOZdtTSUOCvarlCk00HGvMjIf+VlasQhf0mVzRHUgzA1mnkFKc+bCbkBE3d4CZdlS8c1gCkg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-block-quote': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-code-block': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-heading': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-link': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-list': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-paragraph': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      remark-parse: 9.0.0
+      remark-slate: 1.8.6
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       unified: 9.2.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -5248,18 +6493,18 @@ packages:
       - supports-color
     dev: false
 
-  /@udecode/plate-styled-components/18.9.0_7635xpgccrl5o6z4wdgzjengty:
-    resolution: {integrity: sha512-raO3+SRSak9sdho8dMMrRqHxjx4svXygho4FZ1Vceu3nm/QqpiweAX9oMYXjtzFZq0ZLnVl9bh0bm9Zj0qtX7g==}
+  /@udecode/plate-styled-components/10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm:
+    resolution: {integrity: sha512-FYgC53IWat68MNZ4ZN4t/e7aZi0aY/pV/95VKtbWfJlCeBecJr4HLmNWP9PPZRfBeIUFpLyawf6y1yxRFkCv/A==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
       react-is: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       clsx: 1.2.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -5271,97 +6516,217 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-native
-      - scheduler
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
     dev: false
 
-  /@udecode/plate-table/18.11.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-PXA84hVXXj5JwpHOMyYkJaMI7QZLn7NvmrIysocTmYwsLH4xawiM54DgCAvhrqttqKdPulS7qUkoJyLHQOoGEQ==}
+  /@udecode/plate-styled-components/19.0.3_j77ytrqijsbx5j7bdcluvcwwam:
+    resolution: {integrity: sha512-vFdhSfgAifYoI8n2OjmHO05/IcLiBvZ+A5hNMM1G1lNiOEED0IH6sHYQGjqPov+5GfzCFjgAngmReZZA38ELFQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-trailing-block/18.9.0_nwrp2ji3l666i2crfmgr6c52by:
-    resolution: {integrity: sha512-fDqMCl5lqC/eUZUQODQylebXm5FUjwtwuQychBu9BAoFFMJ605kDGn5mKfrAbhOxDUObiu6IzDZdA2Za5SAOEw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
-    dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-alignment/18.9.0_5meegtdqv6ymmwsfb6u22gkgwa:
-    resolution: {integrity: sha512-/6xxrfIH0G8rsjNhisz7kaCcIJudgx59nhWmc/ctcjMPaOyYFtGag4UaonoPl2CkHJKAFT8+5LlUD5q/gtQmAg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      react-is: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-alignment': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-toolbar': 18.9.0_5meegtdqv6ymmwsfb6u22gkgwa
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      clsx: 1.2.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-is: 18.2.0
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-table/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-0/6GAI9YeY92hdyPjGlaFeMeMQ1BcttguwW3DBRDeK6whknvOABubc6MsHc49xvYZlJYoC1xuv1pqBFTa8FLpg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.66.1'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.74.2'
+    dependencies:
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-table/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-npym2CN4aRq4g9tMLdPH7qWhgqR4k0SxOI2H8xdcjk2xmbJE+AJZfg/f0wsg1ldMmlByrCIz5s4kvwQmG2QsiA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-trailing-block/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-bwT6GHfw5u0SXfCaPdoTB/xEYVP/5qS83Ucs5STbEN/6nTBas8UJ5+RZutve6uTttWy8sfBZx06goS16RBJ4pw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.66.1'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.74.2'
+    dependencies:
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.78.0
+      slate-history: 0.66.0_slate@0.78.0
+      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-trailing-block/19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm:
+    resolution: {integrity: sha512-UGOf8icziuTHK4ADI9rUxko4JCbE6E2Qua/0MAkLB40sFZQwo6JgaD11bPqHL/0kihzmoIOxp63suK88MfJWrg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-alignment/10.5.3_bnadrewly7b2t2iy6hs335locu:
+    resolution: {integrity: sha512-/sMEBPM8NVRVx2TKx5o70obmMN3xKEGeoCuycSAbVTn8Wc4aewgfEr9v/knt4ZiuWc0DDcG5eSsmdI1r85bJIA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.66.1'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.74.2'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-alignment': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-toolbar': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.78.0
+      slate-history: 0.66.0_slate@0.78.0
+      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@popperjs/core'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-is
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-alignment/19.0.3_blb3pyyzd7t2vcqgz4ctfappdu:
+    resolution: {integrity: sha512-gdQ5KLuuL2ydY6fdf9nI+oYyptdAoMq3quSFB/skrNx8/WvAnYw05uqyNK+CbQAdNlY6ArM1zb3BSYV3AG4q2w==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-alignment': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-toolbar': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
@@ -5380,24 +6745,56 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-block-quote/18.9.0_7635xpgccrl5o6z4wdgzjengty:
-    resolution: {integrity: sha512-KNAixt/Eut2LL3BtW2UrNMR9V6CDTX6Jvsz/mnPeYJZ1017qa5RAQsQHw6GcSXd8VgAkixvphulbZDyIyBc1TA==}
+  /@udecode/plate-ui-block-quote/10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm:
+    resolution: {integrity: sha512-by/tNFJv3iJEALAws+TRKUtJjh+CW7uS/1JmLykiGO4VXBq7XQUkFa8yGYzTE9jUvT5BAi7+jyTQe93Y1tnJGw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-block-quote': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
+      '@udecode/plate-block-quote': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-is
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-block-quote/19.0.3_j77ytrqijsbx5j7bdcluvcwwam:
+    resolution: {integrity: sha512-TX29rIiOhK0ZQW2tyXr59n6DGGALskuWZ1EnAUn3dVRv3FSTkyWZvSP8kqILtDVjwQhv4lUPCMP8hJzeIcTKwg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-block-quote': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
@@ -5415,24 +6812,55 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-button/18.9.0_7635xpgccrl5o6z4wdgzjengty:
-    resolution: {integrity: sha512-hCA6uDDAdsJaJDXLp78uCqDhJpca0GQv0m8UG0g+kUZXGM3LsEljYajJGnVVshunVbZP3/0vUL9u1YkZl92MwA==}
+  /@udecode/plate-ui-button/10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm:
+    resolution: {integrity: sha512-WS1vPfRTKpMDoEgcb/OHwjdFkgt8qrM6akYLAA1ZvM0MXi93NjVdfgpa6FSsPH3n3hU3lbSfNiEDY4cTI/wzTg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-button': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-is
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-button/19.0.3_j77ytrqijsbx5j7bdcluvcwwam:
+    resolution: {integrity: sha512-rUAKLJvNLfGfb6qk1XdlgbhqQxYybLgbppV7YOWQDf5/TYICmNft5kvt+3Z5UGB/Hf/OJhpzbLJfumbqXqv6OA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-button': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
@@ -5450,25 +6878,59 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-code-block/18.10.1_5meegtdqv6ymmwsfb6u22gkgwa:
-    resolution: {integrity: sha512-aeadUL1vHJZ8XduPVTLfQYAdeB2FW0z7tQ/oc1jFJ/wEiSTR7ZBVPQhT1FvEuIi9sSxhePB2iy2csv8tCUu0bg==}
+  /@udecode/plate-ui-code-block/10.5.3_bnadrewly7b2t2iy6hs335locu:
+    resolution: {integrity: sha512-sdf2j29ydGriOqtB65DJwU8FikKDia7UXFWsie3qYMlQcvilGzVIrhMwcL6TGWYoilclZCUL1ucP42QAqmF25w==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-code-block': 18.10.1_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-toolbar': 18.9.0_5meegtdqv6ymmwsfb6u22gkgwa
+      '@udecode/plate-code-block': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-toolbar': 10.5.3_bnadrewly7b2t2iy6hs335locu
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@popperjs/core'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-is
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-code-block/19.0.3_blb3pyyzd7t2vcqgz4ctfappdu:
+    resolution: {integrity: sha512-v4P09QpTZtclTvU+1kbVEaSrmPpu2Wgat2K/RW7IbWbmzJzcjwSFjVv/vraFowgx0ydEcYTs6ZZrOWzUk8U8bw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-code-block': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-toolbar': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
@@ -5487,25 +6949,58 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-combobox/18.9.0_5meegtdqv6ymmwsfb6u22gkgwa:
-    resolution: {integrity: sha512-XF8+wdJ8D6PR+vL5/sohgEPVweZ15Cr3uFvRvqCE/EuHQPEe6Qty5kPtd1yZRUXRMTj2LMo/XGorsHc+755IxQ==}
+  /@udecode/plate-ui-combobox/10.6.0_l2xhcf2qjd5e6qexqd72n2bvmm:
+    resolution: {integrity: sha512-bJ1A+Dqx6Ydh3KSZoQPVaXKs4KnY5mUAY72Xt7rF4XT5l/qNKuhM+QDud6apBLd5qlqFfDo5dO3/W3u+U556Vw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-combobox': 18.9.0_wgehzp42gx63lvcvbao2qouxoq
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-floating': 18.9.0_wgehzp42gx63lvcvbao2qouxoq
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
+      '@udecode/plate-combobox': 10.6.0_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-popper': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-is
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-combobox/19.0.4_blb3pyyzd7t2vcqgz4ctfappdu:
+    resolution: {integrity: sha512-3Bh3iAZAeULnXm7p7Fn0VYlim6VeYgjt9QMxfNtbqd6rwy820uDRv+ivPMMzUNFwv0kszkYi9N+Qg8WrcgQPeQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-combobox': 19.0.3_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-floating': 19.0.3_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
@@ -5524,23 +7019,61 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-cursor/18.9.0_7635xpgccrl5o6z4wdgzjengty:
-    resolution: {integrity: sha512-V0+NiREBO+Zdyssd7mhllcXYG9jZoGLq8o76lNPokziKkHFZsFZ9hGZ3JTl9ItzJytmkWiDBq7I63BSGy3P5Aw==}
+  /@udecode/plate-ui-comments/19.0.3_blb3pyyzd7t2vcqgz4ctfappdu:
+    resolution: {integrity: sha512-uCyKTqKt558xv+xr3zw/1vgssk94FOBtjDoc4lI9G4UHFBdc91b591KhIW50Wfgkprksb5XWyfXlWuHsqmARtQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
+      '@udecode/plate-comments': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-button': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-toolbar': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-cursor/19.0.3_j77ytrqijsbx5j7bdcluvcwwam:
+    resolution: {integrity: sha512-5Zp1RuAbeuwYxl2TnVufLRndI7NJdQfac0fLaKqSl2xa2QetYLabHfiohFTxOon8nzblrQCQcZH4ahO/5d4oWg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
@@ -5558,26 +7091,23 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-dnd/18.10.1_demitpvrm4kg6thwkxeqoualfi:
-    resolution: {integrity: sha512-UVdiJ/qkyLGXqUY3mRMBnijIpNyUNLfEcjLcALU9eRj/Vs+Z9dpJNF3ghIMIrYWK13sJnqinv3aq2owhvJ4zZw==}
+  /@udecode/plate-ui-dnd/10.5.3_iv6mfpmwnp2vdrqozlik4nfch4:
+    resolution: {integrity: sha512-3VC9WtfcB+QB6l2cPD3rVWF6Qb9Vyhk13i2qR//q1uZq5XtQMDCeAQL/dRRd5ux1boIS1RtPJgzuWhFqKdTjjg==}
     peerDependencies:
       react: '>=16.8.0'
-      react-dnd: '>=14.0.0'
-      react-dnd-html5-backend: '>=14.0.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
       '@react-hook/merged-ref': 1.3.2_react@17.0.2
       '@tippyjs/react': 4.2.6_sfoxds7t5ydpegc3knd667wn6m
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      raf: 3.4.1
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
       react: 17.0.2
-      react-dnd: 16.0.1_smc5esni47gpbltvxzeziduyte
-      react-dnd-html5-backend: 15.1.2
+      react-dnd: 14.0.5_pxzommwrsowkd4kgag6q3sluym
+      react-dnd-html5-backend: 14.1.0
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
@@ -5586,38 +7116,78 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
+      - '@types/hoist-non-react-statics'
+      - '@types/node'
+      - '@types/react'
+      - '@urql/core'
+      - immer
+      - optics-ts
       - react-is
-      - react-native
-      - scheduler
+      - react-query
+      - valtio
+      - wonka
+      - xstate
     dev: false
 
-  /@udecode/plate-ui-emoji/18.11.0_5meegtdqv6ymmwsfb6u22gkgwa:
-    resolution: {integrity: sha512-edfFed9nv6/K2I2GibOGVS4MIlkU4YN2AmgXURjFsmT6mjZWyaZdDphcZe2nspN0OuMRP8QNYEfLC+Rljdss4Q==}
+  /@udecode/plate-ui-dnd/10.5.3_rrl3vdxtvw4k5udj3seozvlkne:
+    resolution: {integrity: sha512-3VC9WtfcB+QB6l2cPD3rVWF6Qb9Vyhk13i2qR//q1uZq5XtQMDCeAQL/dRRd5ux1boIS1RtPJgzuWhFqKdTjjg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-combobox': 18.9.0_wgehzp42gx63lvcvbao2qouxoq
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-combobox': 18.9.0_5meegtdqv6ymmwsfb6u22gkgwa
+      '@react-hook/merged-ref': 1.3.2_react@17.0.2
+      '@tippyjs/react': 4.2.6_sfoxds7t5ydpegc3knd667wn6m
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
       react: 17.0.2
+      react-dnd: 14.0.5_smc5esni47gpbltvxzeziduyte
+      react-dnd-html5-backend: 14.1.0
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/hoist-non-react-statics'
+      - '@types/node'
+      - '@types/react'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-is
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-emoji/19.0.5_blb3pyyzd7t2vcqgz4ctfappdu:
+    resolution: {integrity: sha512-l+qy3ChXy5gfJfPXqjPq58fBqAqOonAqFQxYiWNZ4QxGvzfF0Pn32n3N4Tw/iFlDs78bmGrEAbJBEqqZcH2bUA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-combobox': 19.0.3_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-emoji': 19.0.5_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-combobox': 19.0.4_blb3pyyzd7t2vcqgz4ctfappdu
+      '@udecode/plate-ui-toolbar': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
@@ -5636,25 +7206,59 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-find-replace/18.9.0_5meegtdqv6ymmwsfb6u22gkgwa:
-    resolution: {integrity: sha512-kY22kVp0k6vfLM5nwX2n1Vp3+Hu5lquhYKhgoWYFK/Xk/No5E99LRXnUCbAgstkQcvxcIM4RtcwHuCSICArvVA==}
+  /@udecode/plate-ui-find-replace/10.5.3_bnadrewly7b2t2iy6hs335locu:
+    resolution: {integrity: sha512-AQYNMyQcMQgfw2ItEZ68SlG7QzR7D1mDgz1y+IdsjAZjQ3cc5f+XE0fd9v2M9tlIzJXMbDTPEibOl+QeSI+F/Q==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-find-replace': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-toolbar': 18.9.0_5meegtdqv6ymmwsfb6u22gkgwa
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-find-replace': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-toolbar': 10.5.3_bnadrewly7b2t2iy6hs335locu
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@popperjs/core'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-is
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-find-replace/19.0.3_blb3pyyzd7t2vcqgz4ctfappdu:
+    resolution: {integrity: sha512-k4L5IYI2nBbk3GksGZhQ12eOmvgufIS7u815ew/nXw2tE4s6olXqNsOpx4OOgVN4zYKelC/aCW5K9iGDhw8wBg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-find-replace': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-toolbar': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
@@ -5673,26 +7277,61 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-font/18.9.0_5meegtdqv6ymmwsfb6u22gkgwa:
-    resolution: {integrity: sha512-847D/lZTvn3d63cKM3bvBYzZMIxN1kldzUvgxpur/X05ekj72zAiAOj/35QmFPCdrvIVeJG1R34tDslXCBppIA==}
+  /@udecode/plate-ui-font/10.5.3_bnadrewly7b2t2iy6hs335locu:
+    resolution: {integrity: sha512-jsX1+UP2yZWeRy7ZXqYjavNLWLHivFXGbAznE/3kP3/2GYp0z0T5cfzemaqdqTEVohzLAO5V7I7q97Iget0l/Q==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-font': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-button': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-toolbar': 18.9.0_5meegtdqv6ymmwsfb6u22gkgwa
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-font': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-button': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-toolbar': 10.5.3_bnadrewly7b2t2iy6hs335locu
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@popperjs/core'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-is
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-font/19.0.3_blb3pyyzd7t2vcqgz4ctfappdu:
+    resolution: {integrity: sha512-icFaC/7YaUeMI2vNAt0AK4E+3d0LL80Bhh/vk7dz+6xl0FxFIvGuOS3B4zETQd3Cvn69kd2rBap8Y9vzDFHDKg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-font': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-button': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-toolbar': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
@@ -5711,25 +7350,96 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-line-height/18.9.0_5meegtdqv6ymmwsfb6u22gkgwa:
-    resolution: {integrity: sha512-+Jno1fb8uOKhwCCC8/p3TXH4wkZqHx5gtA/IcyC3YER96zh4fEANL47/VLMNW+1xuSPHOaBGl/bCTowD+PpyAg==}
+  /@udecode/plate-ui-image/10.5.3_ko2crrejjvncj54hu3y5oa63pi:
+    resolution: {integrity: sha512-UhJmfAp/VXQMuzwv2QJkBSmmrb8O08NBaY9PVbbEZFXPzDt1k8U20TTHrCzlX5O8aklDwnXeoACrKdpAP8DuQg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-line-height': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-toolbar': 18.9.0_5meegtdqv6ymmwsfb6u22gkgwa
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-image': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-toolbar': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      re-resizable: 6.9.9_sfoxds7t5ydpegc3knd667wn6m
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-textarea-autosize: 8.4.0_pxzommwrsowkd4kgag6q3sluym
+      slate: 0.78.0
+      slate-history: 0.66.0_slate@0.78.0
+      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@popperjs/core'
+      - '@types/react'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-is
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-line-height/10.5.3_bnadrewly7b2t2iy6hs335locu:
+    resolution: {integrity: sha512-b6+Fov+UGecbSsJrHtnPpovld4yT4/NWc+qGZPYLVBjGX8swbkQWGJimNUEmjmP0tHCj4W/CKQIPQASYlEnwVg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.66.1'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.74.2'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-line-height': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-toolbar': 10.5.3_bnadrewly7b2t2iy6hs335locu
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@popperjs/core'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-is
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-line-height/19.0.3_blb3pyyzd7t2vcqgz4ctfappdu:
+    resolution: {integrity: sha512-LDz8XurgA1oEhM1bhvkONXZPCIRMIDiblJUVRk9K3fGzULBdqRNj0+T0D0+dQ+UVzAqDfNkHmuoD7lDi0Gf09A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-line-height': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-toolbar': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
@@ -5748,26 +7458,60 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-link/18.11.0_5meegtdqv6ymmwsfb6u22gkgwa:
-    resolution: {integrity: sha512-iB+qQIC3BRlzfVrGXQZ2yJm3tQaQ4f6IEcoeRdS1yBGUleUR77rzKAbIa0k2NPeBqi3fAJ9ZV2zDCXu4e4EtHQ==}
+  /@udecode/plate-ui-link/10.5.3_bnadrewly7b2t2iy6hs335locu:
+    resolution: {integrity: sha512-OooB8MEmtV/6NE13/fbnLn8TbQoNxi5iaZcofmjxKb2X/HUOkG+ZY3yn1oVCXedVUsdgbEzUvoyBPBcnJL5PjA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-link': 18.11.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-button': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-toolbar': 18.9.0_5meegtdqv6ymmwsfb6u22gkgwa
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-link': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-toolbar': 10.5.3_bnadrewly7b2t2iy6hs335locu
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@popperjs/core'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-is
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-link/19.0.3_blb3pyyzd7t2vcqgz4ctfappdu:
+    resolution: {integrity: sha512-+OTn4yZ0H+BLdiQMgKRb/dTG9eHJgCMNcUQQLmXc0F/xSAYlNu+jUtX3cVI+FPdoNJXvA61HfLHLJuEx6R8EGQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-link': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-button': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-toolbar': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
@@ -5786,25 +7530,59 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-list/18.9.2_5meegtdqv6ymmwsfb6u22gkgwa:
-    resolution: {integrity: sha512-pfnaEdmdSooobsSrzVm3lbkECoFTjP/aiaCW4hn+Bh/PqeSC2QUurBBUGfvKOpmUp6CyMPjX9qhO1WFh70GKFQ==}
+  /@udecode/plate-ui-list/10.5.3_bnadrewly7b2t2iy6hs335locu:
+    resolution: {integrity: sha512-LNrJMs1St3x6RR+4Uoeg8ZuuqnwU+5DPOEKSorSwzFxkoyHDvUZsluzQIzfRCYirXLWFhkadKvaxnyVmhGSkSA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-list': 18.9.2_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-toolbar': 18.9.0_5meegtdqv6ymmwsfb6u22gkgwa
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-list': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-toolbar': 10.5.3_bnadrewly7b2t2iy6hs335locu
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@popperjs/core'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-is
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-list/19.0.3_blb3pyyzd7t2vcqgz4ctfappdu:
+    resolution: {integrity: sha512-oOOVGZJzEzWnvi9OJG4eUOChosV5wWvtHh2kMPZyjsOdMUYoqG4nhAIuDu3ns0L4YvjB6uzHeZpI+85WQ/WTJQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-list': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-toolbar': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
@@ -5823,29 +7601,63 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-media/18.11.0_5meegtdqv6ymmwsfb6u22gkgwa:
-    resolution: {integrity: sha512-Fv3hIzLzOPBuh7mm4ug6oGigJMx8ncyphEnTpq/Zs09h4CQBuM/YNO5VPD0YuWKzGV6lxOkIA3040bshfLYiKQ==}
+  /@udecode/plate-ui-media-embed/10.5.3_bnadrewly7b2t2iy6hs335locu:
+    resolution: {integrity: sha512-hwbHoYYldZjSTkUqcVGhZ8M8Vvc18jZPQKoBM9ZdKbxfQTeZNUfZEq12mzqJ+EtKjaw0vZqOHrsD3ydK+wFyew==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-floating': 18.9.0_wgehzp42gx63lvcvbao2qouxoq
-      '@udecode/plate-link': 18.11.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-media': 18.9.0_wgehzp42gx63lvcvbao2qouxoq
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-link': 18.11.0_5meegtdqv6ymmwsfb6u22gkgwa
-      '@udecode/plate-ui-toolbar': 18.9.0_5meegtdqv6ymmwsfb6u22gkgwa
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-media-embed': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-toolbar': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.78.0
+      slate-history: 0.66.0_slate@0.78.0
+      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@popperjs/core'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-is
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-media/19.0.3_blb3pyyzd7t2vcqgz4ctfappdu:
+    resolution: {integrity: sha512-NpRJZRTL3lyBg9E7R09HEhV7E/EFXGA9L9LnkDm/+wIwkot0qyyvy7s8kQD5y3BtThALHQpDaGYv4WvGMrK/MA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-floating': 19.0.3_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-link': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-media': 19.0.3_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-link': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      '@udecode/plate-ui-toolbar': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
       js-video-url-parser: 0.5.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
@@ -5864,26 +7676,60 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-mention/18.10.3_5meegtdqv6ymmwsfb6u22gkgwa:
-    resolution: {integrity: sha512-vO2YIAx4+/m4J1+d232N+SxsloOMrMVrRniT/jKlAPykf2EV5JBK5p0G+yZqqUTUYpMrPU+FVZl+omTrcMWUBQ==}
+  /@udecode/plate-ui-mention/10.6.0_l2xhcf2qjd5e6qexqd72n2bvmm:
+    resolution: {integrity: sha512-z+EqRXMAPAu0DdYaEbxOGj9Ny5FqB2lQVJgVSUnCL2o+gNx+C7nfbK1pHOj2XDGH839UNv3ambC7rJrcT1IhCg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-combobox': 18.9.0_wgehzp42gx63lvcvbao2qouxoq
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-mention': 18.10.3_wgehzp42gx63lvcvbao2qouxoq
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-combobox': 18.9.0_5meegtdqv6ymmwsfb6u22gkgwa
+      '@udecode/plate-combobox': 10.6.0_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-mention': 10.6.0_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-combobox': 10.6.0_l2xhcf2qjd5e6qexqd72n2bvmm
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-is
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-mention/19.0.4_blb3pyyzd7t2vcqgz4ctfappdu:
+    resolution: {integrity: sha512-TXgksjdBSNXGKz6t6Id1wQ1CXdLqbePSE0J3oqJzk+UWZS7lJx9n0TrV6JSkLnOZcwQ9x3Oimr65ll7JU0uhDw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-combobox': 19.0.3_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-mention': 19.0.3_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-combobox': 19.0.4_blb3pyyzd7t2vcqgz4ctfappdu
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
@@ -5902,23 +7748,54 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-placeholder/18.9.0_7635xpgccrl5o6z4wdgzjengty:
-    resolution: {integrity: sha512-muT67OFdkDTNeUWB94hLWXrz49iKzrXHZXRn0ubHansv0z6IuR9STaAElis5y/YvBZSDe8O0b0qsiEHdhgtEGA==}
+  /@udecode/plate-ui-placeholder/10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm:
+    resolution: {integrity: sha512-t6R2qIFWDU6vd6J5Jpp9f7prQNgIf/1qjJUjeq5nO1/ZamovfAmNvRkJmRDPcl1eN6oZki6AgmLmNehVhKyqKA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-is
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-placeholder/19.0.3_j77ytrqijsbx5j7bdcluvcwwam:
+    resolution: {integrity: sha512-dBWaHbAINkNZ/yMnGKOb+IkjfB4Eao+K/3E+XfOgH40TTlxPuVU+0BYptG+LPgzdR5ARDr2m8sBEBb7lvIZxSA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
@@ -5936,22 +7813,83 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-table/18.11.0_5meegtdqv6ymmwsfb6u22gkgwa:
-    resolution: {integrity: sha512-ver6DYLkdlsAIIZWWsdzkAtYdTZC3W1CRoLQRUC4jrYjXQYjb5lCJeUgTehY4K2JdA9UgBhhkmeuHd8372O1sA==}
+  /@udecode/plate-ui-popover/10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm:
+    resolution: {integrity: sha512-ex5wqC01XV+vxZmfmmPcaSCuZbOrmyNQazm0bVs95TW8vV3bsRdPieWd6vX3a4jfX8sWGnXQMgWq3wpdWz6o7Q==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
+    dependencies:
+      '@tippyjs/react': 4.2.6_sfoxds7t5ydpegc3knd667wn6m
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.78.0
+      slate-history: 0.66.0_slate@0.78.0
+      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-is
+      - react-query
+      - styled-components
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-popper/10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4:
+    resolution: {integrity: sha512-OoIlEgxdphITc+qEyO6Hw5bqNaoVv6RgJY8kLHZHSaKrPh60reZT/QyvRzZPz4TM4HEcBIfabNwBetAkcwL21A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.66.1'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.74.2'
+    dependencies:
+      '@popperjs/core': 2.10.2
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-popper: 2.2.5_qofm6heeqcbukqym6fyxd6dvda
+      slate: 0.78.0
+      slate-history: 0.66.0_slate@0.78.0
+      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-table/10.5.3_bnadrewly7b2t2iy6hs335locu:
+    resolution: {integrity: sha512-mCT0CA8phY95kQVruSuUH3KNdRkZANC49LsEE1bsr1oj9RN+hESHM0XGnmvmpFRq94pKIfNhtnBD5QLMIFsGGw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.66.1'
+      slate-history: '>=0.66.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-floating': 18.9.0_wgehzp42gx63lvcvbao2qouxoq
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-table': 18.11.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-ui-button': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-toolbar': 18.9.0_5meegtdqv6ymmwsfb6u22gkgwa
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-table': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-ui-button': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-popover': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-toolbar': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      jotai: 1.10.0_dzj4tgexvvjhyxdh56ztoytblu
       re-resizable: 6.9.9_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -5962,7 +7900,9 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
-      - '@types/react'
+      - '@popperjs/core'
+      - '@urql/core'
+      - immer
       - jotai-immer
       - jotai-optics
       - jotai-redux
@@ -5971,32 +7911,36 @@ packages:
       - jotai-valtio
       - jotai-xstate
       - jotai-zustand
+      - optics-ts
       - react-is
-      - react-native
-      - scheduler
+      - react-query
+      - valtio
+      - wonka
+      - xstate
     dev: false
 
-  /@udecode/plate-ui-toolbar/18.9.0_5meegtdqv6ymmwsfb6u22gkgwa:
-    resolution: {integrity: sha512-qUwHWnYddJG0Cmtw/dIi+hqe6FlXt2Y4gPd3fB1VpWEYKjBV9jqvqZdMFjpVfOm2SvCPko/upp30aXH0ArtrDQ==}
+  /@udecode/plate-ui-table/19.0.3_blb3pyyzd7t2vcqgz4ctfappdu:
+    resolution: {integrity: sha512-mh0gthyF+J7HQWn8cFFhcalUqk/hz6ZNTYEVRaf9wsm8ortqzhB+iGdtF4ylchKKUfsiaPC7TWmOIZGAUEkCsw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
-      slate-history: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@tippyjs/react': 4.2.6_sfoxds7t5ydpegc3knd667wn6m
-      '@udecode/plate-core': 18.9.0_nwrp2ji3l666i2crfmgr6c52by
-      '@udecode/plate-floating': 18.9.0_wgehzp42gx63lvcvbao2qouxoq
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-button': 18.9.0_7635xpgccrl5o6z4wdgzjengty
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-floating': 19.0.3_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-table': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-ui-button': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-toolbar': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      re-resizable: 6.9.9_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-use: 17.4.0_sfoxds7t5ydpegc3knd667wn6m
-      slate: 0.78.0
-      slate-history: 0.66.0_slate@0.78.0
-      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
@@ -6015,47 +7959,254 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui/18.11.2_6jhmma7zc7jn5whmtj2xi5zloy:
-    resolution: {integrity: sha512-w/IXCN/0gD/1R/YAVhQFCwoDqpeQSLh30w8bhrlWBrm5MTu3QaefioJHlO7ASv7eLGfycdae+/Mg27wIBRrTaA==}
+  /@udecode/plate-ui-toolbar/10.5.3_bnadrewly7b2t2iy6hs335locu:
+    resolution: {integrity: sha512-iLcjG6THgifVQWiBySRGpnQweGJCrd+hYg68+hk4OeNkMU5iTk1pw440bz3F2uAjx7I6ZzGRICBTiB00fceBPw==}
     peerDependencies:
       react: '>=16.8.0'
-      react-dnd: '>=14.0.0'
-      react-dnd-html5-backend: '>=14.0.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
-      slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-headless': 18.11.2_apsly3itnks4vinztrxz3j36ey
-      '@udecode/plate-styled-components': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-alignment': 18.9.0_5meegtdqv6ymmwsfb6u22gkgwa
-      '@udecode/plate-ui-block-quote': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-button': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-code-block': 18.10.1_5meegtdqv6ymmwsfb6u22gkgwa
-      '@udecode/plate-ui-combobox': 18.9.0_5meegtdqv6ymmwsfb6u22gkgwa
-      '@udecode/plate-ui-cursor': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-dnd': 18.10.1_demitpvrm4kg6thwkxeqoualfi
-      '@udecode/plate-ui-emoji': 18.11.0_5meegtdqv6ymmwsfb6u22gkgwa
-      '@udecode/plate-ui-find-replace': 18.9.0_5meegtdqv6ymmwsfb6u22gkgwa
-      '@udecode/plate-ui-font': 18.9.0_5meegtdqv6ymmwsfb6u22gkgwa
-      '@udecode/plate-ui-line-height': 18.9.0_5meegtdqv6ymmwsfb6u22gkgwa
-      '@udecode/plate-ui-link': 18.11.0_5meegtdqv6ymmwsfb6u22gkgwa
-      '@udecode/plate-ui-list': 18.9.2_5meegtdqv6ymmwsfb6u22gkgwa
-      '@udecode/plate-ui-media': 18.11.0_5meegtdqv6ymmwsfb6u22gkgwa
-      '@udecode/plate-ui-mention': 18.10.3_5meegtdqv6ymmwsfb6u22gkgwa
-      '@udecode/plate-ui-placeholder': 18.9.0_7635xpgccrl5o6z4wdgzjengty
-      '@udecode/plate-ui-table': 18.11.0_5meegtdqv6ymmwsfb6u22gkgwa
-      '@udecode/plate-ui-toolbar': 18.9.0_5meegtdqv6ymmwsfb6u22gkgwa
+      '@tippyjs/react': 4.2.6_sfoxds7t5ydpegc3knd667wn6m
+      '@udecode/plate-core': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-popper': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
       react: 17.0.2
-      react-dnd: 16.0.1_smc5esni47gpbltvxzeziduyte
-      react-dnd-html5-backend: 15.1.2
+      react-dom: 17.0.2_react@17.0.2
+      react-popper: 2.3.0_vov5yimr6vvxyufd6uigwwkst4
+      react-use: 17.4.0_sfoxds7t5ydpegc3knd667wn6m
+      slate: 0.78.0
+      slate-history: 0.66.0_slate@0.78.0
+      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@popperjs/core'
+      - '@urql/core'
+      - immer
+      - optics-ts
+      - react-is
+      - react-query
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui-toolbar/19.0.3_blb3pyyzd7t2vcqgz4ctfappdu:
+    resolution: {integrity: sha512-34/G8vgqFl25HXWHcBM3MPmdbSRyrOOyM4/qSMsfNO8rwTnvLUbXE1aguAs3iSQzBLm0pLolAi/rfZ58XhiWgg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@tippyjs/react': 4.2.6_sfoxds7t5ydpegc3knd667wn6m
+      '@udecode/plate-core': 19.0.3_d5yw7ijn2yafvi3oyhp7ai5gmm
+      '@udecode/plate-floating': 19.0.3_qtly5dcswxon57yu7bqc3bfm3i
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-button': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-use: 17.4.0_sfoxds7t5ydpegc3knd667wn6m
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui/10.6.0_f7z72tac26cjzqnfllstk4x5fq:
+    resolution: {integrity: sha512-TIp4yhXyNMQR+xRxBUZFc1qhhR4JtIRRUjzOThugkmykLCtyLXJcykBO2A6HSD9dNTDurIzBcnJs6h2HQFp3rA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.66.1'
+      slate-history: '>=0.66.0'
+      slate-hyperscript: '>=0.66.0'
+      slate-react: '>=0.74.2'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-headless': 10.6.0_cqokrydfgvnsbtmsouizrlndxm
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-alignment': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-block-quote': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-button': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-code-block': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-combobox': 10.6.0_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-dnd': 10.5.3_rrl3vdxtvw4k5udj3seozvlkne
+      '@udecode/plate-ui-find-replace': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-font': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-image': 10.5.3_ko2crrejjvncj54hu3y5oa63pi
+      '@udecode/plate-ui-line-height': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-link': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-list': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-media-embed': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-mention': 10.6.0_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-placeholder': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-popover': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-popper': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-ui-table': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-toolbar': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-hyperscript: 0.77.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@popperjs/core'
+      - '@types/hoist-non-react-statics'
+      - '@types/node'
+      - '@types/react'
+      - '@urql/core'
+      - encoding
+      - immer
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - optics-ts
+      - react-is
+      - react-query
+      - supports-color
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui/10.6.0_otptddp36c5zs4pbnen5htp4nu:
+    resolution: {integrity: sha512-TIp4yhXyNMQR+xRxBUZFc1qhhR4JtIRRUjzOThugkmykLCtyLXJcykBO2A6HSD9dNTDurIzBcnJs6h2HQFp3rA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.66.1'
+      slate-history: '>=0.66.0'
+      slate-hyperscript: '>=0.66.0'
+      slate-react: '>=0.74.2'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-headless': 10.6.0_cqokrydfgvnsbtmsouizrlndxm
+      '@udecode/plate-styled-components': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-alignment': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-block-quote': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-button': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-code-block': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-combobox': 10.6.0_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-dnd': 10.5.3_iv6mfpmwnp2vdrqozlik4nfch4
+      '@udecode/plate-ui-find-replace': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-font': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-image': 10.5.3_ko2crrejjvncj54hu3y5oa63pi
+      '@udecode/plate-ui-line-height': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-link': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-list': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-media-embed': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-mention': 10.6.0_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-placeholder': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-popover': 10.5.3_l2xhcf2qjd5e6qexqd72n2bvmm
+      '@udecode/plate-ui-popper': 10.5.3_4ezny5ebcf4b4sdkjngrcgvrk4
+      '@udecode/plate-ui-table': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      '@udecode/plate-ui-toolbar': 10.5.3_bnadrewly7b2t2iy6hs335locu
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.78.0
+      slate-history: 0.66.0_slate@0.78.0
+      slate-hyperscript: 0.77.0_slate@0.78.0
+      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@popperjs/core'
+      - '@types/hoist-non-react-statics'
+      - '@types/node'
+      - '@types/react'
+      - '@urql/core'
+      - encoding
+      - immer
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - optics-ts
+      - react-is
+      - react-query
+      - supports-color
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate-ui/19.0.5_46lb47almn5glegy4zpoj25ooe:
+    resolution: {integrity: sha512-gNvRIM+csBg7f8EjAflz4CuQSYrpGeNmKSmdf69K7fBdAOnZo1GqTXZdS9ZqZHZhMYeOiJWi1WTKjKbuEvY/0Q==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dnd: '>=14.0.0'
+      react-dnd-html5-backend: '>=14.0.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-hyperscript: '>=0.66.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-headless': 19.0.5_g7qlm2w3kkyqioasdjobnxofre
+      '@udecode/plate-styled-components': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-alignment': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      '@udecode/plate-ui-block-quote': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-button': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-code-block': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      '@udecode/plate-ui-combobox': 19.0.4_blb3pyyzd7t2vcqgz4ctfappdu
+      '@udecode/plate-ui-comments': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      '@udecode/plate-ui-cursor': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-emoji': 19.0.5_blb3pyyzd7t2vcqgz4ctfappdu
+      '@udecode/plate-ui-find-replace': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      '@udecode/plate-ui-font': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      '@udecode/plate-ui-line-height': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      '@udecode/plate-ui-link': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      '@udecode/plate-ui-list': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      '@udecode/plate-ui-media': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      '@udecode/plate-ui-mention': 19.0.4_blb3pyyzd7t2vcqgz4ctfappdu
+      '@udecode/plate-ui-placeholder': 19.0.3_j77ytrqijsbx5j7bdcluvcwwam
+      '@udecode/plate-ui-table': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      '@udecode/plate-ui-toolbar': 19.0.3_blb3pyyzd7t2vcqgz4ctfappdu
+      react: 17.0.2
+      react-dnd: 16.0.1_smc5esni47gpbltvxzeziduyte
+      react-dnd-html5-backend: 15.1.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-hyperscript: 0.77.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
       use-context-selector: 1.4.1_rb4ld2rhs2bcj52oyr7ss5tkgq
     transitivePeerDependencies:
@@ -6076,25 +8227,119 @@ packages:
       - supports-color
     dev: false
 
-  /@udecode/plate/18.11.2_6jhmma7zc7jn5whmtj2xi5zloy:
-    resolution: {integrity: sha512-Dxt24nEqaZs+m26rYai2I7wo7gB8HwLABx0PVahD3qDKy4XRox3j9T4ohknYMB7QsH/wZB4TJU7ZKlhBqdlnvw==}
+  /@udecode/plate/10.6.0_f7z72tac26cjzqnfllstk4x5fq:
+    resolution: {integrity: sha512-6HKb6p+2dYF+c3PtHNcErfymLFI8XOiaV805wgJUWXKY9CT7r4OpEXFqerjFQrhx+wk+Lc/HW5sYgGmzT74RdQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-      slate: '>=0.78.0'
+      slate: '>=0.66.1'
       slate-history: '>=0.66.0'
       slate-hyperscript: '>=0.66.0'
-      slate-react: '>=0.79.0'
+      slate-react: '>=0.74.2'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-headless': 18.11.2_apsly3itnks4vinztrxz3j36ey
-      '@udecode/plate-ui': 18.11.2_6jhmma7zc7jn5whmtj2xi5zloy
+      '@udecode/plate-headless': 10.6.0_cqokrydfgvnsbtmsouizrlndxm
+      '@udecode/plate-ui': 10.6.0_f7z72tac26cjzqnfllstk4x5fq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.78.0
       slate-history: 0.66.0_slate@0.78.0
       slate-hyperscript: 0.77.0_slate@0.78.0
       slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@popperjs/core'
+      - '@types/hoist-non-react-statics'
+      - '@types/node'
+      - '@types/react'
+      - '@urql/core'
+      - encoding
+      - immer
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - optics-ts
+      - react-is
+      - react-query
+      - supports-color
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate/10.6.0_otptddp36c5zs4pbnen5htp4nu:
+    resolution: {integrity: sha512-6HKb6p+2dYF+c3PtHNcErfymLFI8XOiaV805wgJUWXKY9CT7r4OpEXFqerjFQrhx+wk+Lc/HW5sYgGmzT74RdQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.66.1'
+      slate-history: '>=0.66.0'
+      slate-hyperscript: '>=0.66.0'
+      slate-react: '>=0.74.2'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-headless': 10.6.0_cqokrydfgvnsbtmsouizrlndxm
+      '@udecode/plate-ui': 10.6.0_otptddp36c5zs4pbnen5htp4nu
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.78.0
+      slate-history: 0.66.0_slate@0.78.0
+      slate-hyperscript: 0.77.0_slate@0.78.0
+      slate-react: 0.79.0_73yv25gc2m6entrjrcdpahn2yi
+      styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@popperjs/core'
+      - '@types/hoist-non-react-statics'
+      - '@types/node'
+      - '@types/react'
+      - '@urql/core'
+      - encoding
+      - immer
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - optics-ts
+      - react-is
+      - react-query
+      - supports-color
+      - valtio
+      - wonka
+      - xstate
+    dev: false
+
+  /@udecode/plate/19.0.5_46lb47almn5glegy4zpoj25ooe:
+    resolution: {integrity: sha512-XmRg2TXeDFP3p5BBZbycGpQt5u3a1uRGH0yWRGxgLgCGaIff11TvseRixzzR8LJs7NhZ69OE3M1ztKKBrS0pFg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.87.0'
+      slate-history: '>=0.86.0'
+      slate-hyperscript: '>=0.66.0'
+      slate-react: '>=0.88.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-headless': 19.0.5_g7qlm2w3kkyqioasdjobnxofre
+      '@udecode/plate-ui': 19.0.5_46lb47almn5glegy4zpoj25ooe
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      slate: 0.87.0
+      slate-history: 0.86.0_slate@0.87.0
+      slate-hyperscript: 0.77.0_slate@0.87.0
+      slate-react: 0.88.0_zuw6cui5cs3cobsmg3u6vuy52i
       styled-components: 5.3.6_v5ja746gkdtknuc6tj46sve3be
     transitivePeerDependencies:
       - '@babel/core'
@@ -6116,6 +8361,15 @@ packages:
       - supports-color
     dev: false
 
+  /@udecode/zustood/0.4.4_zustand@3.7.0:
+    resolution: {integrity: sha512-OtkRGu8TKBkidOOf28TY4tqYJRhMAiVt+BF6lHbF/FnXRmOa8eLal8Q/k9sqQcGzQAHBaZYcx0pR1+wlQzaurg==}
+    peerDependencies:
+      zustand: '>=3.5.10'
+    dependencies:
+      immer: 9.0.6
+      zustand: 3.7.0_react@17.0.2
+    dev: false
+
   /@udecode/zustood/1.1.3_j4l4zfucqqy5rkq7yejc6ewt2u:
     resolution: {integrity: sha512-f3mxHDaOF+q2XvDh/mMvLhCNs0LfCLhIBl8jGmvZT/i3WWq7YujzGXgnbK8mxIkun9irfe6wlPhg9sTIB9Gnug==}
     peerDependencies:
@@ -6131,10 +8385,14 @@ packages:
       - scheduler
     dev: false
 
-  /@uiw/codemirror-extensions-basic-setup/4.15.1:
+  /@uiw/codemirror-extensions-basic-setup/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-LP2LHyPQm6ikYyXxT+1Odz+kiVLzzUmHSwBapSF4JgUE4b5QaBA7KCiTfwIWJPC528QVP2qWk1DEBNstPMiUdg==}
+    peerDependencies:
+      '@codemirror/language': '>=6.0.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
     dependencies:
-      '@codemirror/autocomplete': 6.3.4
+      '@codemirror/autocomplete': 6.3.4_4npvozs3agsv66jx2b7pfvr53q
       '@codemirror/commands': 6.1.2
       '@codemirror/language': 6.3.1
       '@codemirror/lint': 6.1.0
@@ -6143,7 +8401,7 @@ packages:
       '@codemirror/view': 6.6.0
     dev: false
 
-  /@uiw/codemirror-extensions-langs/4.15.1:
+  /@uiw/codemirror-extensions-langs/4.15.1_@codemirror+view@6.6.0:
     resolution: {integrity: sha512-osDz7cTs8fVvLcnZNn9+gE9qrH4eErWqIaaeS090px99KHbDTXfqre906Q+UmPFTDnO5JdlISno5MMlpBLdNaQ==}
     dependencies:
       '@codemirror/lang-cpp': 6.0.2
@@ -6156,135 +8414,206 @@ packages:
       '@codemirror/lang-php': 6.0.1
       '@codemirror/lang-python': 6.0.4
       '@codemirror/lang-rust': 6.0.1
-      '@codemirror/lang-sql': 6.3.3
+      '@codemirror/lang-sql': 6.3.3_@codemirror+view@6.6.0
       '@codemirror/lang-wast': 6.0.1
-      '@codemirror/lang-xml': 6.0.1
-      '@codemirror/language-data': 6.1.0
+      '@codemirror/lang-xml': 6.0.1_@codemirror+view@6.6.0
+      '@codemirror/language-data': 6.1.0_@codemirror+view@6.6.0
       '@codemirror/legacy-modes': 6.3.1
+    transitivePeerDependencies:
+      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-abcdef/4.15.1:
+  /@uiw/codemirror-theme-abcdef/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-DjdNJN0paKAS5wx2/ggSs0Fiobufa+UKlIKK/NmGCv1yzv1Xe1ffRzgaZauwVr3WnTc6s1HKA9gA/fqgXYuJaA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1
+      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-androidstudio/4.15.1:
+  /@uiw/codemirror-theme-androidstudio/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-cmQWDmS9XyGv1oYLp4CRh/VunWTDI7d1Nx4/PVOyVGdDz7J3rAEllVoh2iHNRhMgX2esjb0GYqWZJsIHqVp3Gg==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1
+      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-atomone/4.15.1:
+  /@uiw/codemirror-theme-atomone/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-/5O0+rWAz+7as59Sy5nTX1P5l+jihKzt+99OpzGUuda4AMS3Q8SP3WGLv3v+ySTTuvjMHFMgOObzb5uWjVF/ww==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1
+      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-bbedit/4.15.1:
+  /@uiw/codemirror-theme-bbedit/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-1K3vQDt+pnyipdKGSBrYiyOZay1Q+XgI9TrdxgZdnPiAkDbbpjqOxO5ND+JC5+uBx9U93rpzjWPIqdr7uBHGzA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1
+      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-bespin/4.15.1:
+  /@uiw/codemirror-theme-bespin/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-eFB1/BAbYoeaQbspUbShyKueWLmdP/xcvxJYiLNEFrcbzO9j/+lIvGl3M+R0OK3rhzo9pK896aB8Rz5/G3gBTA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1
+      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-darcula/4.15.1:
+  /@uiw/codemirror-theme-darcula/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-rgbqNmMbTShFSYUyy5iXCq8+BcFdZ8CJGJazTYnvRjV8TPm6huX2ukYiFxgitNShRsNrLHMx49CAiriKDwSnYA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1
+      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-dracula/4.15.1:
+  /@uiw/codemirror-theme-dracula/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-Qs4H5Uva5Z0EuX2NHl8soZEaQU0P5E2WBvGHl3jSwQA3LofrpFcL7x46V/cu8il0lmc977TD5A0M2xYKv8yvtg==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1
+      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-duotone/4.15.1:
+  /@uiw/codemirror-theme-duotone/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-LeG3gGpkKS0vy4zMfLqAxqHBtPsgC+4Q3MIRHcinoRaDGcdHZC8teX5W4E3fGntMZ/7DTUMj+Q4Um2NnGskHXg==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1
+      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-eclipse/4.15.1:
+  /@uiw/codemirror-theme-eclipse/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-LyYq3/T4GtaSH7EEwZiQjq6fefM6q9l0f7wtGpgTeR5Ogtf5b1Do3PM6BT12CfSjGtUzZUKnSZhx87vClSYyGg==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1
+      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-github/4.15.1:
+  /@uiw/codemirror-theme-github/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-8Q4V3kbHw/jgD35ry8mxyViN2LHWRFcMRIjY+IbTya0ehVb29bugSmJIAn1eHb/rk1hMQ6ZvDTseNBg+Abdl3Q==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1
+      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-gruvbox-dark/4.15.1:
+  /@uiw/codemirror-theme-gruvbox-dark/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-35dxs0eb19hJTWQc3yEXAM01s/mY0PcA/Cb1I0Z6yBWa7Vm63Mu+9F2hPQ9ldOG2QAKkM6x3p0xI18WH4JfahA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1
+      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-okaidia/4.15.1:
+  /@uiw/codemirror-theme-okaidia/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-Jw9u6BoG3cUvf1AWk696Z4EdwMeKbMcgsxCwm6tQBAEDo7nUqTedUIPAZChTxxviA3hmUKdlxVvZnXsey0q1EQ==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1
+      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-sublime/4.15.1:
+  /@uiw/codemirror-theme-sublime/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-A73SewRROBYyIgRjx5UiQ0YBKkUmJVMg/mqGNoDwQLVn2zN4/oEYlshznN4g32Tnp8ifMVI60d8f3fFwhC2ICQ==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1
+      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-vscode/4.15.1:
+  /@uiw/codemirror-theme-vscode/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-ypW95f2TU7udMrtoJWygcnf0trTPlZflM0s8/MJQrA6/fqxzWa0HyLwcMAUKySCxkmy6SY6/iJ2AivQVVXCJfQ==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1
+      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-xcode/4.15.1:
+  /@uiw/codemirror-theme-xcode/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-2Vr4/p34HACi9bjtl9VXgIKBsF/ObIDVzqtosq+BdJUhMnwo+z1kLX9mK17mCVvx+GNSfMR/TfWhN28UVY38Kw==}
     dependencies:
-      '@uiw/codemirror-themes': 4.15.1
+      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-themes-all/4.15.1:
+  /@uiw/codemirror-themes-all/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-MTxkIxHKcaQn0D6vjDShBY6OnXS3Zi6TqYC+5s9GEHNzaG2Lw90NOpislbFKG3llwr/BFIVAk5IToNPq1jJukg==}
     dependencies:
-      '@uiw/codemirror-theme-abcdef': 4.15.1
-      '@uiw/codemirror-theme-androidstudio': 4.15.1
-      '@uiw/codemirror-theme-atomone': 4.15.1
-      '@uiw/codemirror-theme-bbedit': 4.15.1
-      '@uiw/codemirror-theme-bespin': 4.15.1
-      '@uiw/codemirror-theme-darcula': 4.15.1
-      '@uiw/codemirror-theme-dracula': 4.15.1
-      '@uiw/codemirror-theme-duotone': 4.15.1
-      '@uiw/codemirror-theme-eclipse': 4.15.1
-      '@uiw/codemirror-theme-github': 4.15.1
-      '@uiw/codemirror-theme-gruvbox-dark': 4.15.1
-      '@uiw/codemirror-theme-okaidia': 4.15.1
-      '@uiw/codemirror-theme-sublime': 4.15.1
-      '@uiw/codemirror-theme-vscode': 4.15.1
-      '@uiw/codemirror-theme-xcode': 4.15.1
-      '@uiw/codemirror-themes': 4.15.1
+      '@uiw/codemirror-theme-abcdef': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+      '@uiw/codemirror-theme-androidstudio': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+      '@uiw/codemirror-theme-atomone': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+      '@uiw/codemirror-theme-bbedit': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+      '@uiw/codemirror-theme-bespin': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+      '@uiw/codemirror-theme-darcula': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+      '@uiw/codemirror-theme-dracula': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+      '@uiw/codemirror-theme-duotone': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+      '@uiw/codemirror-theme-eclipse': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+      '@uiw/codemirror-theme-github': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+      '@uiw/codemirror-theme-gruvbox-dark': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+      '@uiw/codemirror-theme-okaidia': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+      '@uiw/codemirror-theme-sublime': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+      '@uiw/codemirror-theme-vscode': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+      '@uiw/codemirror-theme-xcode': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+      '@uiw/codemirror-themes': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-themes/4.15.1:
+  /@uiw/codemirror-themes/4.15.1_4npvozs3agsv66jx2b7pfvr53q:
     resolution: {integrity: sha512-+3NKdmptuZTGE56LQ3j8daOAKer2STEDklkJS9AGHAGoN1o7IdA+s2Pbp3hf5oGxukNb29UA+gskfb5grszWMg==}
+    peerDependencies:
+      '@codemirror/language': '>=6.0.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
     dependencies:
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
       '@codemirror/view': 6.6.0
     dev: false
 
-  /@uiw/react-codemirror/4.15.1_tsqroltqy4j27r2h576o2pxd6u:
+  /@uiw/react-codemirror/4.15.1_h7lscfam4blfrwonbfvxz6f4vi:
     resolution: {integrity: sha512-lgtMFS8D2t9ri3ug3kgWoLPPdxDkqkYBWm3dVU9Z7GRs4R1iN2WSr2Z/biQ8KbdyLygRT5isi1k3Ud9ZY6j+YA==}
     peerDependencies:
+      '@codemirror/state': '>=6.0.0'
       '@codemirror/view': '>=6.0.0'
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -6294,14 +8623,12 @@ packages:
       '@codemirror/state': 6.1.4
       '@codemirror/theme-one-dark': 6.1.0
       '@codemirror/view': 6.6.0
-      '@uiw/codemirror-extensions-basic-setup': 4.15.1
+      '@uiw/codemirror-extensions-basic-setup': 4.15.1_4npvozs3agsv66jx2b7pfvr53q
       codemirror: 6.0.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-    dev: false
-
-  /@viselect/vanilla/3.2.2:
-    resolution: {integrity: sha512-3HRnbDOqkaLTSmfkSMnBImd1TyNVq5esiG8HhfKYpGE3Z8bjH1HeNbMrK87MjK9YX0h1SWJGD5dGn2C4o7tttg==}
+    transitivePeerDependencies:
+      - '@codemirror/language'
     dev: false
 
   /@vitejs/plugin-react/2.2.0_vite@3.2.3:
@@ -6356,6 +8683,16 @@ packages:
       xstate: ^4.29.0
     dependencies:
       immer: 9.0.12
+      xstate: 4.28.1
+    dev: false
+
+  /@xstate/immer/0.3.1_immer@9.0.16+xstate@4.28.1:
+    resolution: {integrity: sha512-YE+KY08IjEEmXo6XKKpeSGW4j9LfcXw+5JVixLLUO3fWQ3M95joWJ40VtGzx0w0zQSzoCNk8NgfvwWBGSbIaTA==}
+    peerDependencies:
+      immer: ^9.0.6
+      xstate: ^4.29.0
+    dependencies:
+      immer: 9.0.16
       xstate: 4.28.1
     dev: false
 
@@ -6467,7 +8804,6 @@ packages:
   /ansi-colors/4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
-    dev: true
 
   /ansi-escapes/4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -6691,6 +9027,11 @@ packages:
     resolution: {integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==}
     dev: true
 
+  /axe-core/4.6.3:
+    resolution: {integrity: sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==}
+    engines: {node: '>=4'}
+    dev: false
+
   /babel-plugin-styled-components/2.0.7_styled-components@5.3.6:
     resolution: {integrity: sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==}
     peerDependencies:
@@ -6723,6 +9064,10 @@ packages:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: true
 
+  /batch-processor/1.0.0:
+    resolution: {integrity: sha512-xoLQD8gmmR32MeuBHgH0Tzd5PuSZx71ZsbhVxOCRbgktZEPe4SQy7s9Z50uPp0F/f7iw2XmkHN2xkgbMfckMDA==}
+    dev: false
+
   /bcrypt-pbkdf/1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
     dependencies:
@@ -6751,7 +9096,6 @@ packages:
 
   /boolbase/1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
-    dev: true
 
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -6823,7 +9167,6 @@ packages:
     dependencies:
       function-bind: 1.1.1
       get-intrinsic: 1.1.3
-    dev: true
 
   /callsites/3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -6912,6 +9255,30 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
+  /cheerio-select/2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.1.0
+      css-what: 6.1.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.0.1
+    dev: false
+
+  /cheerio/1.0.0-rc.12:
+    resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
+    engines: {node: '>= 6'}
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.0.1
+      htmlparser2: 8.0.1
+      parse5: 7.1.2
+      parse5-htmlparser2-tree-adapter: 7.0.0
+    dev: false
+
   /chokidar/3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
@@ -6995,6 +9362,11 @@ packages:
     engines: {node: '>=0.8'}
     dev: true
 
+  /clsx/1.1.1:
+    resolution: {integrity: sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==}
+    engines: {node: '>=6'}
+    dev: false
+
   /clsx/1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
     engines: {node: '>=6'}
@@ -7007,7 +9379,7 @@ packages:
   /codemirror/6.0.1:
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
     dependencies:
-      '@codemirror/autocomplete': 6.3.4
+      '@codemirror/autocomplete': 6.3.4_4npvozs3agsv66jx2b7pfvr53q
       '@codemirror/commands': 6.1.2
       '@codemirror/language': 6.3.1
       '@codemirror/lint': 6.1.0
@@ -7060,6 +9432,11 @@ packages:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
     engines: {node: '>= 6'}
     dev: true
+
+  /commander/6.2.1:
+    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
+    engines: {node: '>= 6'}
+    dev: false
 
   /common-tags/1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
@@ -7134,6 +9511,11 @@ packages:
       toggle-selection: 1.0.6
     dev: false
 
+  /core-js/3.27.2:
+    resolution: {integrity: sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w==}
+    requiresBuild: true
+    dev: false
+
   /core-util-is/1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
     dev: true
@@ -7193,6 +9575,16 @@ packages:
       nth-check: 2.1.1
     dev: true
 
+  /css-select/5.1.0:
+    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.1.0
+      domhandler: 5.0.3
+      domutils: 3.0.1
+      nth-check: 2.1.1
+    dev: false
+
   /css-to-react-native/3.0.0:
     resolution: {integrity: sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==}
     dependencies:
@@ -7212,7 +9604,6 @@ packages:
   /css-what/6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
     engines: {node: '>= 6'}
-    dev: true
 
   /css.escape/1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -7450,11 +9841,27 @@ packages:
   /dlv/1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
+  /dnd-core/14.0.1:
+    resolution: {integrity: sha512-+PVS2VPTgKFPYWo3vAFEA8WPbTf7/xo43TifH9G8S1KqnrQu0o77A3unrF5yOugy4mIz7K5wAVFHUcha7wsz6A==}
+    dependencies:
+      '@react-dnd/asap': 4.0.1
+      '@react-dnd/invariant': 2.0.0
+      redux: 4.2.0
+    dev: false
+
   /dnd-core/15.1.1:
     resolution: {integrity: sha512-Mtj/Sltcx7stVXzeDg4g7roTe/AmzRuIf/FYOxX6F8gULbY54w066BlErBOzQfn9RIJ3gAYLGX7wvVvoBSq7ig==}
     dependencies:
       '@react-dnd/asap': 4.0.0
       '@react-dnd/invariant': 3.0.0
+      redux: 4.2.0
+    dev: false
+
+  /dnd-core/15.1.2:
+    resolution: {integrity: sha512-EOec1LyJUuGRFg0LDa55rSRAUe97uNVKVkUo8iyvzQlcECYTuPblVQfRWXWj1OyPseFIeebWpNmKFy0h6BcF1A==}
+    dependencies:
+      '@react-dnd/asap': 4.0.1
+      '@react-dnd/invariant': 3.0.1
       redux: 4.2.0
     dev: false
 
@@ -7486,7 +9893,6 @@ packages:
       domelementtype: 2.3.0
       domhandler: 4.3.1
       entities: 2.2.0
-    dev: true
 
   /dom-serializer/2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -7494,25 +9900,32 @@ packages:
       domelementtype: 2.3.0
       domhandler: 5.0.3
       entities: 4.4.0
-    dev: true
+
+  /dom-walk/0.1.2:
+    resolution: {integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==}
+    dev: false
 
   /domelementtype/2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
-    dev: true
+
+  /domhandler/3.3.0:
+    resolution: {integrity: sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==}
+    engines: {node: '>= 4'}
+    dependencies:
+      domelementtype: 2.3.0
+    dev: false
 
   /domhandler/4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
     dependencies:
       domelementtype: 2.3.0
-    dev: true
 
   /domhandler/5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
     dependencies:
       domelementtype: 2.3.0
-    dev: true
 
   /domutils/2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -7520,7 +9933,6 @@ packages:
       dom-serializer: 1.4.1
       domelementtype: 2.3.0
       domhandler: 4.3.1
-    dev: true
 
   /domutils/3.0.1:
     resolution: {integrity: sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==}
@@ -7528,7 +9940,6 @@ packages:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
-    dev: true
 
   /dot-prop/6.0.1:
     resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
@@ -7550,6 +9961,19 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /downshift/6.1.7_react@17.0.2:
+    resolution: {integrity: sha512-cVprZg/9Lvj/uhYRxELzlu1aezRcgPWBjTvspiGTVEU64gF5pRdSRKFVLcxqsZC637cLAGMbL40JavEfWnqgNg==}
+    peerDependencies:
+      react: '>=16.12.0'
+    dependencies:
+      '@babel/runtime': 7.20.6
+      compute-scroll-into-view: 1.0.20
+      prop-types: 15.8.1
+      react: 17.0.2
+      react-is: 17.0.2
+      tslib: 2.4.1
+    dev: false
+
   /ecc-jsbn/0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
     dependencies:
@@ -7559,6 +9983,12 @@ packages:
 
   /electron-to-chromium/1.4.284:
     resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
+
+  /element-resize-detector/1.2.4:
+    resolution: {integrity: sha512-Fl5Ftk6WwXE0wqCgNoseKWndjzZlDCwuPTcoVZfCP9R3EHQF8qUtr3YUPNETegRBOKqQKPW3n4kiIWngGi8tKg==}
+    dependencies:
+      batch-processor: 1.0.0
+    dev: false
 
   /emoji-regex/8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -7579,12 +10009,10 @@ packages:
 
   /entities/2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
-    dev: true
 
   /entities/4.4.0:
     resolution: {integrity: sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==}
     engines: {node: '>=0.12'}
-    dev: true
 
   /env-paths/2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -7865,6 +10293,11 @@ packages:
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
+
+  /escape-goat/3.0.0:
+    resolution: {integrity: sha512-w3PwNZJwRxlp47QGzhuEBldEqVHHhh8/tIPcl6ecf2Bou99cdAt0knihBV0Ecc7CGxYduXVBDheH1K2oADRlvw==}
+    engines: {node: '>=10'}
+    dev: false
 
   /escape-html/1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -8421,7 +10854,6 @@ packages:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
-    dev: true
 
   /find-up/5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -8597,7 +11029,6 @@ packages:
       function-bind: 1.1.1
       has: 1.0.3
       has-symbols: 1.0.3
-    dev: true
 
   /get-port/3.2.0:
     resolution: {integrity: sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==}
@@ -8676,6 +11107,13 @@ packages:
       ini: 2.0.0
     dev: true
 
+  /global/4.4.0:
+    resolution: {integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==}
+    dependencies:
+      min-document: 2.19.0
+      process: 0.11.10
+    dev: false
+
   /globals/11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
@@ -8753,14 +11191,12 @@ packages:
   /has-symbols/1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /has-tostringtag/1.0.0:
     resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
-    dev: true
 
   /has/1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
@@ -8799,6 +11235,15 @@ packages:
     resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
     dev: false
 
+  /htmlparser2/4.1.0:
+    resolution: {integrity: sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 3.3.0
+      domutils: 2.8.0
+      entities: 2.2.0
+    dev: false
+
   /htmlparser2/8.0.1:
     resolution: {integrity: sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==}
     dependencies:
@@ -8806,7 +11251,6 @@ packages:
       domhandler: 5.0.3
       domutils: 3.0.1
       entities: 4.4.0
-    dev: true
 
   /http-basic/8.1.3:
     resolution: {integrity: sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==}
@@ -8871,6 +11315,10 @@ packages:
 
   /immer/9.0.16:
     resolution: {integrity: sha512-qenGE7CstVm1NrHQbMh8YaSzTZTFNP3zPqr3YU0S0UY441j4bJTg4A2Hh5KAhwgaiU6ZZ1Ar6y/2f4TblnMReQ==}
+    dev: false
+
+  /immer/9.0.6:
+    resolution: {integrity: sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==}
     dev: false
 
   /import-fresh/3.3.0:
@@ -8954,6 +11402,12 @@ packages:
       '@formatjs/fast-memoize': 1.2.6
       '@formatjs/icu-messageformat-parser': 2.1.11
       tslib: 2.4.0
+    dev: false
+
+  /invariant/2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+    dependencies:
+      loose-envify: 1.4.0
     dev: false
 
   /ipaddr.js/1.9.1:
@@ -9056,6 +11510,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /is-function/1.0.2:
+    resolution: {integrity: sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==}
+    dev: false
+
   /is-generator-function/1.0.10:
     resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
     engines: {node: '>= 0.4'}
@@ -9140,7 +11598,6 @@ packages:
     dependencies:
       call-bind: 1.0.2
       has-tostringtag: 1.0.0
-    dev: true
 
   /is-shared-array-buffer/1.0.2:
     resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==}
@@ -9165,7 +11622,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
-    dev: true
 
   /is-typed-array/1.1.10:
     resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==}
@@ -9211,6 +11667,11 @@ packages:
   /isexe/2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
+
+  /isobject/4.0.0:
+    resolution: {integrity: sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /isstream/0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
@@ -9259,6 +11720,46 @@ packages:
     dependencies:
       '@babel/core': 7.20.2
       react: 17.0.2
+    dev: false
+
+  /jotai/1.5.3_rry5ecjlappe67zcdjx5wnrgka:
+    resolution: {integrity: sha512-iD8MkbehxTjfRUtIJJdyQcjbAe2MqjW1+oFc5lvfgRjLHwjRQyWnZC3gdGAOQCOqUSPZHOBGgWyP/8gBDckaNQ==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      '@babel/template': '*'
+      '@urql/core': '*'
+      immer: '*'
+      optics-ts: '*'
+      react: '>=16.8'
+      react-query: '*'
+      valtio: '*'
+      wonka: '*'
+      xstate: '*'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@babel/template':
+        optional: true
+      '@urql/core':
+        optional: true
+      immer:
+        optional: true
+      optics-ts:
+        optional: true
+      react-query:
+        optional: true
+      valtio:
+        optional: true
+      wonka:
+        optional: true
+      xstate:
+        optional: true
+    dependencies:
+      '@babel/core': 7.20.2
+      immer: 9.0.16
+      react: 17.0.2
+      xstate: 4.28.1
     dev: false
 
   /js-cookie/2.2.1:
@@ -9372,6 +11873,20 @@ packages:
       object.assign: 4.1.4
     dev: true
 
+  /juice/8.0.0:
+    resolution: {integrity: sha512-LRCfXBOqI1wt+zYR/5xwDnf+ZyiJiDt44DGZaBSAVwZWyWv3BliaiGTLS6KCvadv3uw6XGiPPFcTfY7CdF7Z/Q==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    dependencies:
+      cheerio: 1.0.0-rc.12
+      commander: 6.2.1
+      mensch: 0.3.4
+      slick: 1.12.2
+      web-resource-inliner: 5.0.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /just-extend/4.2.1:
     resolution: {integrity: sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==}
     dev: false
@@ -9464,7 +11979,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-locate: 4.1.0
-    dev: true
 
   /locate-path/6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -9578,6 +12092,10 @@ packages:
 
   /make-error/1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  /map-or-similar/1.5.0:
+    resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
+    dev: false
 
   /markdown-table/3.0.2:
     resolution: {integrity: sha512-y8j3a5/DkJCmS5x4dMCQL+OR0+2EAq3DOtio1COSHsmW2BGXnNCK3v12hJt1LrUz5iZH5g0LmuYOjDdI+czghA==}
@@ -9698,6 +12216,16 @@ packages:
 
   /mdn-data/2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+    dev: false
+
+  /memoizerific/1.11.3:
+    resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
+    dependencies:
+      map-or-similar: 1.5.0
+    dev: false
+
+  /mensch/0.3.4:
+    resolution: {integrity: sha512-IAeFvcOnV9V0Yk+bFhYR07O3yNina9ANIN5MoXBKYJ/RLYPurd2d0yw14MDhpr9/momp0WofT1bPUh3hkzdi/g==}
     dev: false
 
   /merge-stream/2.0.0:
@@ -9988,6 +12516,12 @@ packages:
       mime-db: 1.52.0
     dev: true
 
+  /mime/2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
+    dev: false
+
   /mimic-fn/2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -9997,6 +12531,12 @@ packages:
     resolution: {integrity: sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==}
     engines: {node: '>=8'}
     dev: true
+
+  /min-document/2.19.0:
+    resolution: {integrity: sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==}
+    dependencies:
+      dom-walk: 0.1.2
+    dev: false
 
   /min-indent/1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -10142,7 +12682,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-    dev: true
 
   /node-fetch/3.3.0:
     resolution: {integrity: sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==}
@@ -10192,7 +12731,6 @@ packages:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
     dependencies:
       boolbase: 1.0.0
-    dev: true
 
   /object-assign/4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -10204,7 +12742,6 @@ packages:
 
   /object-inspect/1.12.2:
     resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
-    dev: true
 
   /object-keys/1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
@@ -10329,7 +12866,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       p-try: 2.2.0
-    dev: true
 
   /p-limit/3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -10357,7 +12893,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-limit: 2.3.0
-    dev: true
 
   /p-locate/5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -10383,7 +12918,6 @@ packages:
   /p-try/2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
-    dev: true
 
   /papaparse/5.3.2:
     resolution: {integrity: sha512-6dNZu0Ki+gyV0eBsFKJhYr+MdQYAzFUGlBMNj3GNrmHxmz1lfRa24CjFObPXtjcetlOv5Ad299MhIK0znp3afw==}
@@ -10420,6 +12954,19 @@ packages:
       lines-and-columns: 1.2.4
     dev: true
 
+  /parse5-htmlparser2-tree-adapter/7.0.0:
+    resolution: {integrity: sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==}
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.1.2
+    dev: false
+
+  /parse5/7.1.2:
+    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
+    dependencies:
+      entities: 4.4.0
+    dev: false
+
   /path-browserify/1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
     dev: true
@@ -10432,7 +12979,6 @@ packages:
   /path-exists/4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-    dev: true
 
   /path-exists/5.0.0:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
@@ -10477,6 +13023,7 @@ packages:
 
   /performance-now/2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+    dev: true
 
   /picocolors/1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -10657,7 +13204,6 @@ packages:
   /process/0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
-    dev: true
 
   /promise/8.3.0:
     resolution: {integrity: sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==}
@@ -10717,7 +13263,6 @@ packages:
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.0.4
-    dev: true
 
   /qs/6.5.3:
     resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
@@ -10734,12 +13279,6 @@ packages:
   /quick-lru/5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
-
-  /raf/3.4.1:
-    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
-    dependencies:
-      performance-now: 2.1.0
-    dev: false
 
   /re-resizable/6.9.9_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA==}
@@ -10777,6 +13316,12 @@ packages:
       react-popper: 2.3.0_vov5yimr6vvxyufd6uigwwkst4
     dev: false
 
+  /react-dnd-html5-backend/14.1.0:
+    resolution: {integrity: sha512-6ONeqEC3XKVf4eVmMTe0oPds+c5B9Foyj8p/ZKLb7kL2qh9COYxiBHv3szd6gztqi/efkmriywLUVlPotqoJyw==}
+    dependencies:
+      dnd-core: 14.0.1
+    dev: false
+
   /react-dnd-html5-backend/15.1.2:
     resolution: {integrity: sha512-mem9QbutUF+aA2YC1y47G3ECjnYV/sCYKSnu5Jd7cbg3fLMPAwbnTf/JayYdnCH5l3eg9akD9dQt+cD0UdF8QQ==}
     dependencies:
@@ -10787,6 +13332,104 @@ packages:
     resolution: {integrity: sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==}
     dependencies:
       dnd-core: 16.0.1
+    dev: false
+
+  /react-dnd/14.0.5_pxzommwrsowkd4kgag6q3sluym:
+    resolution: {integrity: sha512-9i1jSgbyVw0ELlEVt/NkCUkxy1hmhJOkePoCH713u75vzHGyXhPDm28oLfc2NMSBjZRM1Y+wRjHXJT3sPrTy+A==}
+    peerDependencies:
+      '@types/hoist-non-react-statics': '>= 3.3.1'
+      '@types/node': '>= 12'
+      '@types/react': '>= 16'
+      react: '>= 16.14'
+    peerDependenciesMeta:
+      '@types/hoist-non-react-statics':
+        optional: true
+      '@types/node':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@react-dnd/invariant': 2.0.0
+      '@react-dnd/shallowequal': 2.0.0
+      '@types/react': 17.0.50
+      dnd-core: 14.0.1
+      fast-deep-equal: 3.1.3
+      hoist-non-react-statics: 3.3.2
+      react: 17.0.2
+    dev: false
+
+  /react-dnd/14.0.5_smc5esni47gpbltvxzeziduyte:
+    resolution: {integrity: sha512-9i1jSgbyVw0ELlEVt/NkCUkxy1hmhJOkePoCH713u75vzHGyXhPDm28oLfc2NMSBjZRM1Y+wRjHXJT3sPrTy+A==}
+    peerDependencies:
+      '@types/hoist-non-react-statics': '>= 3.3.1'
+      '@types/node': '>= 12'
+      '@types/react': '>= 16'
+      react: '>= 16.14'
+    peerDependenciesMeta:
+      '@types/hoist-non-react-statics':
+        optional: true
+      '@types/node':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@react-dnd/invariant': 2.0.0
+      '@react-dnd/shallowequal': 2.0.0
+      '@types/node': 18.7.21
+      '@types/react': 17.0.50
+      dnd-core: 14.0.1
+      fast-deep-equal: 3.1.3
+      hoist-non-react-statics: 3.3.2
+      react: 17.0.2
+    dev: false
+
+  /react-dnd/15.1.2_pxzommwrsowkd4kgag6q3sluym:
+    resolution: {integrity: sha512-EaSbMD9iFJDY/o48T3c8wn3uWU+2uxfFojhesZN3LhigJoAIvH2iOjxofSA9KbqhAKP6V9P853G6XG8JngKVtA==}
+    peerDependencies:
+      '@types/hoist-non-react-statics': '>= 3.3.1'
+      '@types/node': '>= 12'
+      '@types/react': '>= 16'
+      react: '>= 16.14'
+    peerDependenciesMeta:
+      '@types/hoist-non-react-statics':
+        optional: true
+      '@types/node':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@react-dnd/invariant': 3.0.1
+      '@react-dnd/shallowequal': 3.0.1
+      '@types/react': 17.0.50
+      dnd-core: 15.1.2
+      fast-deep-equal: 3.1.3
+      hoist-non-react-statics: 3.3.2
+      react: 17.0.2
+    dev: false
+
+  /react-dnd/15.1.2_smc5esni47gpbltvxzeziduyte:
+    resolution: {integrity: sha512-EaSbMD9iFJDY/o48T3c8wn3uWU+2uxfFojhesZN3LhigJoAIvH2iOjxofSA9KbqhAKP6V9P853G6XG8JngKVtA==}
+    peerDependencies:
+      '@types/hoist-non-react-statics': '>= 3.3.1'
+      '@types/node': '>= 12'
+      '@types/react': '>= 16'
+      react: '>= 16.14'
+    peerDependenciesMeta:
+      '@types/hoist-non-react-statics':
+        optional: true
+      '@types/node':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@react-dnd/invariant': 3.0.1
+      '@react-dnd/shallowequal': 3.0.1
+      '@types/node': 18.7.21
+      '@types/react': 17.0.50
+      dnd-core: 15.1.2
+      fast-deep-equal: 3.1.3
+      hoist-non-react-statics: 3.3.2
+      react: 17.0.2
     dev: false
 
   /react-dnd/16.0.1_pxzommwrsowkd4kgag6q3sluym:
@@ -10894,6 +13537,18 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
+  /react-popper/2.2.5_qofm6heeqcbukqym6fyxd6dvda:
+    resolution: {integrity: sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==}
+    peerDependencies:
+      '@popperjs/core': ^2.0.0
+      react: ^16.8.0 || ^17
+    dependencies:
+      '@popperjs/core': 2.10.2
+      react: 17.0.2
+      react-fast-compare: 3.2.0
+      warning: 4.0.3
+    dev: false
+
   /react-popper/2.3.0_vov5yimr6vvxyufd6uigwwkst4:
     resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
     peerDependencies:
@@ -10912,6 +13567,15 @@ packages:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /react-sizeme/3.0.2:
+    resolution: {integrity: sha512-xOIAOqqSSmKlKFJLO3inBQBdymzDuXx4iuwkNcJmC96jeiOg5ojByvL+g3MW9LPEsojLbC6pf68zOfobK8IPlw==}
+    dependencies:
+      element-resize-detector: 1.2.4
+      invariant: 2.2.4
+      shallowequal: 1.1.0
+      throttle-debounce: 3.0.1
+    dev: false
 
   /react-textarea-autosize/8.4.0_pxzommwrsowkd4kgag6q3sluym:
     resolution: {integrity: sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==}
@@ -11360,7 +14024,6 @@ packages:
       call-bind: 1.0.2
       get-intrinsic: 1.1.3
       object-inspect: 1.12.2
-    dev: true
 
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -11395,6 +14058,15 @@ packages:
       slate: 0.78.0
     dev: false
 
+  /slate-history/0.86.0_slate@0.87.0:
+    resolution: {integrity: sha512-OxObL9tbhgwvSlnKSCpGIh7wnuaqvOj5jRExGjEyCU2Ke8ctf22HjT+jw7GEi9ttLzNTUmTEU3YIzqKGeqN+og==}
+    peerDependencies:
+      slate: '>=0.65.3'
+    dependencies:
+      is-plain-object: 5.0.0
+      slate: 0.87.0
+    dev: false
+
   /slate-hyperscript/0.77.0_slate@0.78.0:
     resolution: {integrity: sha512-M6uRpttwKnosniQORNPYQABHQ9XWC7qaSr/127LWWPjTOR5MSSwrHGrghN81BhZVqpICHrI7jkPA2813cWdHNA==}
     peerDependencies:
@@ -11402,6 +14074,15 @@ packages:
     dependencies:
       is-plain-object: 5.0.0
       slate: 0.78.0
+    dev: false
+
+  /slate-hyperscript/0.77.0_slate@0.87.0:
+    resolution: {integrity: sha512-M6uRpttwKnosniQORNPYQABHQ9XWC7qaSr/127LWWPjTOR5MSSwrHGrghN81BhZVqpICHrI7jkPA2813cWdHNA==}
+    peerDependencies:
+      slate: '>=0.65.3'
+    dependencies:
+      is-plain-object: 5.0.0
+      slate: 0.87.0
     dev: false
 
   /slate-react/0.79.0_73yv25gc2m6entrjrcdpahn2yi:
@@ -11424,8 +14105,36 @@ packages:
       tiny-invariant: 1.0.6
     dev: false
 
+  /slate-react/0.88.0_zuw6cui5cs3cobsmg3u6vuy52i:
+    resolution: {integrity: sha512-hmrl7VZAAdOUlReI/EkI2GuRSLWuQFD+n9ZZaVqSUMjJR3T/MGNMPsJQAfrjgke2+xf4LIGEDGWZHKbUFK1hhw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.65.3'
+    dependencies:
+      '@types/is-hotkey': 0.1.7
+      '@types/lodash': 4.14.190
+      direction: 1.0.4
+      is-hotkey: 0.1.8
+      is-plain-object: 5.0.0
+      lodash: 4.17.21
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      scroll-into-view-if-needed: 2.2.31
+      slate: 0.87.0
+      tiny-invariant: 1.0.6
+    dev: false
+
   /slate/0.78.0:
     resolution: {integrity: sha512-VwQ0RafT3JPf9SFrXI02Dh3S4Iz9en7d1nn50C/LJjjqjfgv+a2ORbgWMdYjhycPYldaxJwcI3OpP9D1g4SXEg==}
+    dependencies:
+      immer: 9.0.16
+      is-plain-object: 5.0.0
+      tiny-warning: 1.0.3
+    dev: false
+
+  /slate/0.87.0:
+    resolution: {integrity: sha512-m+IWERpdtb7Zna09MxHlUYIAoo4WVdxp2fSf7c+jSV9pDmJ4QvUTuHghX/TVrxtr+8BKGhyQCWIerZt32B1Ysg==}
     dependencies:
       immer: 9.0.16
       is-plain-object: 5.0.0
@@ -11449,6 +14158,10 @@ packages:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
     dev: true
+
+  /slick/1.12.2:
+    resolution: {integrity: sha512-4qdtOGcBjral6YIBCWJ0ljFSKNLz9KkhbWtuGvUyRowl1kxfuE1x/Z/aJcaiilpb3do9bl5K7/1h9XC5wWpY/A==}
+    dev: false
 
   /sonic-boom/3.2.0:
     resolution: {integrity: sha512-SbbZ+Kqj/XIunvIAgUZRlqd6CGQYq71tRRbXR92Za8J/R3Yh4Av+TWENiSiEgnlwckYLyP0YZQWVfyNC0dzLaA==}
@@ -11548,6 +14261,10 @@ packages:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
     dev: true
+
+  /store2/2.14.2:
+    resolution: {integrity: sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==}
+    dev: false
 
   /strict-event-emitter/0.2.8:
     resolution: {integrity: sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==}
@@ -11717,10 +14434,12 @@ packages:
       get-port: 3.2.0
     dev: true
 
-  /tailwindcss/3.2.1:
+  /tailwindcss/3.2.1_postcss@8.4.19:
     resolution: {integrity: sha512-Uw+GVSxp5CM48krnjHObqoOwlCt5Qo6nw1jlCRwfGy68dSYb/LwS9ZFidYGRiM+w6rMawkZiu1mEMAsHYAfoLg==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -11749,10 +14468,12 @@ packages:
       - ts-node
     dev: true
 
-  /tailwindcss/3.2.3:
+  /tailwindcss/3.2.3_postcss@8.4.19:
     resolution: {integrity: sha512-Xt9D4PK4zuuQCEB8bwK9JUCKmTgUwyac/6b0/42Vqhgl6YJkep+Wf5wq+5uXYfmrupdAD0YY2NY1hyZp1HjRrg==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -11780,10 +14501,12 @@ packages:
     transitivePeerDependencies:
       - ts-node
 
-  /tailwindcss/3.2.3_ts-node@10.9.1:
+  /tailwindcss/3.2.3_v776zzvn44o7tpgzieipaairwm:
     resolution: {integrity: sha512-Xt9D4PK4zuuQCEB8bwK9JUCKmTgUwyac/6b0/42Vqhgl6YJkep+Wf5wq+5uXYfmrupdAD0YY2NY1hyZp1HjRrg==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -11821,6 +14544,19 @@ packages:
       inherits: 2.0.4
       readable-stream: 3.6.0
     dev: true
+
+  /telejson/6.0.8:
+    resolution: {integrity: sha512-nerNXi+j8NK1QEfBHtZUN/aLdDcyupA//9kAboYLrtzZlPLpUfqbVGWb9zz91f/mIjRbAYhbgtnJHY8I1b5MBg==}
+    dependencies:
+      '@types/is-function': 1.0.1
+      global: 4.4.0
+      is-function: 1.0.2
+      is-regex: 1.1.4
+      is-symbol: 1.0.4
+      isobject: 4.0.0
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+    dev: false
 
   /text-table/0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -11937,7 +14673,6 @@ packages:
 
   /tr46/0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: true
 
   /trough/1.0.5:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
@@ -11945,6 +14680,11 @@ packages:
 
   /trough/2.1.0:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
+    dev: false
+
+  /ts-dedent/2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
     dev: false
 
   /ts-easing/0.2.0:
@@ -12274,6 +15014,11 @@ packages:
   /v8-compile-cache-lib/3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
+  /valid-data-url/3.0.1:
+    resolution: {integrity: sha512-jOWVmzVceKlVVdwjNSenT4PbGghU0SBIizAev8ofZVgivk/TVHXSbNL8LP6M3spZvkR9/QolkyJavGSX5Cs0UA==}
+    engines: {node: '>=10'}
+    dev: false
+
   /validate-npm-package-license/3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
     dependencies:
@@ -12493,6 +15238,20 @@ packages:
       '@zxing/text-encoding': 0.9.0
     dev: true
 
+  /web-resource-inliner/5.0.0:
+    resolution: {integrity: sha512-AIihwH+ZmdHfkJm7BjSXiEClVt4zUFqX4YlFAzjL13wLtDuUneSaFvDBTbdYRecs35SiU7iNKbMnN+++wVfb6A==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      ansi-colors: 4.1.3
+      escape-goat: 3.0.0
+      htmlparser2: 4.1.0
+      mime: 2.6.0
+      node-fetch: 2.6.7
+      valid-data-url: 3.0.1
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /web-streams-polyfill/3.2.1:
     resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
     engines: {node: '>= 8'}
@@ -12500,7 +15259,6 @@ packages:
 
   /webidl-conversions/3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: true
 
   /webidl-conversions/7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
@@ -12524,7 +15282,6 @@ packages:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    dev: true
 
   /which-boxed-primitive/1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
@@ -12676,6 +15433,18 @@ packages:
       compress-commons: 4.1.1
       readable-stream: 3.6.0
     dev: true
+
+  /zustand/3.7.0_react@17.0.2:
+    resolution: {integrity: sha512-USzVzLGrvZ8VK1/sEsOAmeqa8N7D3OBdZskVaL7DL89Q4QLTYD053iIlZ5KDidyZ+Od80Dttin/f8ZulOLFFDQ==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      react: '>=16.8'
+    peerDependenciesMeta:
+      react:
+        optional: true
+    dependencies:
+      react: 17.0.2
+    dev: false
 
   /zustand/3.7.2_react@17.0.2:
     resolution: {integrity: sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==}


### PR DESCRIPTION
Text block tests should pass after the gap prop is implemented within fondue: https://github.com/Frontify/fondue/pull/1184

Other tests need to be checked