### PR TITLE
feat(shared): add getBackgroundSettings

### DIFF
--- a/packages/asset-kit-block/src/settings.ts
+++ b/packages/asset-kit-block/src/settings.ts
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { Color, SettingBlock, defineSettings } from '@frontify/guideline-blocks-settings';
-import { getBorderRadiusSettings, getBorderSettings } from '@frontify/guideline-blocks-shared';
+import { Color, defineSettings } from '@frontify/guideline-blocks-settings';
+import { getBackgroundSettings, getBorderRadiusSettings, getBorderSettings } from '@frontify/guideline-blocks-shared';
 
 export const ASSET_SETTINGS_ID = 'images';
 export const BACKGROUND_COLOR_DEFAULT_VALUE: Color = {
@@ -17,21 +17,6 @@ export const BORDER_COLOR_DEFAULT_VALUE: Color = {
     alpha: 1,
 };
 
-const backgroundColor = (id: string, defaultValue = true): SettingBlock => ({
-    id: `hasBackground${id}`,
-    label: 'Background',
-    type: 'switch',
-    defaultValue,
-    on: [
-        {
-            id: `backgroundColor${id}`,
-            defaultValue: defaultValue ? BACKGROUND_COLOR_DEFAULT_VALUE : undefined,
-            type: 'colorInput',
-        },
-    ],
-    off: [],
-});
-
 export const settings = defineSettings({
     style: [
         {
@@ -39,7 +24,7 @@ export const settings = defineSettings({
             type: 'sectionHeading',
             label: 'Block',
             blocks: [
-                backgroundColor('Blocks', false),
+                getBackgroundSettings({ id: 'Blocks' }),
                 getBorderSettings({ id: 'blocks', defaultValue: true, defaultColor: BORDER_COLOR_DEFAULT_VALUE }),
                 getBorderRadiusSettings({ id: 'blocks' }),
             ],
@@ -49,7 +34,7 @@ export const settings = defineSettings({
             type: 'sectionHeading',
             label: 'Thumbnails',
             blocks: [
-                backgroundColor('Thumbnails'),
+                getBackgroundSettings({ id: 'Thumbnails', defaultValue: true }),
                 getBorderSettings({ id: 'thumbnails', defaultValue: true, defaultColor: BORDER_COLOR_DEFAULT_VALUE }),
                 getBorderRadiusSettings({ id: 'thumbnails' }),
             ],

--- a/packages/shared/src/settings/background.spec.ts
+++ b/packages/shared/src/settings/background.spec.ts
@@ -22,7 +22,6 @@ describe('getBackgroundSettings', () => {
                     type: 'colorInput',
                 },
             ],
-            off: [],
         });
     });
 
@@ -44,7 +43,6 @@ describe('getBackgroundSettings', () => {
                     type: 'colorInput',
                 },
             ],
-            off: [],
         });
     });
 
@@ -66,7 +64,6 @@ describe('getBackgroundSettings', () => {
                     type: 'colorInput',
                 },
             ],
-            off: [],
         });
     });
 
@@ -88,7 +85,6 @@ describe('getBackgroundSettings', () => {
                     type: 'colorInput',
                 },
             ],
-            off: [],
         });
     });
 
@@ -116,7 +112,6 @@ describe('getBackgroundSettings', () => {
                     type: 'colorInput',
                 },
             ],
-            off: [],
         });
     });
 });

--- a/packages/shared/src/settings/background.spec.ts
+++ b/packages/shared/src/settings/background.spec.ts
@@ -1,0 +1,122 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { describe, expect, it } from 'vitest';
+import { getBackgroundSettings } from './background';
+
+describe('getBackgroundSettings', () => {
+    it('should return background settings without arguments', () => {
+        expect(getBackgroundSettings()).toEqual({
+            id: 'hasBackground',
+            label: 'Background',
+            type: 'switch',
+            defaultValue: false,
+            on: [
+                {
+                    id: 'backgroundColor',
+                    defaultValue: {
+                        red: 241,
+                        green: 241,
+                        blue: 241,
+                        alpha: 1,
+                    },
+                    type: 'colorInput',
+                },
+            ],
+            off: [],
+        });
+    });
+
+    it('should return background settings with id', () => {
+        expect(getBackgroundSettings({ id: 'Test' })).toEqual({
+            id: 'hasBackgroundTest',
+            label: 'Background',
+            type: 'switch',
+            defaultValue: false,
+            on: [
+                {
+                    id: 'backgroundColorTest',
+                    defaultValue: {
+                        red: 241,
+                        green: 241,
+                        blue: 241,
+                        alpha: 1,
+                    },
+                    type: 'colorInput',
+                },
+            ],
+            off: [],
+        });
+    });
+
+    it('should return background settings with default value', () => {
+        expect(getBackgroundSettings({ defaultValue: true })).toEqual({
+            id: 'hasBackground',
+            label: 'Background',
+            type: 'switch',
+            defaultValue: true,
+            on: [
+                {
+                    id: 'backgroundColor',
+                    defaultValue: {
+                        red: 241,
+                        green: 241,
+                        blue: 241,
+                        alpha: 1,
+                    },
+                    type: 'colorInput',
+                },
+            ],
+            off: [],
+        });
+    });
+
+    it('should return background settings with default color', () => {
+        expect(getBackgroundSettings({ defaultColor: { red: 0, green: 0, blue: 0, alpha: 1 } })).toEqual({
+            id: 'hasBackground',
+            label: 'Background',
+            type: 'switch',
+            defaultValue: false,
+            on: [
+                {
+                    id: 'backgroundColor',
+                    defaultValue: {
+                        red: 0,
+                        green: 0,
+                        blue: 0,
+                        alpha: 1,
+                    },
+                    type: 'colorInput',
+                },
+            ],
+            off: [],
+        });
+    });
+
+    it('should return background settings with id, default value and default color', () => {
+        expect(
+            getBackgroundSettings({
+                id: 'Test',
+                defaultValue: true,
+                defaultColor: { red: 0, green: 0, blue: 0, alpha: 1 },
+            })
+        ).toEqual({
+            id: 'hasBackgroundTest',
+            label: 'Background',
+            type: 'switch',
+            defaultValue: true,
+            on: [
+                {
+                    id: 'backgroundColorTest',
+                    defaultValue: {
+                        red: 0,
+                        green: 0,
+                        blue: 0,
+                        alpha: 1,
+                    },
+                    type: 'colorInput',
+                },
+            ],
+            off: [],
+        });
+    });
+});

