### PR TITLE
fix(DoDontItem): margin top breaks the title

### DIFF
--- a/packages/dos-donts-block/src/DoDontItem.tsx
+++ b/packages/dos-donts-block/src/DoDontItem.tsx
@@ -260,7 +260,15 @@ export const DoDontItem = React.forwardRef<HTMLDivElement, DoDontItemProps>(
                             </div>
                         )}
                         <div className="tw-w-full tw-flex tw-items-center">
-                            <h3 style={{ marginBottom: 0, width: '100%', lineHeight: 1, display: 'inline-flex' }}>
+                            <h3
+                                style={{
+                                    marginBottom: 0,
+                                    marginTop: 0,
+                                    width: '100%',
+                                    lineHeight: 1,
+                                    display: 'inline-flex',
+                                }}
+                            >
                                 <textarea
                                     rows={1}
                                     ref={titleRef}

--- a/packages/dos-donts-block/src/DoDontItem.tsx
+++ b/packages/dos-donts-block/src/DoDontItem.tsx
@@ -270,6 +270,7 @@ export const DoDontItem = React.forwardRef<HTMLDivElement, DoDontItemProps>(
                                         {
                                             ...designTokens?.heading3,
                                             marginBottom: 0,
+                                            marginTop: 0,
                                             color: headingColor,
                                             '--placeholder-color': headingColor,
                                         } as CSSProperties

--- a/packages/dos-donts-block/src/settings.ts
+++ b/packages/dos-donts-block/src/settings.ts
@@ -159,7 +159,7 @@ export const settings = defineSettings({
                     id: 'keepSideBySide',
                     label: 'Always show side by side',
                     type: 'switch',
-                    show: (bundle) => bundle.getBlock('columns')?.value === '2',
+                    show: (bundle) => bundle.getBlock('columns')?.value?.toString() === '2',
                     defaultValue: true,
                 },
                 {


### PR DESCRIPTION
-Checkbox in settings sidebar was not visible by default
-If H3 had margin top it broke the layout