### PR TITLE
feat(shared): split downloadButton out of the Attachment

### DIFF
--- a/packages/audio-block/src/AudioBlock.tsx
+++ b/packages/audio-block/src/AudioBlock.tsx
@@ -20,7 +20,12 @@ import {
     UnderlinePlugin,
 } from '@frontify/fondue';
 import { Plugin, PluginProps } from '@frontify/fondue/dist/components/RichTextEditor/Plugins/Plugin';
-import { joinClassNames, useGuidelineDesignTokens } from '@frontify/guideline-blocks-shared';
+import {
+    DownloadButton,
+    downloadAsset,
+    joinClassNames,
+    useGuidelineDesignTokens,
+} from '@frontify/guideline-blocks-shared';
 import {
     Asset,
     AssetChooserObjectType,
@@ -204,7 +209,12 @@ export const AudioBlock = ({ appBridge }: BlockProps) => {
                         />
                     </div>
                 </div>
-                {audio ? <BlockAttachments assetToDownload={audio} appBridge={appBridge} /> : null}
+                {audio ? (
+                    <div className="tw-flex tw-gap-2">
+                        <DownloadButton onDownload={() => downloadAsset(audio)} />
+                        <BlockAttachments appBridge={appBridge} />
+                    </div>
+                ) : null}
             </div>
         </div>
     );

--- a/packages/audio-block/src/components/BlockAttachments.tsx
+++ b/packages/audio-block/src/components/BlockAttachments.tsx
@@ -1,10 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { Attachments, downloadAsset, useAttachments } from '@frontify/guideline-blocks-shared';
+import { Attachments, useAttachments } from '@frontify/guideline-blocks-shared';
 import { BlockAttachmentsProps } from '../types';
 import { ATTACHMENTS_SETTING_ID } from '../settings';
 
-export const BlockAttachments = ({ assetToDownload, appBridge }: BlockAttachmentsProps) => {
+export const BlockAttachments = ({ appBridge }: BlockAttachmentsProps) => {
     const {
         sortedAttachments: attachments,
         onAddAttachments,
@@ -14,18 +14,15 @@ export const BlockAttachments = ({ assetToDownload, appBridge }: BlockAttachment
     } = useAttachments(appBridge, ATTACHMENTS_SETTING_ID, ATTACHMENTS_SETTING_ID);
 
     return (
-        <div>
-            <Attachments
-                onUploadAttachments={onAddAttachments}
-                onAttachmentDelete={onAttachmentDelete}
-                onAttachmentReplaceWithBrowse={onAttachmentReplace}
-                onAttachmentReplaceWithUpload={onAttachmentReplace}
-                onAttachmentsSorted={onAttachmentsSorted}
-                onBrowseAttachments={onAddAttachments}
-                attachmentItems={attachments}
-                appBridge={appBridge}
-                onDownload={() => downloadAsset(assetToDownload)}
-            />
-        </div>
+        <Attachments
+            onUploadAttachments={onAddAttachments}
+            onAttachmentDelete={onAttachmentDelete}
+            onAttachmentReplaceWithBrowse={onAttachmentReplace}
+            onAttachmentReplaceWithUpload={onAttachmentReplace}
+            onAttachmentsSorted={onAttachmentsSorted}
+            onBrowseAttachments={onAddAttachments}
+            attachmentItems={attachments}
+            appBridge={appBridge}
+        />
     );
 };

--- a/packages/audio-block/src/types.ts
+++ b/packages/audio-block/src/types.ts
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { AppBridgeBlock, Asset } from '@frontify/app-bridge';
+import { AppBridgeBlock } from '@frontify/app-bridge';
 
 export enum TextPosition {
     Below = 'Below',
@@ -14,7 +14,6 @@ export type BlockSettings = {
 };
 
 export type BlockAttachmentsProps = {
-    assetToDownload: Asset;
     appBridge: AppBridgeBlock;
 };
 

--- a/packages/image-block/src/ImageBlock.spec.ct.tsx
+++ b/packages/image-block/src/ImageBlock.spec.ct.tsx
@@ -17,7 +17,7 @@ const ImageBlockSelector = '[data-test-id="image-block"]';
 const ImageBlockImageWrapperSelector = '[data-test-id="image-block-img-wrapper"]';
 const ImageBlockImageSelector = '[data-test-id="image-block-img"]';
 const PlaceholderSelector = '[data-test-id="block-inject-button"]';
-const DownloadSelector = '[data-test-id="attachments-download"]';
+const DownloadSelector = '[data-test-id="download-button"]';
 const AttachmentsSelector = '[data-test-id="attachments-flyout-button"]';
 
 describe('Image Block', () => {

--- a/packages/image-block/src/components/Image.tsx
+++ b/packages/image-block/src/components/Image.tsx
@@ -11,6 +11,7 @@ import {
 } from '../types';
 import {
     Attachments,
+    DownloadButton,
     downloadAsset,
     joinClassNames,
     toRgbaString,
@@ -96,17 +97,19 @@ export const ImageComponent = ({ image, appBridge, blockSettings }: ImageProps) 
         >
             <div className="tw-relative">
                 <div className="tw-absolute tw-top-2 tw-right-2">
-                    <Attachments
-                        onUploadAttachments={onAddAttachments}
-                        onAttachmentDelete={onAttachmentDelete}
-                        onAttachmentReplaceWithBrowse={onAttachmentReplace}
-                        onAttachmentReplaceWithUpload={onAttachmentReplace}
-                        onAttachmentsSorted={onAttachmentsSorted}
-                        onBrowseAttachments={onAddAttachments}
-                        attachmentItems={attachments}
-                        appBridge={appBridge}
-                        onDownload={() => downloadAsset(image)}
-                    />
+                    <div className="tw-flex tw-gap-2">
+                        <DownloadButton onDownload={() => downloadAsset(image)} />
+                        <Attachments
+                            onUploadAttachments={onAddAttachments}
+                            onAttachmentDelete={onAttachmentDelete}
+                            onAttachmentReplaceWithBrowse={onAttachmentReplace}
+                            onAttachmentReplaceWithUpload={onAttachmentReplace}
+                            onAttachmentsSorted={onAttachmentsSorted}
+                            onBrowseAttachments={onAddAttachments}
+                            attachmentItems={attachments}
+                            appBridge={appBridge}
+                        />
+                    </div>
                 </div>
                 <img
                     data-test-id="image-block-img"

--- a/packages/shared/src/components/Attachments/Attachments.spec.ct.tsx
+++ b/packages/shared/src/components/Attachments/Attachments.spec.ct.tsx
@@ -6,8 +6,6 @@ import { mount } from 'cypress/react';
 import { Attachments as AttachmentsComponent } from './Attachments';
 import { AttachmentsProps } from './types';
 
-const AttachmentsSelector = '[data-test-id="attachments"]';
-const DownloadButtonSelector = '[data-test-id="attachments-download"]';
 const FlyoutButtonSelector = '[data-test-id="attachments-flyout-button"]';
 const AssetInputSelector = '[data-test-id="asset-input-placeholder"]';
 const ActionBarSelector = '[data-test-id="attachments-actionbar"]';
@@ -21,7 +19,6 @@ const Attachments = ({
     onAttachmentReplaceWithUpload = cy.stub(),
     onAttachmentsSorted = cy.stub(),
     onBrowseAttachments = cy.stub(),
-    onDownload = cy.stub(),
     onUploadAttachments = cy.stub(),
 }: Partial<AttachmentsProps>) => {
     return (
@@ -33,25 +30,12 @@ const Attachments = ({
             onAttachmentReplaceWithUpload={onAttachmentReplaceWithUpload}
             onAttachmentsSorted={onAttachmentsSorted}
             onBrowseAttachments={onBrowseAttachments}
-            onDownload={onDownload}
             onUploadAttachments={onUploadAttachments}
         />
     );
 };
 
 describe('Attachments', () => {
-    it('renders component', () => {
-        mount(<Attachments />);
-        cy.get(AttachmentsSelector).should('exist');
-    });
-
-    it('renders download button and calls onDownload on click', () => {
-        const onDownloadStub = cy.stub().as('downloadStub');
-        mount(<Attachments onDownload={onDownloadStub} />);
-        cy.get(DownloadButtonSelector).should('exist').click();
-        cy.get('@downloadStub').should('have.been.called');
-    });
-
     it('renders attachments flyout if it is in edit mode', () => {
         mount(<Attachments appBridge={getAppBridgeBlockStub({ editorState: true })} />);
         cy.get(FlyoutButtonSelector).should('exist');

--- a/packages/shared/src/components/Attachments/Attachments.tsx
+++ b/packages/shared/src/components/Attachments/Attachments.tsx
@@ -18,7 +18,6 @@ import {
     AssetInputSize,
     Flyout,
     FlyoutPlacement,
-    IconArrowCircleDown16,
     IconCaretDown12,
     IconPaperclip16,
 } from '@frontify/fondue';
@@ -35,7 +34,6 @@ export const Attachments = ({
     onBrowseAttachments,
     onUploadAttachments,
     onAttachmentsSorted,
-    onDownload,
     appBridge,
 }: AttachmentsProps) => {
     const [internalItems, setInternalItems] = useState<Asset[] | undefined>(attachmentItems || []);
@@ -121,17 +119,7 @@ export const Attachments = ({
     };
 
     return (
-        <div className="tw-flex tw-gap-2" data-test-id="attachments">
-            {onDownload && (
-                <button
-                    data-test-id="attachments-download"
-                    onClick={onDownload}
-                    className="tw-rounded-full tw-bg-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-inverse-hover active:tw-bg-box-neutral-strong-inverse-pressed  tw-text-box-neutral-strong tw-outline tw-outline-1 tw-outline-offset-[1px] tw-p-[6px] tw-outline-line"
-                >
-                    <IconArrowCircleDown16 />
-                </button>
-            )}
-
+        <>
             {(isEditing || (internalItems?.length ?? 0) > 0) && (
                 <div className="-tw-mx-3" data-test-id="attachments-flyout-button">
                     <Flyout
@@ -216,6 +204,6 @@ export const Attachments = ({
                     </Flyout>
                 </div>
             )}
-        </div>
+        </>
     );
 };

--- a/packages/shared/src/components/Attachments/types.ts
+++ b/packages/shared/src/components/Attachments/types.ts
@@ -3,7 +3,7 @@
 import { AppBridgeBlock, Asset } from '@frontify/app-bridge';
 import { DesignTokenName, TokenValues } from '../../hooks';
 
-export interface AttachmentsProps {
+export type AttachmentsProps = {
     attachmentItems: Asset[] | undefined;
     appBridge: AppBridgeBlock;
     onAttachmentReplaceWithUpload: (attachmentToReplace: Asset, newAsset: Asset) => void;
@@ -12,8 +12,7 @@ export interface AttachmentsProps {
     onUploadAttachments: (uploadedAttachments: Asset[]) => void;
     onBrowseAttachments: (browserAttachments: Asset[]) => void;
     onAttachmentsSorted: (sortedAttachments: Asset[]) => void;
-    onDownload: () => void;
-}
+};
 
 export type AttachmentItemProps = SortableAttachmentItemProps & {
     isDragging?: boolean;

--- a/packages/shared/src/components/DownloadButton/DownloadButton.spec.ct.tsx
+++ b/packages/shared/src/components/DownloadButton/DownloadButton.spec.ct.tsx
@@ -1,0 +1,21 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import React from 'react';
+import { mount } from 'cypress/react';
+import { DownloadButton } from './';
+
+const DownloadButtonSelector = '[data-test-id="download-button"]';
+
+describe('DownloadButton', () => {
+    it('renders component', () => {
+        mount(<DownloadButton onDownload={cy.stub()} />);
+        cy.get(DownloadButtonSelector).should('exist');
+    });
+
+    it('calls onDownload on click', () => {
+        const onDownloadStub = cy.stub().as('downloadStub');
+        mount(<DownloadButton onDownload={onDownloadStub} />);
+        cy.get(DownloadButtonSelector).click();
+        cy.get('@downloadStub').should('have.been.called');
+    });
+});

--- a/packages/shared/src/components/DownloadButton/DownloadButton.tsx
+++ b/packages/shared/src/components/DownloadButton/DownloadButton.tsx
@@ -6,14 +6,12 @@ import { IconArrowCircleDown16 } from '@frontify/fondue';
 
 export const DownloadButton = ({ onDownload }: DownloadButtonProps) => {
     return (
-        <>
-            <button
-                data-test-id="download-button"
-                onClick={onDownload}
-                className="tw-rounded-full tw-mb-auto tw-bg-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-inverse-hover active:tw-bg-box-neutral-strong-inverse-pressed  tw-text-box-neutral-strong tw-outline tw-outline-1 tw-outline-offset-[1px] tw-p-1.5 tw-outline-line"
-            >
-                <IconArrowCircleDown16 />
-            </button>
-        </>
+        <button
+            data-test-id="download-button"
+            onClick={onDownload}
+            className="tw-rounded-full tw-mb-auto tw-bg-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-inverse-hover active:tw-bg-box-neutral-strong-inverse-pressed  tw-text-box-neutral-strong tw-outline tw-outline-1 tw-outline-offset-[1px] tw-p-1.5 tw-outline-line"
+        >
+            <IconArrowCircleDown16 />
+        </button>
     );
 };

--- a/packages/shared/src/components/DownloadButton/DownloadButton.tsx
+++ b/packages/shared/src/components/DownloadButton/DownloadButton.tsx
@@ -1,0 +1,19 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import React from 'react';
+import { DownloadButtonProps } from './types';
+import { IconArrowCircleDown16 } from '@frontify/fondue';
+
+export const DownloadButton = ({ onDownload }: DownloadButtonProps) => {
+    return (
+        <>
+            <button
+                data-test-id="download-button"
+                onClick={onDownload}
+                className="tw-rounded-full tw-mb-auto tw-bg-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-inverse-hover active:tw-bg-box-neutral-strong-inverse-pressed  tw-text-box-neutral-strong tw-outline tw-outline-1 tw-outline-offset-[1px] tw-p-1.5 tw-outline-line"
+            >
+                <IconArrowCircleDown16 />
+            </button>
+        </>
+    );
+};

--- a/packages/shared/src/components/DownloadButton/index.ts
+++ b/packages/shared/src/components/DownloadButton/index.ts
@@ -1,0 +1,3 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export * from './DownloadButton';

--- a/packages/shared/src/components/DownloadButton/types.ts
+++ b/packages/shared/src/components/DownloadButton/types.ts
@@ -1,0 +1,5 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+export type DownloadButtonProps = {
+    onDownload: () => void;
+};

--- a/packages/shared/src/components/index.ts
+++ b/packages/shared/src/components/index.ts
@@ -3,3 +3,4 @@
 export * from './BlockInjectButton';
 export * from './BlockItemWrapper';
 export * from './Attachments';
+export * from './DownloadButton';


### PR DESCRIPTION
Splitting the downloadButton out of the attachments components so the attachments component has a single purpose.

There will be a follow-up PR with adjusting the Props of the attachment