### PR TITLE
Feat(shared)/adjust attachment props

### DIFF
--- a/packages/audio-block/src/components/BlockAttachments.tsx
+++ b/packages/audio-block/src/components/BlockAttachments.tsx
@@ -15,13 +15,13 @@ export const BlockAttachments = ({ appBridge }: BlockAttachmentsProps) => {
 
     return (
         <Attachments
-            onUploadAttachments={onAddAttachments}
-            onAttachmentDelete={onAttachmentDelete}
-            onAttachmentReplaceWithBrowse={onAttachmentReplace}
-            onAttachmentReplaceWithUpload={onAttachmentReplace}
-            onAttachmentsSorted={onAttachmentsSorted}
-            onBrowseAttachments={onAddAttachments}
-            attachmentItems={attachments}
+            onUpload={onAddAttachments}
+            onDelete={onAttachmentDelete}
+            onReplaceWithBrowse={onAttachmentReplace}
+            onReplaceWithUpload={onAttachmentReplace}
+            onSorted={onAttachmentsSorted}
+            onBrowse={onAddAttachments}
+            items={attachments}
             appBridge={appBridge}
         />
     );

--- a/packages/image-block/src/components/Image.tsx
+++ b/packages/image-block/src/components/Image.tsx
@@ -100,13 +100,13 @@ export const ImageComponent = ({ image, appBridge, blockSettings }: ImageProps) 
                     <div className="tw-flex tw-gap-2">
                         <DownloadButton onDownload={() => downloadAsset(image)} />
                         <Attachments
-                            onUploadAttachments={onAddAttachments}
-                            onAttachmentDelete={onAttachmentDelete}
-                            onAttachmentReplaceWithBrowse={onAttachmentReplace}
-                            onAttachmentReplaceWithUpload={onAttachmentReplace}
-                            onAttachmentsSorted={onAttachmentsSorted}
-                            onBrowseAttachments={onAddAttachments}
-                            attachmentItems={attachments}
+                            onUpload={onAddAttachments}
+                            onDelete={onAttachmentDelete}
+                            onReplaceWithBrowse={onAttachmentReplace}
+                            onReplaceWithUpload={onAttachmentReplace}
+                            onSorted={onAttachmentsSorted}
+                            onBrowse={onAddAttachments}
+                            items={attachments}
                             appBridge={appBridge}
                         />
                     </div>

--- a/packages/shared/src/components/Attachments/AttachmentItem.tsx
+++ b/packages/shared/src/components/Attachments/AttachmentItem.tsx
@@ -70,8 +70,8 @@ export const AttachmentItem = forwardRef<HTMLDivElement, AttachmentItemProps>(
             // eslint-disable-next-line react-hooks/exhaustive-deps
         }, [doneAll, uploadResults]);
 
