### PR TITLE
fix(gradientBlock): remove dark:tw-bg-black-95

### DIFF
--- a/packages/gradient-block/src/components/ColorFlyout.tsx
+++ b/packages/gradient-block/src/components/ColorFlyout.tsx
@@ -74,7 +74,7 @@ export const ColorFlyout = ({
     return (
         <Flyout
             fixedHeader={
-                <div className="tw-flex tw-justify-between tw-items-center tw-font-bold tw-text-s tw-py-3 tw-px-6 tw-bg-white dark:tw-bg-black-95 tw-border-b tw-border-b-black-10">
+                <div className="tw-flex tw-justify-between tw-items-center tw-font-bold tw-text-s tw-py-3 tw-px-6 tw-bg-white tw-border-b tw-border-b-black-10">
                     <span>Configure Color</span>
                     <span
                         className="hover:tw-bg-box-neutral-hover hover:tw-cursor-pointer tw-rounded-sm tw-p-0.5 tw-text-strong"


### PR DESCRIPTION
Just a small fix for this [bug](https://frontify.slack.com/archives/C02PSJTPA3D/p1683122013998859), as mentioned in the thread this version is already deployed to product.