### PR TITLE
fix(CalloutBlock): prevent text color overwrite

### DIFF
--- a/packages/callout-block/src/CalloutBlock.spec.ct.tsx
+++ b/packages/callout-block/src/CalloutBlock.spec.ct.tsx
@@ -193,4 +193,33 @@ describe('Callout Block', () => {
         cy.get(CalloutWrapper).should('have.css', 'background-color', 'rgba(222, 27, 27, 0.1)');
         cy.get(HtmlContent).should('have.css', 'color', 'rgb(222, 27, 27)');
     });
+
+    it('renders a callout block with the overwritten css variables for the theme styles', () => {
+        const [CalloutBlockWithStubs] = withAppBridgeBlockStubs(CalloutBlock, {
+            blockSettings: {
+                textValue: 'This is a warning',
+                type: Type.Warning,
+            },
+        });
+
+        mount(<CalloutBlockWithStubs />);
+        cy.document().then((doc) => {
+            const style = doc.createElement('style');
+            style.innerHTML = EXAMPLE_THEME_SETTINGS;
+            doc.head.appendChild(style);
+        });
+
+        cy.get(CalloutBlockSelector)
+            .find('style')
+            .should('contain', '--f-theme-settings-heading1-color: rgba(222, 27, 27, 1)')
+            .and('contain', '--f-theme-settings-heading2-color: rgba(222, 27, 27, 1)')
+            .and('contain', '--f-theme-settings-heading3-color: rgba(222, 27, 27, 1)')
+            .and('contain', '--f-theme-settings-heading4-color: rgba(222, 27, 27, 1)')
+            .and('contain', '--f-theme-settings-custom1-color: rgba(222, 27, 27, 1)')
+            .and('contain', '--f-theme-settings-custom2-color: rgba(222, 27, 27, 1)')
+            .and('contain', '--f-theme-settings-custom3-color: rgba(222, 27, 27, 1)')
+            .and('contain', '--f-theme-settings-body-color: rgba(222, 27, 27, 1)')
+            .and('contain', '--f-theme-settings-quote-color: rgba(222, 27, 27, 1)')
+            .and('contain', '--f-theme-settings-link-color: rgba(222, 27, 27, 1)');
+    });
 });

--- a/packages/callout-block/src/CalloutBlock.spec.ct.tsx
+++ b/packages/callout-block/src/CalloutBlock.spec.ct.tsx
@@ -194,7 +194,7 @@ describe('Callout Block', () => {
         cy.get(HtmlContent).should('have.css', 'color', 'rgb(222, 27, 27)');
     });
 
