### PR TITLE
fix(callout): overriding the theme settings variables

### DIFF
--- a/packages/callout-block/src/CalloutBlock.tsx
+++ b/packages/callout-block/src/CalloutBlock.tsx
@@ -75,8 +75,6 @@ export const CalloutBlock: FC<BlockProps> = ({ appBridge }) => {
 
     const onTextChange = (value: string) => value !== blockSettings.textValue && setBlockSettings({ textValue: value });
 
-    //document.documentElement.style.setProperty(`${THEME_PREFIX}heading1-color`, textColor);
-
     return (
         <>
             <style type="text/css">{`

--- a/packages/callout-block/src/CalloutBlock.tsx
+++ b/packages/callout-block/src/CalloutBlock.tsx
@@ -24,8 +24,11 @@ export const CalloutBlock: FC<BlockProps> = ({ appBridge }) => {
     const isEditing = useEditorState(appBridge);
     const { blockAssets } = useBlockAssets(appBridge);
 
+    const containerClass = `callout-block-${appBridge.getBlockId().toString()}`;
+
     const containerDivClassNames = joinClassNames([
         outerWidthMap[blockSettings.width],
+        containerClass,
         blockSettings.width === Width.HugContents && alignmentMap[blockSettings.alignment],
     ]);
 
@@ -72,10 +75,12 @@ export const CalloutBlock: FC<BlockProps> = ({ appBridge }) => {
 
     const onTextChange = (value: string) => value !== blockSettings.textValue && setBlockSettings({ textValue: value });
 
+    //document.documentElement.style.setProperty(`${THEME_PREFIX}heading1-color`, textColor);
+
     return (
-        <div data-test-id="callout-block" className={containerDivClassNames}>
-            <style>{`
-                :root { 
+        <>
+            <style type="text/css">{`
+                .${containerClass} { 
                     ${THEME_PREFIX}heading1-color: ${textColor};
                     ${THEME_PREFIX}heading2-color: ${textColor};
                     ${THEME_PREFIX}heading3-color: ${textColor};
@@ -90,31 +95,37 @@ export const CalloutBlock: FC<BlockProps> = ({ appBridge }) => {
                 }
             `}</style>
             <div
-                data-test-id="callout-wrapper"
-                className={textDivClassNames}
-                style={{
-                    backgroundColor,
-                    ...customPaddingStyle,
-                    ...customCornerRadiusStyle,
-                }}
+                data-test-id="callout-block"
+                className={`${containerDivClassNames}`}
+                style={{ color: `var${THEME_PREFIX}heading1-color` }}
             >
-                {showIcon && (
-                    <CalloutIcon
-                        iconUrl={iconUrl}
-                        isActive={hasRichTextValue(blockSettings.textValue)}
-                        iconType={blockSettings.iconSwitch ? Icon.Custom : blockSettings.iconType}
-                        color={textColor}
+                <div
+                    data-test-id="callout-wrapper"
+                    className={textDivClassNames}
+                    style={{
+                        backgroundColor,
+                        ...customPaddingStyle,
+                        ...customCornerRadiusStyle,
+                    }}
+                >
+                    {showIcon && (
+                        <CalloutIcon
+                            iconUrl={iconUrl}
+                            isActive={hasRichTextValue(blockSettings.textValue)}
+                            iconType={blockSettings.iconSwitch ? Icon.Custom : blockSettings.iconType}
+                            color={textColor}
+                        />
+                    )}
+                    <RichTextEditor
+                        id={appBridge.getBlockId().toString()}
+                        isEditing={isEditing}
+                        onBlur={onTextChange}
+                        placeholder="Type your text here"
+                        value={blockSettings.textValue}
+                        plugins={getDefaultPluginsWithLinkChooser(appBridge)}
                     />
-                )}
-                <RichTextEditor
-                    id={appBridge.getBlockId().toString()}
-                    isEditing={isEditing}
-                    onBlur={onTextChange}
-                    placeholder="Type your text here"
-                    value={blockSettings.textValue}
-                    plugins={getDefaultPluginsWithLinkChooser(appBridge)}
-                />
+                </div>
             </div>
-        </div>
+        </>
     );
 };

--- a/packages/callout-block/src/CalloutBlock.tsx
+++ b/packages/callout-block/src/CalloutBlock.tsx
@@ -24,6 +24,11 @@ export const CalloutBlock: FC<BlockProps> = ({ appBridge }) => {
     const isEditing = useEditorState(appBridge);
     const { blockAssets } = useBlockAssets(appBridge);
 
+    if (blockSettings.appearance !== Appearance.Strong && blockSettings.appearance !== Appearance.Light) {
+        // workaround as the appearance could be hubAppearance
+        setBlockSettings({ appearance: Appearance.Light });
+    }
+
     const containerClass = `callout-block-${appBridge.getBlockId().toString()}`;
 
     const containerDivClassNames = joinClassNames([


### PR DESCRIPTION
before the override was on `:root` and so it has overridden all styles on the page, and if you would have multiple on a page the last one would be taken - now the overrides are just for the specific block.

[Task](https://app.clickup.com/t/867814fnp)

[Check on product](https://product.frontify.com/document/11#/new-content-blocks/callout-block)