### PR TITLE
feat(AssetKitBlock): changes & improvements

### DIFF
--- a/packages/asset-kit-block/src/AssetKitBlock.spec.ct.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.spec.ct.tsx
@@ -77,7 +77,7 @@ describe('AssetKit Block', () => {
             },
         });
         mount(<AssetKitBlockWithStubs />);
-        cy.get(BLOCK_THUMBNAIL).should('have.attr', 'src', 'https://picsum.photos/width=218');
+        cy.get(BLOCK_THUMBNAIL_IMAGE).should('have.attr', 'src', 'https://picsum.photos/width=218');
     });
 
     it('shoud not display thumbnails in view mode if showThumbnails is set to false', () => {

--- a/packages/asset-kit-block/src/AssetKitBlock.spec.ct.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.spec.ct.tsx
@@ -68,6 +68,43 @@ describe('AssetKit Block', () => {
         cy.get(BLOCK_THUMBNAIL).should('have.length', 2);
     });
 
+    it('should display assets with small width', () => {
+        const [AssetKitBlockWithStubs] = withAppBridgeBlockStubs(AssetKitBlock, {
+            blockAssets: {
+                [ASSET_SETTINGS_ID]: [{ ...AssetDummy.with(1), previewUrl: 'https://picsum.photos/width={width}' }],
+            },
+        });
+        mount(<AssetKitBlockWithStubs />);
+        cy.get(BLOCK_THUMBNAIL).should('have.attr', 'src', 'https://picsum.photos/width=218');
+    });
+
+    it('shoud not display thumbnails in view mode if showThumbnails is set to false', () => {
+        const [AssetKitBlockWithStubs] = withAppBridgeBlockStubs(AssetKitBlock, {
+            blockSettings: {
+                showThumbnails: false,
+            },
+            blockAssets: {
+                [ASSET_SETTINGS_ID]: [AssetDummy.with(1), AssetDummy.with(2)],
+            },
+        });
+        mount(<AssetKitBlockWithStubs />);
+        cy.get(BLOCK_THUMBNAIL).should('not.exist');
+    });
+
+    it('should display thumbnails in edit mode if showThumbnails is set to false', () => {
+        const [AssetKitBlockWithStubs] = withAppBridgeBlockStubs(AssetKitBlock, {
+            editorState: true,
+            blockSettings: {
+                showThumbnails: false,
+            },
+            blockAssets: {
+                [ASSET_SETTINGS_ID]: [AssetDummy.with(1), AssetDummy.with(2)],
+            },
+        });
+        mount(<AssetKitBlockWithStubs />);
+        cy.get(BLOCK_THUMBNAIL).should('have.length', 2);
+    });
+
     it('should display no padding on block if no border and no background is set', () => {
         const [AssetKitBlockWithStubs] = withAppBridgeBlockStubs(AssetKitBlock, {
             blockSettings: {

--- a/packages/asset-kit-block/src/AssetKitBlock.spec.ct.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.spec.ct.tsx
@@ -1,11 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { mount } from 'cypress/react18';
-import { AssetKitBlock } from './AssetKitBlock';
 import { AssetDummy, getAppBridgeBlockStub, withAppBridgeBlockStubs } from '@frontify/app-bridge';
 import { Color } from '@frontify/fondue';
-import { ASSET_SETTINGS_ID } from './settings';
 import { BorderStyle } from '@frontify/guideline-blocks-shared';
+import { mount } from 'cypress/react18';
+import { AssetKitBlock } from './AssetKitBlock';
+import { ASSET_SETTINGS_ID } from './settings';
 
 const BLOCK_SELECTOR = '[data-test-id="asset-kit-block"]';
 const BLOCK_TITLE = '[data-test-id="block-title"]';

--- a/packages/asset-kit-block/src/AssetKitBlock.spec.ct.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.spec.ct.tsx
@@ -22,8 +22,10 @@ const BLOCK_DOWNLOAD_MESSAGE_ERROR = '[data-test-id="asset-kit-error-message"]';
 const BLOCK_DOWNLOAD_MESSAGE_LOADING_CIRCLE =
     '[data-test-id="asset-kit-download-message"] [data-test-id="loading-circle"]';
 const BLOCK_DOWNLOAD_ANNOUNCEMENT = '[data-test-id="asset-kit-block-screen-reader"]';
+const BLOCK_ASSET_COUNT = '[data-test-id="asset-kit-count"]';
 
 const BLACK: Color = { red: 0, green: 0, blue: 0, alpha: 1 };
+const PINK: Color = { red: 255, green: 0, blue: 255, alpha: 1 };
 const WHITE: Color = { red: 255, green: 255, blue: 255, alpha: 1 };
 
 describe('AssetKit Block', () => {
@@ -103,6 +105,47 @@ describe('AssetKit Block', () => {
         });
         mount(<AssetKitBlockWithStubs />);
         cy.get(BLOCK_THUMBNAIL).should('have.length', 2);
+    });
+
+    it('should display asset count if enabled', () => {
+        const [AssetKitBlockWithStubs] = withAppBridgeBlockStubs(AssetKitBlock, {
+            blockSettings: {
+                showAssetCount: true,
+            },
+            blockAssets: {
+                [ASSET_SETTINGS_ID]: [AssetDummy.with(1), AssetDummy.with(2)],
+            },
+        });
+        mount(<AssetKitBlockWithStubs />);
+        cy.get(BLOCK_ASSET_COUNT).should('include.text', '2 assets');
+    });
+
+    it('should not display asset count if disabled', () => {
+        const [AssetKitBlockWithStubs] = withAppBridgeBlockStubs(AssetKitBlock, {
+            blockSettings: {
+                showAssetCount: true,
+            },
+            blockAssets: {
+                [ASSET_SETTINGS_ID]: [AssetDummy.with(1), AssetDummy.with(2)],
+            },
+        });
+        mount(<AssetKitBlockWithStubs />);
+        cy.get(BLOCK_ASSET_COUNT).should('not.exist');
+    });
+
+    it('should display asset count in custom color if enabled', () => {
+        const [AssetKitBlockWithStubs] = withAppBridgeBlockStubs(AssetKitBlock, {
+            blockSettings: {
+                showAssetCount: true,
+                assetCountColor: 'override',
+                countCustomColor: PINK,
+            },
+            blockAssets: {
+                [ASSET_SETTINGS_ID]: [AssetDummy.with(1), AssetDummy.with(2)],
+            },
+        });
+        mount(<AssetKitBlockWithStubs />);
+        cy.get(BLOCK_ASSET_COUNT).should('have.css', 'color', 'rgb(255, 0, 255)');
     });
 
     it('should display no padding on block if no border and no background is set', () => {

--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -7,9 +7,10 @@ import {
     useBulkDownload,
     useEditorState,
 } from '@frontify/app-bridge';
+import { PaddingSizes, ParagraphPlugin, PluginComposer, RichTextEditor } from '@frontify/fondue';
 import '@frontify/fondue-tokens/styles';
 import { BlockProps } from '@frontify/guideline-blocks-settings';
-import { BlockStyles, joinClassNames } from '@frontify/guideline-blocks-shared';
+import { BlockStyles, hasRichTextValue, joinClassNames } from '@frontify/guideline-blocks-shared';
 import { ReactElement, useEffect, useRef, useState } from 'react';
 import 'tailwindcss/tailwind.css';
 import { AssetGrid, AssetSelection, DownloadMessage, InformationSection } from './components';
@@ -34,11 +35,10 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
         showCount = true,
         assetCountColor,
         countCustomColor,
+        buttonText = 'Download package',
     } = blockSettings;
     const currentAssets = blockAssets[ASSET_SETTINGS_ID] ?? [];
     const { generateBulkDownload, status, downloadUrl } = useBulkDownload(appBridge);
-
-    console.log({ currentAssets });
 
     const startDownload = () => {
         if (downloadUrlBlock && downloadExpiration && downloadExpiration > Math.floor(Date.now() / 1000)) {
@@ -80,6 +80,9 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [downloadUrl]);
 
+    const RtePlugins = new PluginComposer({ noToolbar: true });
+    RtePlugins.setPlugin([new ParagraphPlugin()]);
+
     return (
         <div
             data-test-id="asset-kit-block"
@@ -110,7 +113,14 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
                         onClick={startDownload}
                         style={BlockStyles.buttonPrimary}
                     >
-                        Download package
+                        <RichTextEditor
+                            value={hasRichTextValue(buttonText) ? buttonText : 'Download package'}
+                            readonly={!isEditing}
+                            plugins={RtePlugins}
+                            onBlur={(value) => setBlockSettings({ buttonText: value })}
+                            padding={PaddingSizes.None}
+                            border={false}
+                        />
                         <span
                             data-test-id="asset-kit-block-screen-reader"
                             ref={screenReaderRef}

--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -10,7 +10,13 @@ import {
 import { PluginComposer } from '@frontify/fondue';
 import '@frontify/fondue-tokens/styles';
 import { BlockProps } from '@frontify/guideline-blocks-settings';
-import { BlockStyles, RichTextEditor, hasRichTextValue, joinClassNames } from '@frontify/guideline-blocks-shared';
+import {
+    BlockStyles,
+    RichTextEditor,
+    convertToRteValue,
+    hasRichTextValue,
+    joinClassNames,
+} from '@frontify/guideline-blocks-shared';
 import { ReactElement, useEffect, useRef, useState } from 'react';
 import 'tailwindcss/tailwind.css';
 import { AssetGrid, AssetSelection, DownloadMessage, InformationSection } from './components';
@@ -35,8 +41,9 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
         showCount = true,
         assetCountColor,
         countCustomColor,
-        buttonText = 'Download package',
+        buttonText,
     } = blockSettings;
+
     const currentAssets = blockAssets[ASSET_SETTINGS_ID] ?? [];
     const { generateBulkDownload, status, downloadUrl } = useBulkDownload(appBridge);
 
@@ -114,7 +121,9 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
                     >
                         <RichTextEditor
                             id="asset-kit-block-download-button-text"
-                            value={hasRichTextValue(buttonText) ? buttonText : 'Download package'}
+                            value={
+                                hasRichTextValue(buttonText) ? buttonText : convertToRteValue('p', 'Download package')
+                            }
                             isEditing={isEditing}
                             plugins={RtePlugins}
                             onBlur={(value) => setBlockSettings({ buttonText: value })}

--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -30,13 +30,15 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
         hasBackgroundBlocks,
         downloadUrlBlock,
         downloadExpiration,
-        showThumbnails,
-        showCount,
+        showThumbnails = true,
+        showCount = true,
         assetCountColor,
         countCustomColor,
     } = blockSettings;
     const currentAssets = blockAssets[ASSET_SETTINGS_ID] ?? [];
     const { generateBulkDownload, status, downloadUrl } = useBulkDownload(appBridge);
+
+    console.log({ currentAssets });
 
     const startDownload = () => {
         if (downloadUrlBlock && downloadExpiration && downloadExpiration > Math.floor(Date.now() / 1000)) {

--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -32,6 +32,8 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
         downloadExpiration,
         showThumbnails,
         showCount,
+        assetCountColor,
+        countCustomColor,
     } = blockSettings;
     const currentAssets = blockAssets[ASSET_SETTINGS_ID] ?? [];
     const { generateBulkDownload, status, downloadUrl } = useBulkDownload(appBridge);
@@ -89,10 +91,10 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
         >
             <div className="sm:tw-flex tw-gap-8 tw-space-y-3 md:tw-space-y-0">
                 <InformationSection
-                    description={description ?? ''}
+                    description={description}
                     isEditing={isEditing}
                     setBlockSettings={setBlockSettings}
-                    title={title ?? ''}
+                    title={title}
                     appBridge={appBridge}
                 />
                 <div className="tw-flex-none">
@@ -121,27 +123,30 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
                 <DownloadMessage blockStyle={blockStyle(blockSettings)} status={status} />
             )}
 
-            <AssetGrid
-                appBridge={appBridge}
-                currentAssets={currentAssets}
-                deleteAssetIdsFromKey={deleteAssetIdsFromKey}
-                updateAssetIdsFromKey={updateAssetIdsFromKey}
-                saveDownloadUrl={saveDownloadUrl}
-                isEditing={isEditing}
-                showThumbnails={showThumbnails}
-                showCount={showCount}
-            />
-
-            {isEditing && (
-                <AssetSelection
+            <div>
+                <AssetGrid
                     appBridge={appBridge}
-                    isUploadingAssets={isUploadingAssets}
-                    setIsUploadingAssets={setIsUploadingAssets}
-                    addAssetIdsToKey={addAssetIdsToKey}
-                    saveDownloadUrl={saveDownloadUrl}
                     currentAssets={currentAssets}
+                    deleteAssetIdsFromKey={deleteAssetIdsFromKey}
+                    updateAssetIdsFromKey={updateAssetIdsFromKey}
+                    saveDownloadUrl={saveDownloadUrl}
+                    isEditing={isEditing}
+                    showThumbnails={showThumbnails}
+                    showCount={showCount}
+                    countColor={assetCountColor === 'override' ? countCustomColor : undefined}
                 />
-            )}
+
+                {isEditing && (
+                    <AssetSelection
+                        appBridge={appBridge}
+                        isUploadingAssets={isUploadingAssets}
+                        setIsUploadingAssets={setIsUploadingAssets}
+                        addAssetIdsToKey={addAssetIdsToKey}
+                        saveDownloadUrl={saveDownloadUrl}
+                        currentAssets={currentAssets}
+                    />
+                )}
+            </div>
         </div>
     );
 };

--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -7,10 +7,10 @@ import {
     useBulkDownload,
     useEditorState,
 } from '@frontify/app-bridge';
-import { PaddingSizes, ParagraphPlugin, PluginComposer, RichTextEditor } from '@frontify/fondue';
+import { PluginComposer } from '@frontify/fondue';
 import '@frontify/fondue-tokens/styles';
 import { BlockProps } from '@frontify/guideline-blocks-settings';
-import { BlockStyles, hasRichTextValue, joinClassNames } from '@frontify/guideline-blocks-shared';
+import { BlockStyles, RichTextEditor, hasRichTextValue, joinClassNames } from '@frontify/guideline-blocks-shared';
 import { ReactElement, useEffect, useRef, useState } from 'react';
 import 'tailwindcss/tailwind.css';
 import { AssetGrid, AssetSelection, DownloadMessage, InformationSection } from './components';
@@ -80,8 +80,7 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [downloadUrl]);
 
-    const RtePlugins = new PluginComposer({ noToolbar: true });
-    RtePlugins.setPlugin([new ParagraphPlugin()]);
+    const RtePlugins = new PluginComposer({ noToolbar: true }).setPlugin();
 
     return (
         <div
@@ -114,12 +113,11 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
                         style={BlockStyles.buttonPrimary}
                     >
                         <RichTextEditor
+                            id="asset-kit-block-download-button-text"
                             value={hasRichTextValue(buttonText) ? buttonText : 'Download package'}
-                            readonly={!isEditing}
+                            isEditing={isEditing}
                             plugins={RtePlugins}
                             onBlur={(value) => setBlockSettings({ buttonText: value })}
-                            padding={PaddingSizes.None}
-                            border={false}
                         />
                         <span
                             data-test-id="asset-kit-block-screen-reader"

--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -7,6 +7,7 @@ import {
     useBulkDownload,
     useEditorState,
 } from '@frontify/app-bridge';
+import { getButtonStyleCssProperties } from '@frontify/fondue';
 import '@frontify/fondue-tokens/styles';
 import { BlockProps } from '@frontify/guideline-blocks-settings';
 import { BlockStyles, joinClassNames } from '@frontify/guideline-blocks-shared';
@@ -23,8 +24,16 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
     const isEditing = useEditorState(appBridge);
     const { blockAssets, addAssetIdsToKey, deleteAssetIdsFromKey, updateAssetIdsFromKey } = useBlockAssets(appBridge);
     const [isUploadingAssets, setIsUploadingAssets] = useState<boolean>(false);
-    const { title, description, hasBorder_blocks, hasBackgroundBlocks, downloadUrlBlock, downloadExpiration } =
-        blockSettings;
+    const {
+        title,
+        description,
+        hasBorder_blocks,
+        hasBackgroundBlocks,
+        downloadUrlBlock,
+        downloadExpiration,
+        showThumbnails,
+        showCount,
+    } = blockSettings;
     const currentAssets = blockAssets[ASSET_SETTINGS_ID] ?? [];
     const { generateBulkDownload, status, downloadUrl } = useBulkDownload(appBridge);
 
@@ -117,6 +126,8 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
                 updateAssetIdsFromKey={updateAssetIdsFromKey}
                 saveDownloadUrl={saveDownloadUrl}
                 isEditing={isEditing}
+                showThumbnails={showThumbnails}
+                showCount={showCount}
             />
 
             {isEditing && (

--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -110,7 +110,7 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
                                 status
                             ) || currentAssets.length === 0
                         }
-                        onClick={startDownload}
+                        onClick={isEditing ? undefined : startDownload}
                         style={BlockStyles.buttonPrimary}
                     >
                         <RichTextEditor

--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -7,7 +7,6 @@ import {
     useBulkDownload,
     useEditorState,
 } from '@frontify/app-bridge';
-import { getButtonStyleCssProperties } from '@frontify/fondue';
 import '@frontify/fondue-tokens/styles';
 import { BlockProps } from '@frontify/guideline-blocks-settings';
 import { BlockStyles, joinClassNames } from '@frontify/guideline-blocks-shared';
@@ -80,12 +79,15 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
     return (
         <div
             data-test-id="asset-kit-block"
-            className={joinClassNames(['tw-w-full', (hasBorder_blocks || hasBackgroundBlocks) && 'tw-p-5 sm:tw-p-8'])}
+            className={joinClassNames([
+                'tw-w-full tw-space-y-8',
+                (hasBorder_blocks || hasBackgroundBlocks) && 'tw-p-5 sm:tw-p-8',
+            ])}
             style={{
                 ...blockStyle(blockSettings),
             }}
         >
-            <div className="tw-mb-8 sm:tw-flex tw-gap-8 tw-space-y-3 md:tw-space-y-0">
+            <div className="sm:tw-flex tw-gap-8 tw-space-y-3 md:tw-space-y-0">
                 <InformationSection
                     description={description ?? ''}
                     isEditing={isEditing}

--- a/packages/asset-kit-block/src/components/AssetCount.tsx
+++ b/packages/asset-kit-block/src/components/AssetCount.tsx
@@ -1,0 +1,18 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { toRgbaString } from '@frontify/guideline-blocks-shared';
+import { ReactElement } from 'react';
+import { AssetCountProps } from '../types';
+
+export const AssetCount = ({ count, color }: AssetCountProps): ReactElement => {
+    if (count > 0) {
+        return (
+            <div
+                data-test-id="asset-kit-count"
+                style={{ color: color ? toRgbaString(color) : undefined }}
+            >{`${count} asset${count > 1 ? 's' : ''}`}</div>
+        );
+    } else {
+        return <div className="tw-text-black-50">Add assets to make them available</div>;
+    }
+};

--- a/packages/asset-kit-block/src/components/AssetCount.tsx
+++ b/packages/asset-kit-block/src/components/AssetCount.tsx
@@ -1,18 +1,20 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { toRgbaString } from '@frontify/guideline-blocks-shared';
+import { BlockStyles, TextStyles, toRgbaString } from '@frontify/guideline-blocks-shared';
 import { ReactElement } from 'react';
 import { AssetCountProps } from '../types';
 
 export const AssetCount = ({ count, color }: AssetCountProps): ReactElement => {
+    const imageCaptionStyles = BlockStyles[TextStyles.imageCaption];
+
     if (count > 0) {
         return (
             <div
                 data-test-id="asset-kit-count"
-                style={{ color: color ? toRgbaString(color) : undefined }}
+                style={{ ...imageCaptionStyles, color: color ? toRgbaString(color) : undefined }}
             >{`${count} asset${count > 1 ? 's' : ''}`}</div>
         );
-    } else {
-        return <div className="tw-text-black-50">Add assets to make them available</div>;
     }
+
+    return <div className="tw-text-black-50">Add assets to make them available</div>;
 };

--- a/packages/asset-kit-block/src/components/AssetGrid.tsx
+++ b/packages/asset-kit-block/src/components/AssetGrid.tsx
@@ -4,12 +4,18 @@ import { ReactElement } from 'react';
 import { ThumbnailItem } from '.';
 import { ASSET_SETTINGS_ID } from '../settings';
 import { AssetGridProps } from '../types';
+import { Color } from '@frontify/fondue';
+import { toRgbaString } from '@frontify/guideline-blocks-shared';
 
-const AssetCount = ({ count }: { count: number }): ReactElement => {
+const AssetCount = ({ count, color }: { count: number; color?: Color }): ReactElement => {
     if (count > 0) {
-        return <span>{`${count} asset${count > 1 ? 's' : ''}`}</span>;
+        return (
+            <div style={{ color: color ? toRgbaString(color) : undefined }}>{`${count} asset${
+                count > 1 ? 's' : ''
+            }`}</div>
+        );
     } else {
-        return <span className="tw-text-black-50">Add assets to make them available</span>;
+        return <div className="tw-text-black-50">Add assets to make them available</div>;
     }
 };
 
@@ -21,6 +27,7 @@ export const AssetGrid = ({
     isEditing,
     showCount,
     showThumbnails,
+    countColor,
     appBridge,
 }: AssetGridProps) => {
     const onRemoveAsset = async (assetId: number) => {
@@ -38,8 +45,8 @@ export const AssetGrid = ({
 
     return (
         <>
-            {showCount && <AssetCount count={currentAssets.length} />}
-            {shouldShowThumbnails && (
+            {showCount && <AssetCount count={currentAssets.length} color={countColor} />}
+            {shouldShowThumbnails && currentAssets.length > 0 && (
                 <div className="tw-mt-2.5 tw-grid tw-grid-cols-3 sm:tw-grid-cols-4 md:tw-grid-cols-6 tw-gap-4">
                     {currentAssets
                         ? currentAssets.map((asset) => (

--- a/packages/asset-kit-block/src/components/AssetGrid.tsx
+++ b/packages/asset-kit-block/src/components/AssetGrid.tsx
@@ -1,8 +1,17 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { ReactElement } from 'react';
 import { ThumbnailItem } from '.';
 import { ASSET_SETTINGS_ID } from '../settings';
 import { AssetGridProps } from '../types';
+
+const AssetCount = ({ count }: { count: number }): ReactElement => {
+    if (count > 0) {
+        return <span>{`${count} asset${count > 1 ? 's' : ''}`}</span>;
+    } else {
+        return <span className="tw-text-black-50">Add assets to make them available</span>;
+    }
+};
 
 export const AssetGrid = ({
     currentAssets,
@@ -10,6 +19,8 @@ export const AssetGrid = ({
     updateAssetIdsFromKey,
     saveDownloadUrl,
     isEditing,
+    showCount,
+    showThumbnails,
     appBridge,
 }: AssetGridProps) => {
     const onRemoveAsset = async (assetId: number) => {
@@ -23,27 +34,27 @@ export const AssetGrid = ({
         await updateAssetIdsFromKey(ASSET_SETTINGS_ID, assetIds);
     };
 
+    const shouldShowThumbnails = isEditing || showThumbnails;
+
     return (
         <>
-            {currentAssets.length > 0 ? (
-                <span>{`${currentAssets.length} asset${currentAssets.length > 1 ? 's' : ''}`}</span>
-            ) : (
-                <span className="tw-text-black-50">Add assets to make them available</span>
+            {showCount && <AssetCount count={currentAssets.length} />}
+            {shouldShowThumbnails && (
+                <div className="tw-mt-2.5 tw-grid tw-grid-cols-3 sm:tw-grid-cols-4 md:tw-grid-cols-6 tw-gap-4">
+                    {currentAssets
+                        ? currentAssets.map((asset) => (
+                              <ThumbnailItem
+                                  key={asset.id}
+                                  asset={asset}
+                                  isEditing={isEditing}
+                                  onRemoveAsset={onRemoveAsset}
+                                  onReplaceAsset={onReplaceAsset}
+                                  appBridge={appBridge}
+                              />
+                          ))
+                        : null}
+                </div>
             )}
-            <div className="tw-mt-2.5 tw-grid tw-grid-cols-3 sm:tw-grid-cols-4 md:tw-grid-cols-6 tw-gap-4">
-                {currentAssets
-                    ? currentAssets.map((asset) => (
-                          <ThumbnailItem
-                              key={asset.id}
-                              asset={asset}
-                              isEditing={isEditing}
-                              onRemoveAsset={onRemoveAsset}
-                              onReplaceAsset={onReplaceAsset}
-                              appBridge={appBridge}
-                          />
-                      ))
-                    : null}
-            </div>
         </>
     );
 };

--- a/packages/asset-kit-block/src/components/AssetGrid.tsx
+++ b/packages/asset-kit-block/src/components/AssetGrid.tsx
@@ -1,23 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { ReactElement } from 'react';
-import { ThumbnailItem } from '.';
 import { ASSET_SETTINGS_ID } from '../settings';
 import { AssetGridProps } from '../types';
-import { Color } from '@frontify/fondue';
-import { toRgbaString } from '@frontify/guideline-blocks-shared';
-
-const AssetCount = ({ count, color }: { count: number; color?: Color }): ReactElement => {
-    if (count > 0) {
-        return (
-            <div style={{ color: color ? toRgbaString(color) : undefined }}>{`${count} asset${
-                count > 1 ? 's' : ''
-            }`}</div>
-        );
-    } else {
-        return <div className="tw-text-black-50">Add assets to make them available</div>;
-    }
-};
+import { AssetCount } from './AssetCount';
+import { ThumbnailItem } from './ThumbnailItem';
 
 export const AssetGrid = ({
     currentAssets,

--- a/packages/asset-kit-block/src/components/ThumbnailItem.tsx
+++ b/packages/asset-kit-block/src/components/ThumbnailItem.tsx
@@ -72,7 +72,7 @@ export const ThumbnailItem = ({ asset, isEditing, appBridge, onRemoveAsset, onRe
                 ) : (
                     <img
                         data-test-id="block-thumbnail-image"
-                        className="tw-object-scale-down tw-w-full tw-h-full"
+                        className="tw-object-cover tw-w-full tw-h-full"
                         src={getSmallPreviewUrl(asset.previewUrl)}
                         style={thumbnailStyle(blockSettings)}
                         alt={asset.title}

--- a/packages/asset-kit-block/src/components/ThumbnailItem.tsx
+++ b/packages/asset-kit-block/src/components/ThumbnailItem.tsx
@@ -5,7 +5,7 @@ import { Settings, ThumbnailItemProps } from '../types';
 import { IconArrowCircleUp20, IconImageStack20, IconTrashBin16, LoadingCircle } from '@frontify/fondue';
 import { BlockItemWrapper } from '@frontify/guideline-blocks-shared';
 import { AssetChooserObjectType, useAssetUpload, useBlockSettings, useFileInput } from '@frontify/app-bridge';
-import { thumbnailStyle } from '../helpers';
+import { getSmallPreviewUrl, thumbnailStyle } from '../helpers';
 
 export const ThumbnailItem = ({ asset, isEditing, appBridge, onRemoveAsset, onReplaceAsset }: ThumbnailItemProps) => {
     const [isUploading, setIsUploading] = useState(false);
@@ -73,7 +73,7 @@ export const ThumbnailItem = ({ asset, isEditing, appBridge, onRemoveAsset, onRe
                     <img
                         data-test-id="block-thumbnail-image"
                         className="tw-object-scale-down tw-w-full tw-h-full"
-                        src={asset.previewUrl}
+                        src={getSmallPreviewUrl(asset.previewUrl)}
                         style={thumbnailStyle(blockSettings)}
                         alt={asset.title}
                     />

--- a/packages/asset-kit-block/src/components/index.ts
+++ b/packages/asset-kit-block/src/components/index.ts
@@ -1,7 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+export * from './AssetCount';
 export * from './AssetGrid';
-export * from './DownloadMessage';
 export * from './AssetSelection';
+export * from './DownloadMessage';
 export * from './InformationSection';
 export * from './ThumbnailItem';

--- a/packages/asset-kit-block/src/helpers/assetKitHelpers.ts
+++ b/packages/asset-kit-block/src/helpers/assetKitHelpers.ts
@@ -44,3 +44,7 @@ export const blockStyle = (blockSetting: Settings): CSSProperties => {
         ...getRadiusStyles(radiusChoice_blocks, hasRadius_blocks, radiusValue_blocks),
     };
 };
+
+export const getSmallPreviewUrl = (url: string) => {
+    return url.replace('{width}', '218');
+};

--- a/packages/asset-kit-block/src/settings.ts
+++ b/packages/asset-kit-block/src/settings.ts
@@ -18,6 +18,20 @@ export const BORDER_COLOR_DEFAULT_VALUE: Color = {
 };
 
 export const settings = defineSettings({
+    layout: [
+        {
+            id: 'showThumbnails',
+            type: 'switch',
+            label: 'Thumbnails',
+            defaultValue: true,
+        },
+        {
+            id: 'showCount',
+            type: 'switch',
+            label: 'Asset count',
+            defaultValue: true,
+        },
+    ],
     style: [
         {
             id: 'blockSection',

--- a/packages/asset-kit-block/src/settings.ts
+++ b/packages/asset-kit-block/src/settings.ts
@@ -53,6 +53,30 @@ export const settings = defineSettings({
                 getBorderRadiusSettings({ id: 'thumbnails' }),
             ],
         },
+        {
+            id: 'textSection',
+            type: 'sectionHeading',
+            label: 'Text',
+            blocks: [
+                {
+                    id: 'assetCountColor',
+                    type: 'slider',
+                    label: 'Asset count color',
+                    info: 'This setting is defined in the text style and you can override it here.',
+                    defaultValue: 'inherit',
+                    choices: [
+                        {
+                            value: 'inherit',
+                            label: 'Inherit settings',
+                        },
+                        {
+                            value: 'override',
+                            label: 'Override',
+                        },
+                    ],
+                },
+            ],
+        },
     ],
     targets: [],
 });

--- a/packages/asset-kit-block/src/settings.ts
+++ b/packages/asset-kit-block/src/settings.ts
@@ -4,6 +4,7 @@ import { Color, defineSettings } from '@frontify/guideline-blocks-settings';
 import { getBackgroundSettings, getBorderRadiusSettings, getBorderSettings } from '@frontify/guideline-blocks-shared';
 
 export const ASSET_SETTINGS_ID = 'images';
+const COUNT_COLOR_ID = 'assetCountColor';
 export const BACKGROUND_COLOR_DEFAULT_VALUE: Color = {
     red: 241,
     green: 241,
@@ -59,7 +60,7 @@ export const settings = defineSettings({
             label: 'Text',
             blocks: [
                 {
-                    id: 'assetCountColor',
+                    id: COUNT_COLOR_ID,
                     type: 'slider',
                     label: 'Asset count color',
                     info: 'This setting is defined in the text style and you can override it here.',
@@ -74,6 +75,11 @@ export const settings = defineSettings({
                             label: 'Override',
                         },
                     ],
+                },
+                {
+                    id: 'countCustomColor',
+                    type: 'colorInput',
+                    show: (bundle) => bundle.getBlock(COUNT_COLOR_ID)?.value === 'override',
                 },
             ],
         },

--- a/packages/asset-kit-block/src/types.ts
+++ b/packages/asset-kit-block/src/types.ts
@@ -30,6 +30,8 @@ export type Settings = {
     downloadUrlBlock: string;
     showThumbnails?: boolean;
     showCount?: boolean;
+    assetCountColor?: 'inherit' | 'override';
+    countCustomColor?: Color;
 };
 
 export type AssetGridProps = {
@@ -38,6 +40,7 @@ export type AssetGridProps = {
     isEditing: boolean;
     showThumbnails?: boolean;
     showCount?: boolean;
+    countColor?: Color;
     deleteAssetIdsFromKey: (key: string, assetIds: number[]) => Promise<void>;
     updateAssetIdsFromKey: (key: string, assetIds: number[]) => Promise<void>;
     saveDownloadUrl: (downloadUrlBlock: string) => void;
@@ -58,9 +61,9 @@ export type DownloadMessageProps = {
 };
 
 export type InformationSectionProps = {
-    description: string;
+    title?: string;
+    description?: string;
     isEditing: boolean;
-    title: string;
     appBridge: AppBridgeBlock;
     setBlockSettings: (newSettings: Partial<Settings>) => void;
 };

--- a/packages/asset-kit-block/src/types.ts
+++ b/packages/asset-kit-block/src/types.ts
@@ -32,6 +32,7 @@ export type Settings = {
     showCount?: boolean;
     assetCountColor?: 'inherit' | 'override';
     countCustomColor?: Color;
+    buttonText?: string;
 };
 
 export type AssetGridProps = {

--- a/packages/asset-kit-block/src/types.ts
+++ b/packages/asset-kit-block/src/types.ts
@@ -85,3 +85,8 @@ export type ThumbnailToolbarProps = {
     setIsUploading: (isLoading: boolean) => void;
     isUploading: boolean;
 };
+
+export type AssetCountProps = {
+    count: number;
+    color?: Color;
+};

--- a/packages/asset-kit-block/src/types.ts
+++ b/packages/asset-kit-block/src/types.ts
@@ -28,12 +28,16 @@ export type Settings = {
     title?: string;
     downloadExpiration?: number;
     downloadUrlBlock: string;
+    showThumbnails?: boolean;
+    showCount?: boolean;
 };
 
 export type AssetGridProps = {
     currentAssets: Asset[];
     appBridge: AppBridgeBlock;
     isEditing: boolean;
+    showThumbnails?: boolean;
+    showCount?: boolean;
     deleteAssetIdsFromKey: (key: string, assetIds: number[]) => Promise<void>;
     updateAssetIdsFromKey: (key: string, assetIds: number[]) => Promise<void>;
     saveDownloadUrl: (downloadUrlBlock: string) => void;

--- a/packages/shared/src/components/RichTextEditor/SerializedText.tsx
+++ b/packages/shared/src/components/RichTextEditor/SerializedText.tsx
@@ -2,7 +2,6 @@
 
 import React, { useEffect, useState } from 'react';
 import { SerializedTextProps } from './types';
-import { BlockStyles } from './plugins';
 import { serializeRawToHtmlAsync } from './serializer';
 
 export const SerializedText = ({ value = '', gap, columns, show = true, plugins }: SerializedTextProps) => {
@@ -10,7 +9,7 @@ export const SerializedText = ({ value = '', gap, columns, show = true, plugins 
 
     useEffect(() => {
         (async () => {
-            setHtml(await serializeRawToHtmlAsync(value, columns, gap, BlockStyles, plugins));
+            setHtml(await serializeRawToHtmlAsync(value, columns, gap, plugins));
         })();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [value, columns, gap, plugins]);

--- a/packages/shared/src/components/RichTextEditor/serializer/serializeToHtml.ts
+++ b/packages/shared/src/components/RichTextEditor/serializer/serializeToHtml.ts
@@ -3,17 +3,16 @@
 import { TDescendant } from '@udecode/plate';
 import { PluginComposer, SerializeNodesToHtmlOptions, mapMentionable, parseRawValue } from '@frontify/fondue';
 import { BlockStyles } from '../plugins';
-import { CSSProperties } from 'react';
 import { serializeNodeToHtmlRecursive } from './serializeNodesToHtmlRecursive';
 
 export const serializeRawToHtmlAsync = async (
     raw: string,
     columns: SerializeNodesToHtmlOptions['columns'] = 1,
     columnGap: SerializeNodesToHtmlOptions['columnGap'] = 'normal',
-    styles: Record<string, CSSProperties & { hover?: CSSProperties }> = BlockStyles,
     plugins: PluginComposer = new PluginComposer()
 ): Promise<string> => {
     const nodes = parseRawValue({ raw, plugins });
+    const styles = plugins.getStyles;
     return Promise.resolve(serializeNodesToHtml(nodes, { columns, columnGap, styles }));
 };
 


### PR DESCRIPTION
Ticket: https://app.clickup.com/t/8677vvdnn

- [x] Show/hide thumbnails option (but always show thumbnails in edit mode)
- [x] Show/hide asset count option
- [x] Add option for a custom asset count font color
- [x] Fix default styles for title & description
- [x] Use image caption styles for asset count
- [x] Change asset display to `cover`
- [x] Use smaller image sizes for the asset thumbnails
- [x] Add inline editing of button "Download package"