-        const downloadAttachment = (attachmentUrl: string, filename: string) => {
-            fetch(attachmentUrl).then((response) => {
+        const download = (url: string, filename: string) => {
+            fetch(url).then((response) => {
                 response.blob().then((blob) => {
                     const url = URL.createObjectURL(blob);
                     const a = document.createElement('a');
@@ -85,7 +85,7 @@ export const AttachmentItem = forwardRef<HTMLDivElement, AttachmentItemProps>(
         return (
             <div
                 data-test-id="attachments-item"
-                onClick={() => downloadAttachment(item.genericUrl, item.fileName)}
+                onClick={() => download(item.genericUrl, item.fileName)}
                 ref={ref}
                 style={{
                     ...transformStyle,

--- a/packages/shared/src/components/Attachments/AttachmentItem.tsx
+++ b/packages/shared/src/components/Attachments/AttachmentItem.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
 import { Asset, useAssetUpload, useFileInput } from '@frontify/app-bridge';
 import { useSortable } from '@dnd-kit/sortable';
 import {
@@ -21,7 +21,6 @@ import {
     MenuItemContentSize,
     MenuItemStyle,
 } from '@frontify/fondue';
-import { forwardRef, useEffect, useState } from 'react';
 import { AttachmentItemProps, SortableAttachmentItemProps } from './types';
 import { joinClassNames } from '../../utilities';
 
@@ -47,9 +46,9 @@ export const AttachmentItem = forwardRef<HTMLDivElement, AttachmentItemProps>(
             transformStyle,
             isDragging,
             isOverlay,
-            onAttachmentDelete,
-            onAttachmentReplaceWithBrowse,
-            onAttachmentReplaceWithUpload,
+            onDelete,
+            onReplaceWithBrowse,
+            onReplaceWithUpload,
         },
         ref
     ) => {
@@ -66,7 +65,7 @@ export const AttachmentItem = forwardRef<HTMLDivElement, AttachmentItemProps>(
 
         useEffect(() => {
             if (doneAll) {
-                onAttachmentReplaceWithUpload(uploadResults[0]);
+                onReplaceWithUpload(uploadResults[0]);
             }
             // eslint-disable-next-line react-hooks/exhaustive-deps
         }, [doneAll, uploadResults]);
@@ -161,7 +160,7 @@ export const AttachmentItem = forwardRef<HTMLDivElement, AttachmentItemProps>(
                                                     size: MenuItemContentSize.XSmall,
                                                     title: 'Replace with asset',
                                                     onClick: () => {
-                                                        onAttachmentReplaceWithBrowse();
+                                                        onReplaceWithBrowse();
                                                         setSelectedAsset(undefined);
                                                     },
                                                     initialValue: true,
@@ -182,7 +181,7 @@ export const AttachmentItem = forwardRef<HTMLDivElement, AttachmentItemProps>(
                                                     title: 'Delete',
                                                     style: MenuItemStyle.Danger,
                                                     onClick: () => {
-                                                        onAttachmentDelete();
+                                                        onDelete();
                                                         setSelectedAsset(undefined);
                                                     },
 

--- a/packages/shared/src/components/Attachments/Attachments.spec.ct.tsx
+++ b/packages/shared/src/components/Attachments/Attachments.spec.ct.tsx
@@ -13,24 +13,24 @@ const AttachmentItemSelector = '[data-test-id="attachments-item"]';
 
 const Attachments = ({
     appBridge = getAppBridgeBlockStub(),
-    onAttachmentDelete = cy.stub(),
-    attachmentItems,
-    onAttachmentReplaceWithBrowse = cy.stub(),
-    onAttachmentReplaceWithUpload = cy.stub(),
-    onAttachmentsSorted = cy.stub(),
-    onBrowseAttachments = cy.stub(),
-    onUploadAttachments = cy.stub(),
+    onDelete = cy.stub(),
+    items,
+    onReplaceWithBrowse = cy.stub(),
+    onReplaceWithUpload = cy.stub(),
+    onSorted = cy.stub(),
+    onBrowse = cy.stub(),
+    onUpload = cy.stub(),
 }: Partial<AttachmentsProps>) => {
     return (
         <AttachmentsComponent
             appBridge={appBridge}
-            onAttachmentDelete={onAttachmentDelete}
-            attachmentItems={attachmentItems}
-            onAttachmentReplaceWithBrowse={onAttachmentReplaceWithBrowse}
-            onAttachmentReplaceWithUpload={onAttachmentReplaceWithUpload}
-            onAttachmentsSorted={onAttachmentsSorted}
-            onBrowseAttachments={onBrowseAttachments}
-            onUploadAttachments={onUploadAttachments}
+            onDelete={onDelete}
+            items={items}
+            onReplaceWithBrowse={onReplaceWithBrowse}
+            onReplaceWithUpload={onReplaceWithUpload}
+            onSorted={onSorted}
+            onBrowse={onBrowse}
+            onUpload={onUpload}
         />
     );
 };
@@ -42,51 +42,41 @@ describe('Attachments', () => {
     });
 
     it('renders attachments flyout if it has attachments', () => {
-        mount(<Attachments attachmentItems={[AssetDummy.with(1)]} />);
+        mount(<Attachments items={[AssetDummy.with(1)]} />);
         cy.get(FlyoutButtonSelector).should('exist');
     });
 
     it('does not render attachments flyout if there are no attachments', () => {
-        mount(<Attachments attachmentItems={[]} />);
+        mount(<Attachments items={[]} />);
         cy.get(FlyoutButtonSelector).should('not.exist');
     });
 
     it('renders asset input if in edit mode', () => {
-        mount(
-            <Attachments
-                appBridge={getAppBridgeBlockStub({ editorState: true })}
-                attachmentItems={[AssetDummy.with(1)]}
-            />
-        );
+        mount(<Attachments appBridge={getAppBridgeBlockStub({ editorState: true })} items={[AssetDummy.with(1)]} />);
         cy.get(FlyoutButtonSelector).click();
         cy.get(AssetInputSelector).should('exist');
     });
 
     it('does not render asset input if in view mode', () => {
-        mount(<Attachments attachmentItems={[AssetDummy.with(1)]} />);
+        mount(<Attachments items={[AssetDummy.with(1)]} />);
         cy.get(FlyoutButtonSelector).click();
         cy.get(AssetInputSelector).should('not.exist');
     });
 
     it('renders asset action buttons if in edit mode', () => {
-        mount(
-            <Attachments
-                appBridge={getAppBridgeBlockStub({ editorState: true })}
-                attachmentItems={[AssetDummy.with(1)]}
-            />
-        );
+        mount(<Attachments appBridge={getAppBridgeBlockStub({ editorState: true })} items={[AssetDummy.with(1)]} />);
         cy.get(FlyoutButtonSelector).click();
         cy.get(ActionBarSelector).should('exist');
     });
 
     it('does not render asset action buttons if in view mode', () => {
-        mount(<Attachments attachmentItems={[AssetDummy.with(1)]} />);
+        mount(<Attachments items={[AssetDummy.with(1)]} />);
         cy.get(FlyoutButtonSelector).click();
         cy.get(ActionBarSelector).should('not.exist');
     });
 
     it('renders an attachment item for each asset', () => {
-        mount(<Attachments attachmentItems={[AssetDummy.with(1), AssetDummy.with(2), AssetDummy.with(3)]} />);
+        mount(<Attachments items={[AssetDummy.with(1), AssetDummy.with(2), AssetDummy.with(3)]} />);
         cy.get(FlyoutButtonSelector).click();
         cy.get(AttachmentItemSelector).should('have.length', 3);
     });

--- a/packages/shared/src/components/Attachments/Attachments.tsx
+++ b/packages/shared/src/components/Attachments/Attachments.tsx
@@ -83,11 +83,11 @@ export const Attachments = ({
         );
     };
 
-    const onReplaceAttachmentWithBrowse = (attachmentToReplace: Asset) => {
+    const onReplaceItemWithBrowse = (toReplace: Asset) => {
         setIsFlyoutOpen(false);
         appBridge.openAssetChooser(
             (result: Asset[]) => {
-                onReplaceWithBrowse(attachmentToReplace, result[0]);
+                onReplaceWithBrowse(toReplace, result[0]);
                 appBridge.closeAssetChooser();
             },
             {
@@ -96,8 +96,8 @@ export const Attachments = ({
         );
     };
 
-    const onReplaceAttachmentWithUpload = (attachmentToReplace: Asset, uploadedAsset: Asset) => {
-        onReplaceWithUpload(attachmentToReplace, uploadedAsset);
+    const onReplaceItemWithUpload = (toReplace: Asset, uploadedAsset: Asset) => {
+        onReplaceWithUpload(toReplace, uploadedAsset);
     };
 
     const handleDragStart = (event: DragStartEvent) => {
@@ -145,18 +145,16 @@ export const Attachments = ({
                                 >
                                     <SortableContext items={internalItems || []} strategy={rectSortingStrategy}>
                                         <div className="tw-border-b tw-border-b-line">
-                                            {(internalItems || []).map((attachmentItem) => (
+                                            {(internalItems || []).map((item) => (
                                                 <SortableAttachmentItem
                                                     isEditing={isEditing}
                                                     designTokens={designTokens}
-                                                    key={attachmentItem.id}
-                                                    item={attachmentItem}
-                                                    onDelete={() => onDelete(attachmentItem)}
-                                                    onReplaceWithBrowse={() =>
-                                                        onReplaceAttachmentWithBrowse(attachmentItem)
-                                                    }
+                                                    key={item.id}
+                                                    item={item}
+                                                    onDelete={() => onDelete(item)}
+                                                    onReplaceWithBrowse={() => onReplaceItemWithBrowse(item)}
                                                     onReplaceWithUpload={(uploadedAsset: Asset) =>
-                                                        onReplaceAttachmentWithUpload(attachmentItem, uploadedAsset)
+                                                        onReplaceItemWithUpload(item, uploadedAsset)
                                                     }
                                                 />
                                             ))}
@@ -172,9 +170,9 @@ export const Attachments = ({
                                                 item={draggedItem}
                                                 isDragging={true}
                                                 onDelete={() => onDelete(draggedItem)}
-                                                onReplaceWithBrowse={() => onReplaceAttachmentWithBrowse(draggedItem)}
+                                                onReplaceWithBrowse={() => onReplaceItemWithBrowse(draggedItem)}
                                                 onReplaceWithUpload={(uploadedAsset: Asset) =>
-                                                    onReplaceAttachmentWithUpload(draggedItem, uploadedAsset)
+                                                    onReplaceItemWithUpload(draggedItem, uploadedAsset)
                                                 }
                                             />
                                         ) : null}

--- a/packages/shared/src/components/Attachments/Attachments.tsx
+++ b/packages/shared/src/components/Attachments/Attachments.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
     DndContext,
     DragEndEvent,
@@ -21,22 +21,21 @@ import {
     IconCaretDown12,
     IconPaperclip16,
 } from '@frontify/fondue';
-import { useEffect, useState } from 'react';
 import { useGuidelineDesignTokens } from '../../hooks';
 import { AttachmentItem, SortableAttachmentItem } from './AttachmentItem';
 import { AttachmentsProps } from './types';
 
 export const Attachments = ({
-    attachmentItems,
-    onAttachmentDelete,
-    onAttachmentReplaceWithBrowse,
-    onAttachmentReplaceWithUpload,
-    onBrowseAttachments,
-    onUploadAttachments,
-    onAttachmentsSorted,
+    items,
+    onDelete,
+    onReplaceWithBrowse,
+    onReplaceWithUpload,
+    onBrowse,
+    onUpload,
+    onSorted,
     appBridge,
 }: AttachmentsProps) => {
-    const [internalItems, setInternalItems] = useState<Asset[] | undefined>(attachmentItems || []);
+    const [internalItems, setInternalItems] = useState<Asset[] | undefined>(items || []);
     const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
     const sensors = useSensors(useSensor(PointerSensor));
     const [draggedAssetId, setDraggedAssetId] = useState<number | undefined>(undefined);
@@ -45,15 +44,15 @@ export const Attachments = ({
     const [selectedFiles, setSelectedFiles] = useState<FileList | null>(null);
     const isEditing = useEditorState(appBridge);
 
-    const draggedAttachment = internalItems?.find((item) => item.id === draggedAssetId);
+    const draggedItem = internalItems?.find((item) => item.id === draggedAssetId);
 
     const [uploadFile, { results: uploadResults, doneAll }] = useAssetUpload({
         onUploadProgress: () => !isUploadLoading && setIsUploadLoading(true),
     });
 
     useEffect(() => {
-        setInternalItems(attachmentItems);
-    }, [attachmentItems]);
+        setInternalItems(items);
+    }, [items]);
 
     useEffect(() => {
         if (selectedFiles) {
@@ -65,7 +64,7 @@ export const Attachments = ({
 
     useEffect(() => {
         if (doneAll) {
-            onUploadAttachments(uploadResults);
+            onUpload(uploadResults);
             setIsUploadLoading(false);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -75,7 +74,7 @@ export const Attachments = ({
         setIsFlyoutOpen(false);
         appBridge.openAssetChooser(
             (result: Asset[]) => {
-                onBrowseAttachments(result);
+                onBrowse(result);
                 appBridge.closeAssetChooser();
             },
             {
@@ -88,7 +87,7 @@ export const Attachments = ({
         setIsFlyoutOpen(false);
         appBridge.openAssetChooser(
             (result: Asset[]) => {
-                onAttachmentReplaceWithBrowse(attachmentToReplace, result[0]);
+                onReplaceWithBrowse(attachmentToReplace, result[0]);
                 appBridge.closeAssetChooser();
             },
             {
@@ -98,7 +97,7 @@ export const Attachments = ({
     };
 
     const onReplaceAttachmentWithUpload = (attachmentToReplace: Asset, uploadedAsset: Asset) => {
-        onAttachmentReplaceWithUpload(attachmentToReplace, uploadedAsset);
+        onReplaceWithUpload(attachmentToReplace, uploadedAsset);
     };
 
     const handleDragStart = (event: DragStartEvent) => {
@@ -114,7 +113,7 @@ export const Attachments = ({
             const sortedItems = arrayMove(internalItems, oldIndex, newIndex);
             setInternalItems(sortedItems);
             setDraggedAssetId(undefined);
-            onAttachmentsSorted(sortedItems);
+            onSorted(sortedItems);
         }
     };
 
@@ -131,7 +130,7 @@ export const Attachments = ({
                         trigger={
                             <button className="tw-flex tw-text-[13px] tw-font-body tw-items-center tw-gap-1 tw-rounded-full tw-bg-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-inverse-hover active:tw-bg-box-neutral-strong-inverse-pressed  tw-text-box-neutral-strong tw-outline tw-outline-1 tw-outline-offset-[1px] tw-p-[6px] tw-outline-line">
                                 <IconPaperclip16 />
-                                <div>{(attachmentItems?.length || 0) > 0 ? attachmentItems?.length : 'Add'}</div>
+                                <div>{(items?.length || 0) > 0 ? items?.length : 'Add'}</div>
                                 <IconCaretDown12 />
                             </button>
                         }
@@ -152,11 +151,11 @@ export const Attachments = ({
                                                     designTokens={designTokens}
                                                     key={attachmentItem.id}
                                                     item={attachmentItem}
-                                                    onAttachmentDelete={() => onAttachmentDelete(attachmentItem)}
-                                                    onAttachmentReplaceWithBrowse={() =>
+                                                    onDelete={() => onDelete(attachmentItem)}
+                                                    onReplaceWithBrowse={() =>
                                                         onReplaceAttachmentWithBrowse(attachmentItem)
                                                     }
-                                                    onAttachmentReplaceWithUpload={(uploadedAsset: Asset) =>
+                                                    onReplaceWithUpload={(uploadedAsset: Asset) =>
                                                         onReplaceAttachmentWithUpload(attachmentItem, uploadedAsset)
                                                     }
                                                 />
@@ -164,20 +163,18 @@ export const Attachments = ({
                                         </div>
                                     </SortableContext>
                                     <DragOverlay>
-                                        {draggedAttachment ? (
+                                        {draggedItem ? (
                                             <AttachmentItem
                                                 isOverlay={true}
                                                 isEditing={isEditing}
                                                 key={draggedAssetId}
                                                 designTokens={designTokens}
-                                                item={draggedAttachment}
+                                                item={draggedItem}
                                                 isDragging={true}
-                                                onAttachmentDelete={() => onAttachmentDelete(draggedAttachment)}
-                                                onAttachmentReplaceWithBrowse={() =>
-                                                    onReplaceAttachmentWithBrowse(draggedAttachment)
-                                                }
-                                                onAttachmentReplaceWithUpload={(uploadedAsset: Asset) =>
-                                                    onReplaceAttachmentWithUpload(draggedAttachment, uploadedAsset)
+                                                onDelete={() => onDelete(draggedItem)}
+                                                onReplaceWithBrowse={() => onReplaceAttachmentWithBrowse(draggedItem)}
+                                                onReplaceWithUpload={(uploadedAsset: Asset) =>
+                                                    onReplaceAttachmentWithUpload(draggedItem, uploadedAsset)
                                                 }
                                             />
                                         ) : null}

--- a/packages/shared/src/components/Attachments/types.ts
+++ b/packages/shared/src/components/Attachments/types.ts
@@ -4,14 +4,14 @@ import { AppBridgeBlock, Asset } from '@frontify/app-bridge';
 import { DesignTokenName, TokenValues } from '../../hooks';
 
 export type AttachmentsProps = {
-    attachmentItems: Asset[] | undefined;
+    items: Asset[] | undefined;
     appBridge: AppBridgeBlock;
-    onAttachmentReplaceWithUpload: (attachmentToReplace: Asset, newAsset: Asset) => void;
-    onAttachmentReplaceWithBrowse: (attachmentToReplace: Asset, newAsset: Asset) => void;
-    onAttachmentDelete: (attachmentToDelete: Asset) => void;
-    onUploadAttachments: (uploadedAttachments: Asset[]) => void;
-    onBrowseAttachments: (browserAttachments: Asset[]) => void;
-    onAttachmentsSorted: (sortedAttachments: Asset[]) => void;
+    onReplaceWithUpload: (attachmentToReplace: Asset, newAsset: Asset) => void;
+    onReplaceWithBrowse: (attachmentToReplace: Asset, newAsset: Asset) => void;
+    onDelete: (attachmentToDelete: Asset) => void;
+    onUpload: (uploadedAttachments: Asset[]) => void;
+    onBrowse: (browserAttachments: Asset[]) => void;
+    onSorted: (sortedAttachments: Asset[]) => void;
 };
 
 export type AttachmentItemProps = SortableAttachmentItemProps & {
@@ -25,7 +25,7 @@ export type SortableAttachmentItemProps = {
     item: Asset;
     isEditing: boolean;
     designTokens: Partial<Record<DesignTokenName, TokenValues>> | null;
-    onAttachmentDelete: () => void;
-    onAttachmentReplaceWithBrowse: () => void;
-    onAttachmentReplaceWithUpload: (uploadedAsset: Asset) => void;
+    onDelete: () => void;
+    onReplaceWithBrowse: () => void;
+    onReplaceWithUpload: (uploadedAsset: Asset) => void;
 };


### PR DESCRIPTION
This is the follow up PR of https://github.com/Frontify/guideline-blocks/pull/501

It removes the term "attachment" from the Props of Attachment because its only purpose is handling attachments.