### PR TITLE
fix(RteSerializer): Button styles

### DIFF
--- a/packages/shared/src/components/RichTextEditor/plugins/ButtonPlugin/createButtonPlugin.ts
+++ b/packages/shared/src/components/RichTextEditor/plugins/ButtonPlugin/createButtonPlugin.ts
@@ -3,11 +3,13 @@
 import { AppBridgeBlock } from '@frontify/app-bridge';
 import { Plugin, PluginProps } from '@frontify/fondue';
 import { RangeBeforeOptions, createPluginFactory } from '@udecode/plate';
+import { CSSProperties } from 'react';
+import { isValidUrl } from '../LinkPlugin/utils/url';
 import { ButtonMarkupElement } from './ButtonMarkupElement';
 import { ButtonButton } from './components/ButtonButton';
 import { CustomFloatingButton } from './components/FloatingButton/CustomFloatingButton';
+import { BlockButtonStyles } from './utils';
 import { withButton } from './withButton';
-import { isValidUrl } from '../LinkPlugin/utils/url';
 
 export const ELEMENT_BUTTON = 'button';
 export const BUTTON_PLUGIN = 'button-plugin';
@@ -91,17 +93,20 @@ export const createButtonPlugin = (appBridge: AppBridgeBlock) =>
         }),
     })();
 
-export type ButtonPluginProps = PluginProps & { appBridge: AppBridgeBlock };
+export type ButtonPluginProps = Omit<PluginProps, 'styles'> & {
+    styles?: Record<string, CSSProperties & { hover?: CSSProperties }>;
+} & { appBridge: AppBridgeBlock };
 
 export class ButtonPlugin extends Plugin {
+    public styles: CSSProperties = {};
     private appBridge: AppBridgeBlock;
-
-    constructor(props?: ButtonPluginProps) {
+    constructor({ styles = BlockButtonStyles, ...props }: ButtonPluginProps) {
         super(BUTTON_PLUGIN, {
             button: ButtonButton,
             markupElement: new ButtonMarkupElement(),
             ...props,
         });
+        this.styles = styles;
         this.appBridge = props?.appBridge as AppBridgeBlock;
     }
 

--- a/packages/shared/src/components/RichTextEditor/serializer/nodes/button.ts
+++ b/packages/shared/src/components/RichTextEditor/serializer/nodes/button.ts
@@ -3,22 +3,23 @@
 import { TElement } from '@udecode/plate';
 import { reactCssPropsToCss } from '../utlis/reactCssPropsToCss';
 import { CSSProperties } from 'react';
-export const buttonNode = (
-    node: TElement,
-    children: string,
-    defaultClassNames: string,
-    styles: Record<string, CSSProperties & { hover?: CSSProperties }>
-) => {
+import { BUTTON_PLUGIN } from '../../plugins';
+
+export type ButtonStylesType = Record<string, Record<string, CSSProperties & { hover?: CSSProperties }>>;
+
+export const buttonNode = (node: TElement, children: string, defaultClassNames: string, styles: ButtonStylesType) => {
+    const buttonStyles = styles[BUTTON_PLUGIN];
     const buttonTypeString = (node.buttonStyle as string) ?? 'primary';
     const buttonType = `button${buttonTypeString.charAt(0).toUpperCase()}${buttonTypeString.slice(1)}`;
-    const buttonStyle = styles[buttonType];
+    const buttonStyle = buttonStyles[buttonType];
 
     const defaultStyles = reactCssPropsToCss(buttonStyle);
+
     return `<a href="${node.url}"
                 target="${node.target ?? '_blank'}"
                 style="${defaultStyles}"
                 class="${defaultClassNames}"
-                onmouseenter="this.setAttribute('style', '${defaultStyles} ${reactCssPropsToCss(buttonStyle.hover)}');"
+                onmouseenter="this.setAttribute('style', '${defaultStyles} ${reactCssPropsToCss(buttonStyle?.hover)}');"
                 onmouseleave="this.setAttribute('style', '${reactCssPropsToCss(buttonStyle)}');"
                 >${children}</a>`;
 };

--- a/packages/shared/src/components/RichTextEditor/serializer/serializeNodesToHtmlRecursive.ts
+++ b/packages/shared/src/components/RichTextEditor/serializer/serializeNodesToHtmlRecursive.ts
@@ -26,7 +26,7 @@ import {
 import { serializeLeafToHtml } from './utlis/serializeLeafToHtml';
 import { reactCssPropsToCss } from './utlis/reactCssPropsToCss';
 import { CSSProperties } from 'react';
-import { buttonNode } from './nodes/button';
+import { ButtonStylesType, buttonNode } from './nodes/button';
 import { linkNode } from './nodes/link';
 import { defaultNode } from './nodes/default';
 import { checkItemNode } from './nodes/checkItemNode';
@@ -56,7 +56,7 @@ type SerializeNodeToHtmlRecursiveOptions = {
 
 export const serializeNodeToHtmlRecursive = (
     node: TDescendant,
-    styles: Record<string, CSSProperties & { hover?: CSSProperties }>,
+    styles: Record<string, CSSProperties & { hover?: CSSProperties }> | ButtonStylesType,
     { mappedMentionable, nestingCount = {} }: SerializeNodeToHtmlRecursiveOptions
 ): string => {
     if (isText(node)) {
@@ -101,7 +101,7 @@ type Arguments = {
     rootNestingCount: number;
     node: TElement;
     mappedMentionable?: MappedMentionableItems;
-    styles: Record<string, CSSProperties & { hover?: CSSProperties }>;
+    styles: Record<string, CSSProperties & { hover?: CSSProperties }> | ButtonStylesType;
 };
 
 const MapNodeTypesToHtml: { [key: string]: ({ ...args }: Arguments) => string } = {
@@ -119,7 +119,8 @@ const MapNodeTypesToHtml: { [key: string]: ({ ...args }: Arguments) => string } 
     [ELEMENT_LIC]: ({ classNames, children, node }) =>
         `<p class="${classNames} ${getLicElementClassNames(node)}"><span>${children}</span></p>`,
     [ELEMENT_LINK]: ({ node, children, classNames, styles }) => linkNode(node, children, classNames, styles),
-    [ELEMENT_BUTTON]: ({ node, children, classNames, styles }) => buttonNode(node, children, classNames, styles),
+    [ELEMENT_BUTTON]: ({ node, children, classNames, styles }) =>
+        buttonNode(node, children, classNames, styles as ButtonStylesType),
     [ELEMENT_CHECK_ITEM]: ({ node, children, classNames, styles }) => checkItemNode(node, children, classNames, styles),
     [ELEMENT_MENTION]: ({ node, mappedMentionable }) => mentionHtmlNode(node, { mentionable: mappedMentionable }),
 };


### PR DESCRIPTION
Fixes an issue where a callout block would not appear in view mode, if there is a button inside the content. Ticket: https://app.clickup.com/t/2523021/TASK-7617

This was caused because the serializer didn't get the correct button styles passed down. And also because of a call to the hover property, which was undefined: 
<img width="571" alt="Bildschirmfoto 2023-06-05 um 09 26 12" src="https://github.com/Frontify/guideline-blocks/assets/11270687/3e96d2c8-9494-4d25-989a-179e0f715ae7">
