### PR TITLE
fix(ImageBlock): fix various issues

### DIFF
--- a/packages/image-block/src/components/Image.tsx
+++ b/packages/image-block/src/components/Image.tsx
@@ -37,7 +37,7 @@ export const ImageComponent = ({ image, blockSettings, isEditing }: ImageProps) 
                     className="tw-w-full"
                     href={link.link.link}
                     target={link.openInNewTab ? '_blank' : undefined}
-                    rel="noreferrer"
+                    rel={link.openInNewTab ? 'noopener noreferrer' : 'noreferrer'}
                 >
                     <img
                         data-test-id="image-block-img"

--- a/packages/image-block/src/components/Image.tsx
+++ b/packages/image-block/src/components/Image.tsx
@@ -27,7 +27,7 @@ type ImageProps = {
     appBridge: AppBridgeBlock;
 };
 
-export const Image = ({ image, appBridge, blockSettings, isEditing }: ImageProps) => {
+export const ImageComponent = ({ image, blockSettings, isEditing }: ImageProps) => {
     const link = blockSettings.hasLink ? blockSettings.linkObject : undefined;
 
     return (
@@ -39,26 +39,34 @@ export const Image = ({ image, appBridge, blockSettings, isEditing }: ImageProps
                     target={link.openInNewTab ? '_blank' : undefined}
                     rel="noreferrer"
                 >
-                    <ImageComponent
-                        appBridge={appBridge}
-                        blockSettings={blockSettings}
-                        isEditing={isEditing}
-                        image={image}
+                    <img
+                        data-test-id="image-block-img"
+                        className="tw-flex"
+                        loading="lazy"
+                        src={image.genericUrl.replace('{width}', `${800 * window.devicePixelRatio}`)}
+                        alt={image.fileName}
+                        style={{
+                            width: image.width,
+                        }}
                     />
                 </a>
             ) : (
-                <ImageComponent
-                    appBridge={appBridge}
-                    blockSettings={blockSettings}
-                    isEditing={isEditing}
-                    image={image}
+                <img
+                    data-test-id="image-block-img"
+                    className="tw-flex"
+                    loading="lazy"
+                    src={image.genericUrl.replace('{width}', `${800 * window.devicePixelRatio}`)}
+                    alt={image.fileName}
+                    style={{
+                        width: image.width,
+                    }}
                 />
             )}
         </>
     );
 };
 
-export const ImageComponent = ({ image, appBridge, blockSettings }: ImageProps) => {
+export const Image = ({ image, appBridge, blockSettings, isEditing }: ImageProps) => {
     const { attachments, onAddAttachments, onAttachmentDelete, onAttachmentReplace, onAttachmentsSorted } =
         useAttachments(appBridge, ATTACHMENTS_ASSET_ID);
 
@@ -106,15 +114,11 @@ export const ImageComponent = ({ image, appBridge, blockSettings }: ImageProps) 
                         />
                     </div>
                 </div>
-                <img
-                    data-test-id="image-block-img"
-                    className="tw-flex"
-                    loading="lazy"
-                    src={image.genericUrl.replace('{width}', `${800 * window.devicePixelRatio}`)}
-                    alt={image.fileName}
-                    style={{
-                        width: image.width,
-                    }}
+                <ImageComponent
+                    appBridge={appBridge}
+                    blockSettings={blockSettings}
+                    image={image}
+                    isEditing={isEditing}
                 />
             </div>
         </div>

--- a/packages/shared/src/components/Attachments/Attachments.tsx
+++ b/packages/shared/src/components/Attachments/Attachments.tsx
@@ -132,6 +132,7 @@ export const Attachments = ({
                     position={TooltipPosition.Top}
                     content="Attachments"
                     disabled={isFlyoutOpen}
+                    enterDelay={500}
                     triggerElement={
                         <div className="-tw-mx-3" data-test-id="attachments-flyout-button">
                             <Flyout

--- a/packages/shared/src/components/DownloadButton/DownloadButton.tsx
+++ b/packages/shared/src/components/DownloadButton/DownloadButton.tsx
@@ -20,6 +20,7 @@ export const DownloadButton = ({ onDownload }: DownloadButtonProps) => {
                     {...focusProps}
                     className={joinClassNames(['tw-outline-none tw-rounded', isFocused && FOCUS_STYLE])}
                     onClick={onDownload}
+                    onPointerDown={(e) => e.preventDefault()}
                 >
                     <span
                         data-test-id="download-button"

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -1,6 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
+    presets: [require('@frontify/fondue/tailwind')],
+    content: ['src/**/*.{ts,tsx}'],
+    corePlugins: {
+        preflight: false,
+    },
     theme: {
         extend: {
             colors: {


### PR DESCRIPTION
1. `tw-outline-line` was not applied/generated. Added back the tailwind fondue tokens to the shared tailwind config.
2. When link was added to the image and the attachments were clicked the link opened. Prevented it by only wrapping the image itself inside <a> tags.
3. Tooltips were popping up immediately making it really annoying to click the options menu in the top-right. Added some delay.
4. Download button had a huge focus outline when clicked. Looked a bit ugly. Removed it when it is clicked. Still visible by tabbing.