--- a/packages/shared/src/settings/background.ts
+++ b/packages/shared/src/settings/background.ts
@@ -1,0 +1,41 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { Color, SettingBlock } from '@frontify/guideline-blocks-settings';
+import { BACKGROUND_COLOR_DEFAULT_VALUE } from './defaultValues';
+
+/**
+ * Returns background settings: background switch, background color
+ *
+ * @param options Options for the settings
+ * @param options.id Custom suffix for the setting ids
+ * @param options.defaultValue Default value for the background switch
+ * @param options.defaultColor Default value for the background color
+ * @returns {SettingBlock} Returns border settings
+ */
+
+type BackgroundSettingsType = {
+    id?: string;
+    defaultValue?: boolean;
+    defaultColor?: Color;
+};
+
+export const getBackgroundSettings = (options?: BackgroundSettingsType): SettingBlock => {
+    const hasId = options?.id ? `hasBackground${options.id}` : 'hasBackground';
+    const colorId = options?.id ? `backgroundColor${options.id}` : 'backgroundColor';
+    const defaultColor = options?.defaultColor || BACKGROUND_COLOR_DEFAULT_VALUE;
+
+    return {
+        id: hasId,
+        label: 'Background',
+        type: 'switch',
+        defaultValue: !!options?.defaultValue,
+        on: [
+            {
+                id: colorId,
+                defaultValue: defaultColor,
+                type: 'colorInput',
+            },
+        ],
+        off: [],
+    };
+};

--- a/packages/shared/src/settings/background.ts
+++ b/packages/shared/src/settings/background.ts
@@ -36,6 +36,5 @@ export const getBackgroundSettings = (options?: BackgroundSettingsType): Setting
                 type: 'colorInput',
             },
         ],
-        off: [],
     };
 };

--- a/packages/shared/src/settings/borderRadius.ts
+++ b/packages/shared/src/settings/borderRadius.ts
@@ -17,6 +17,7 @@ type BorderRadiusSettingsType = {
     id?: string;
     dependentSettingId?: string;
     radiusStyleMap?: Record<Radius, string>;
+    defaultRadius?: Radius;
 };
 
 export const getBorderRadiusSlider = (id: string, defaultValue: Radius = Radius.None): SettingBlock => ({
@@ -47,6 +48,7 @@ export const getBorderRadiusSettings = (options?: BorderRadiusSettingsType): Set
     const hasId = options?.id ? `hasRadius_${options.id}` : 'hasRadius';
     const valueId = options?.id ? `radiusValue_${options.id}` : 'radiusValue';
     const choiceId = options?.id ? `radiusChoice_${options.id}` : 'radiusChoice';
+    const defaultValue = options?.defaultRadius || Radius.None;
 
     return {
         id: hasId,
@@ -66,6 +68,6 @@ export const getBorderRadiusSettings = (options?: BorderRadiusSettingsType): Set
                 onChange: (bundle) => appendUnit(bundle, valueId),
             },
         ],
-        off: [getBorderRadiusSlider(choiceId)],
+        off: [getBorderRadiusSlider(choiceId, defaultValue)],
     };
 };

--- a/packages/shared/src/settings/defaultValues.ts
+++ b/packages/shared/src/settings/defaultValues.ts
@@ -1,5 +1,12 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+export const BACKGROUND_COLOR_DEFAULT_VALUE = {
+    red: 241,
+    green: 241,
+    blue: 241,
+    alpha: 1,
+};
+
 export const BORDER_COLOR_DEFAULT_VALUE = {
     red: 234,
     green: 235,

--- a/packages/shared/src/settings/index.ts
+++ b/packages/shared/src/settings/index.ts
@@ -1,5 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+export * from './background';
 export * from './border';
 export * from './borderRadius';
 export * from './borderRadiusExtended';


### PR DESCRIPTION
added `getBackgroundSettings` and used it within AssetKitBlock, and its also needed for the AnimationCurveBlock

Also extended the `getBorderRadiusSlider` so you can define a defaultRadius 