-    it('renders a callout block with the overwritten css variables for the theme styles', () => {
+    it('renders a warning block with the overwritten css variables for the theme styles', () => {
         const [CalloutBlockWithStubs] = withAppBridgeBlockStubs(CalloutBlock, {
             blockSettings: {
                 textValue: 'This is a warning',
@@ -209,17 +209,32 @@ describe('Callout Block', () => {
             doc.head.appendChild(style);
         });
 
-        cy.get(CalloutBlockSelector)
-            .find('style')
-            .should('contain', '--f-theme-settings-heading1-color: rgba(222, 27, 27, 1)')
-            .and('contain', '--f-theme-settings-heading2-color: rgba(222, 27, 27, 1)')
-            .and('contain', '--f-theme-settings-heading3-color: rgba(222, 27, 27, 1)')
-            .and('contain', '--f-theme-settings-heading4-color: rgba(222, 27, 27, 1)')
-            .and('contain', '--f-theme-settings-custom1-color: rgba(222, 27, 27, 1)')
-            .and('contain', '--f-theme-settings-custom2-color: rgba(222, 27, 27, 1)')
-            .and('contain', '--f-theme-settings-custom3-color: rgba(222, 27, 27, 1)')
-            .and('contain', '--f-theme-settings-body-color: rgba(222, 27, 27, 1)')
-            .and('contain', '--f-theme-settings-quote-color: rgba(222, 27, 27, 1)')
-            .and('contain', '--f-theme-settings-link-color: rgba(222, 27, 27, 1)');
+        cy.get(CalloutBlockSelector).should(
+            'have.attr',
+            'style',
+            '--f-theme-settings-heading1-color:rgba(222, 27, 27, 1); --f-theme-settings-heading2-color:rgba(222, 27, 27, 1); --f-theme-settings-heading3-color:rgba(222, 27, 27, 1); --f-theme-settings-heading4-color:rgba(222, 27, 27, 1); --f-theme-settings-custom1-color:rgba(222, 27, 27, 1); --f-theme-settings-custom2-color:rgba(222, 27, 27, 1); --f-theme-settings-custom3-color:rgba(222, 27, 27, 1); --f-theme-settings-body-color:rgba(222, 27, 27, 1); --f-theme-settings-quote-color:rgba(222, 27, 27, 1); --f-theme-settings-link-color:rgba(222, 27, 27, 1); --f-theme-settings-link-text-decoration:underline; color: rgb(222, 27, 27);'
+        );
+    });
+
+    it('renders a npte block with the overwritten css variables for the theme styles', () => {
+        const [CalloutBlockWithStubs] = withAppBridgeBlockStubs(CalloutBlock, {
+            blockSettings: {
+                textValue: 'This is a note',
+                type: Type.Note,
+            },
+        });
+
+        mount(<CalloutBlockWithStubs />);
+        cy.document().then((doc) => {
+            const style = doc.createElement('style');
+            style.innerHTML = EXAMPLE_THEME_SETTINGS;
+            doc.head.appendChild(style);
+        });
+
+        cy.get(CalloutBlockSelector).should(
+            'have.attr',
+            'style',
+            '--f-theme-settings-heading1-color:rgba(246, 216, 56, 1); --f-theme-settings-heading2-color:rgba(246, 216, 56, 1); --f-theme-settings-heading3-color:rgba(246, 216, 56, 1); --f-theme-settings-heading4-color:rgba(246, 216, 56, 1); --f-theme-settings-custom1-color:rgba(246, 216, 56, 1); --f-theme-settings-custom2-color:rgba(246, 216, 56, 1); --f-theme-settings-custom3-color:rgba(246, 216, 56, 1); --f-theme-settings-body-color:rgba(246, 216, 56, 1); --f-theme-settings-quote-color:rgba(246, 216, 56, 1); --f-theme-settings-link-color:rgba(246, 216, 56, 1); --f-theme-settings-link-text-decoration:underline; color: rgb(246, 216, 56);'
+        );
     });
 });

--- a/packages/callout-block/src/CalloutBlock.spec.ct.tsx
+++ b/packages/callout-block/src/CalloutBlock.spec.ct.tsx
@@ -4,7 +4,7 @@ import { AssetDummy, withAppBridgeBlockStubs } from '@frontify/app-bridge';
 import { mount } from 'cypress/react18';
 import { CalloutBlock } from './CalloutBlock';
 import { ICON_ASSET_ID } from './settings';
-import { Alignment, Icon, Padding, Width } from './types';
+import { Alignment, Icon, Padding, Type, Width } from './types';
 
 const CalloutBlockSelector = '[data-test-id="callout-block"]';
 const RichTextEditor = '[data-test-id="rich-text-editor"]';
@@ -13,6 +13,9 @@ const CalloutWrapper = '[data-test-id="callout-wrapper"]';
 const CalloutIcon = '[data-test-id="callout-icon"]';
 const CalloutIconCustom = '[data-test-id="callout-icon-custom"]';
 const CalloutIconInfo = '[data-test-id="callout-icon-info"]';
+
+const EXAMPLE_THEME_SETTINGS =
+    ':root {--f-theme-settings-accent-color-info-color: rgba(26, 199, 211, 1); --f-theme-settings-accent-color-note-color: rgba(246, 216, 56, 1); --f-theme-settings-accent-color-tip-color: rgba(42, 191, 24, 1); --f-theme-settings-accent-color-warning-color: rgba(222, 27, 27, 1);}';
 
 describe('Callout Block', () => {
     it('renders a callout block in edit mode', () => {
@@ -60,7 +63,7 @@ describe('Callout Block', () => {
         });
 
         mount(<CalloutBlockWithStubs />);
-        cy.get(CalloutWrapper).should('have.css', 'border-radius').and('eq', '10px 20px 30px 40px');
+        cy.get(CalloutWrapper).should('have.css', 'border-radius', '10px 20px 30px 40px');
     });
 
     it('renders a callout block with a predefined icon', () => {
@@ -113,5 +116,81 @@ describe('Callout Block', () => {
 
         mount(<CalloutBlockWithStubs />);
         cy.get(CalloutIcon).should('not.exist');
+    });
+
+    it('renders a callout block with the correct colors for type info', () => {
+        const [CalloutBlockWithStubs] = withAppBridgeBlockStubs(CalloutBlock, {
+            blockSettings: {
+                textValue: 'This is an info',
+                type: Type.Info,
+            },
+        });
+
+        mount(<CalloutBlockWithStubs />);
+        cy.document().then((doc) => {
+            const style = doc.createElement('style');
+            style.innerHTML = EXAMPLE_THEME_SETTINGS;
+            doc.head.appendChild(style);
+        });
+
+        cy.get(CalloutWrapper).should('have.css', 'background-color', 'rgba(26, 199, 211, 0.1)');
+        cy.get(HtmlContent).should('have.css', 'color', 'rgb(26, 199, 211)');
+    });
+
+    it('renders a callout block with the correct colors for type note', () => {
+        const [CalloutBlockWithStubs] = withAppBridgeBlockStubs(CalloutBlock, {
+            blockSettings: {
+                textValue: 'This is a note',
+                type: Type.Note,
+            },
+        });
+
+        mount(<CalloutBlockWithStubs />);
+        cy.document().then((doc) => {
+            const style = doc.createElement('style');
+            style.innerHTML = EXAMPLE_THEME_SETTINGS;
+            doc.head.appendChild(style);
+        });
+
+        cy.get(CalloutWrapper).should('have.css', 'background-color', 'rgba(246, 216, 56, 0.1)');
+        cy.get(HtmlContent).should('have.css', 'color', 'rgb(246, 216, 56)');
+    });
+
+    it('renders a callout block with the correct colors for type tip', () => {
+        const [CalloutBlockWithStubs] = withAppBridgeBlockStubs(CalloutBlock, {
+            blockSettings: {
+                textValue: 'This is a tip',
+                type: Type.Tip,
+            },
+        });
+
+        mount(<CalloutBlockWithStubs />);
+        cy.document().then((doc) => {
+            const style = doc.createElement('style');
+            style.innerHTML = EXAMPLE_THEME_SETTINGS;
+            doc.head.appendChild(style);
+        });
+
+        cy.get(CalloutWrapper).should('have.css', 'background-color', 'rgba(42, 191, 24, 0.1)');
+        cy.get(HtmlContent).should('have.css', 'color', 'rgb(42, 191, 24)');
+    });
+
+    it('renders a callout block with the correct colors for type warning', () => {
+        const [CalloutBlockWithStubs] = withAppBridgeBlockStubs(CalloutBlock, {
+            blockSettings: {
+                textValue: 'This is a warning',
+                type: Type.Warning,
+            },
+        });
+
+        mount(<CalloutBlockWithStubs />);
+        cy.document().then((doc) => {
+            const style = doc.createElement('style');
+            style.innerHTML = EXAMPLE_THEME_SETTINGS;
+            doc.head.appendChild(style);
+        });
+
+        cy.get(CalloutWrapper).should('have.css', 'background-color', 'rgba(222, 27, 27, 0.1)');
+        cy.get(HtmlContent).should('have.css', 'color', 'rgb(222, 27, 27)');
     });
 });

--- a/packages/callout-block/src/CalloutBlock.spec.ct.tsx
+++ b/packages/callout-block/src/CalloutBlock.spec.ct.tsx
@@ -216,7 +216,7 @@ describe('Callout Block', () => {
         );
     });
 
-    it('renders a npte block with the overwritten css variables for the theme styles', () => {
+    it('renders a note block with the overwritten css variables for the theme styles', () => {
         const [CalloutBlockWithStubs] = withAppBridgeBlockStubs(CalloutBlock, {
             blockSettings: {
                 textValue: 'This is a note',

--- a/packages/callout-block/src/CalloutBlock.tsx
+++ b/packages/callout-block/src/CalloutBlock.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { generateRandomString, useBlockAssets, useBlockSettings, useEditorState } from '@frontify/app-bridge';
+import { useBlockAssets, useBlockSettings, useEditorState } from '@frontify/app-bridge';
 import '@frontify/fondue-tokens/styles';
 import type { BlockProps } from '@frontify/guideline-blocks-settings';
 import {
@@ -13,13 +13,13 @@ import {
     radiusStyleMap,
     setAlpha,
 } from '@frontify/guideline-blocks-shared';
-import { FC } from 'react';
+import { CSSProperties, ReactElement } from 'react';
 import 'tailwindcss/tailwind.css';
 import { CalloutIcon } from './components/CalloutIcon';
 import { ICON_ASSET_ID } from './settings';
 import { Appearance, BlockSettings, Icon, Type, Width, alignmentMap, outerWidthMap, paddingMap } from './types';
 
-export const CalloutBlock: FC<BlockProps> = ({ appBridge }) => {
+export const CalloutBlock = ({ appBridge }: BlockProps): ReactElement => {
     const [blockSettings, setBlockSettings] = useBlockSettings<BlockSettings>(appBridge);
     const isEditing = useEditorState(appBridge);
     const { blockAssets } = useBlockAssets(appBridge);
@@ -28,11 +28,8 @@ export const CalloutBlock: FC<BlockProps> = ({ appBridge }) => {
         setBlockSettings({ appearance: Appearance.Light });
     }
 
-    const containerClass = `callout-block-${generateRandomString()}`;
-
     const containerDivClassNames = joinClassNames([
         outerWidthMap[blockSettings.width],
-        containerClass,
         blockSettings.width === Width.HugContents && alignmentMap[blockSettings.alignment],
     ]);
 
@@ -78,24 +75,23 @@ export const CalloutBlock: FC<BlockProps> = ({ appBridge }) => {
 
     const onTextChange = (value: string) => value !== blockSettings.textValue && setBlockSettings({ textValue: value });
 
+    const overwrittenThemeSettings = {
+        [`${THEME_PREFIX}heading1-color`]: textColor,
+        [`${THEME_PREFIX}heading2-color`]: textColor,
+        [`${THEME_PREFIX}heading3-color`]: textColor,
+        [`${THEME_PREFIX}heading4-color`]: textColor,
+        [`${THEME_PREFIX}custom1-color`]: textColor,
+        [`${THEME_PREFIX}custom2-color`]: textColor,
+        [`${THEME_PREFIX}custom3-color`]: textColor,
+        [`${THEME_PREFIX}body-color`]: textColor,
+        [`${THEME_PREFIX}quote-color`]: textColor,
+        [`${THEME_PREFIX}link-color`]: textColor,
+        [`${THEME_PREFIX}link-text-decoration`]: 'underline',
+        color: textColor,
+    } as CSSProperties;
+
     return (
-        <div data-test-id="callout-block" className={containerDivClassNames}>
-            <style>{`
-                .${containerClass} {
-                    ${THEME_PREFIX}heading1-color: ${textColor};
-                    ${THEME_PREFIX}heading2-color: ${textColor};
-                    ${THEME_PREFIX}heading3-color: ${textColor};
-                    ${THEME_PREFIX}heading4-color: ${textColor};
-                    ${THEME_PREFIX}custom1-color: ${textColor};
-                    ${THEME_PREFIX}custom2-color: ${textColor};
-                    ${THEME_PREFIX}custom3-color: ${textColor};
-                    ${THEME_PREFIX}body-color: ${textColor};
-                    ${THEME_PREFIX}quote-color: ${textColor};
-                    ${THEME_PREFIX}link-color: ${textColor};
-                    ${THEME_PREFIX}link-text-decoration: underline;
-                    color: ${textColor};
-                }
-            `}</style>
+        <div data-test-id="callout-block" style={overwrittenThemeSettings} className={containerDivClassNames}>
             <div
                 data-test-id="callout-wrapper"
                 className={textDivClassNames}

--- a/packages/callout-block/src/CalloutBlock.tsx
+++ b/packages/callout-block/src/CalloutBlock.tsx
@@ -81,7 +81,7 @@ export const CalloutBlock: FC<BlockProps> = ({ appBridge }) => {
     return (
         <div data-test-id="callout-block" className={containerDivClassNames}>
             <style>{`
-                .${containerClass} { 
+                .${containerClass} {
                     ${THEME_PREFIX}heading1-color: ${textColor};
                     ${THEME_PREFIX}heading2-color: ${textColor};
                     ${THEME_PREFIX}heading3-color: ${textColor};
@@ -93,6 +93,7 @@ export const CalloutBlock: FC<BlockProps> = ({ appBridge }) => {
                     ${THEME_PREFIX}quote-color: ${textColor};
                     ${THEME_PREFIX}link-color: ${textColor};
                     ${THEME_PREFIX}link-text-decoration: underline;
+                    color: ${textColor};
                 }
             `}</style>
             <div


### PR DESCRIPTION
Paragraph text in Callout block get's overwritten by hub appearance css, this should fix it.

I also refactored the block a bit: removed the `style` tag for the css variables and directly added them to the element itself.

Last but not least: added a bunch of tests for all of the color handling.

Before:
<img width="883" alt="Bildschirmfoto 2023-06-02 um 08 41 55" src="https://github.com/Frontify/guideline-blocks/assets/11270687/cea68426-53aa-4a73-a274-3d3f7b892df8">

After:
<img width="887" alt="Bildschirmfoto 2023-06-02 um 08 42 11" src="https://github.com/Frontify/guideline-blocks/assets/11270687/0ecadd45-3fbb-4f0a-b41a-2490d8446d64">
