### PR TITLE
feat(CalloutBlock): adjust for light colors

### DIFF
--- a/packages/callout-block/src/CalloutBlock.spec.ct.tsx
+++ b/packages/callout-block/src/CalloutBlock.spec.ct.tsx
@@ -4,7 +4,7 @@ import { AssetDummy, withAppBridgeBlockStubs } from '@frontify/app-bridge';
 import { mount } from 'cypress/react18';
 import { CalloutBlock } from './CalloutBlock';
 import { ICON_ASSET_ID } from './settings';
-import { Alignment, Icon, Padding, Type, Width } from './types';
+import { Alignment, Appearance, Icon, Padding, Type, Width } from './types';
 
 const CalloutBlockSelector = '[data-test-id="callout-block"]';
 const RichTextEditor = '[data-test-id="rich-text-editor"]';
@@ -134,7 +134,7 @@ describe('Callout Block', () => {
         });
 
         cy.get(CalloutWrapper).should('have.css', 'background-color', 'rgba(26, 199, 211, 0.1)');
-        cy.get(HtmlContent).should('have.css', 'color', 'rgb(26, 199, 211)');
+        cy.get(HtmlContent).should('have.css', 'color', 'rgb(9, 70, 75)');
     });
 
     it('renders a callout block with the correct colors for type note', () => {
@@ -153,7 +153,7 @@ describe('Callout Block', () => {
         });
 
         cy.get(CalloutWrapper).should('have.css', 'background-color', 'rgba(246, 216, 56, 0.1)');
-        cy.get(HtmlContent).should('have.css', 'color', 'rgb(246, 216, 56)');
+        cy.get(HtmlContent).should('have.css', 'color', 'rgb(103, 88, 5)');
     });
 
     it('renders a callout block with the correct colors for type tip', () => {
@@ -234,7 +234,47 @@ describe('Callout Block', () => {
         cy.get(CalloutBlockSelector).should(
             'have.attr',
             'style',
-            '--f-theme-settings-heading1-color:rgba(246, 216, 56, 1); --f-theme-settings-heading2-color:rgba(246, 216, 56, 1); --f-theme-settings-heading3-color:rgba(246, 216, 56, 1); --f-theme-settings-heading4-color:rgba(246, 216, 56, 1); --f-theme-settings-custom1-color:rgba(246, 216, 56, 1); --f-theme-settings-custom2-color:rgba(246, 216, 56, 1); --f-theme-settings-custom3-color:rgba(246, 216, 56, 1); --f-theme-settings-body-color:rgba(246, 216, 56, 1); --f-theme-settings-quote-color:rgba(246, 216, 56, 1); --f-theme-settings-link-color:rgba(246, 216, 56, 1); --f-theme-settings-link-text-decoration:underline; color: rgb(246, 216, 56);'
+            '--f-theme-settings-heading1-color:rgb(103, 88, 5); --f-theme-settings-heading2-color:rgb(103, 88, 5); --f-theme-settings-heading3-color:rgb(103, 88, 5); --f-theme-settings-heading4-color:rgb(103, 88, 5); --f-theme-settings-custom1-color:rgb(103, 88, 5); --f-theme-settings-custom2-color:rgb(103, 88, 5); --f-theme-settings-custom3-color:rgb(103, 88, 5); --f-theme-settings-body-color:rgb(103, 88, 5); --f-theme-settings-quote-color:rgb(103, 88, 5); --f-theme-settings-link-color:rgb(103, 88, 5); --f-theme-settings-link-text-decoration:underline; color: rgb(103, 88, 5);'
         );
+    });
+
+    it('renders a callout block with light appearance', () => {
+        const [CalloutBlockWithStubs] = withAppBridgeBlockStubs(CalloutBlock, {
+            blockSettings: {
+                textValue: 'This is a note',
+                type: Type.Note,
+                appearance: Appearance.Light,
+            },
+        });
+
+        mount(<CalloutBlockWithStubs />);
+        cy.document().then((doc) => {
+            const style = doc.createElement('style');
+            style.innerHTML = ':root {--f-theme-settings-accent-color-note-color: rgba(50, 40, 145, 1);';
+            doc.head.appendChild(style);
+        });
+
+        cy.get(CalloutWrapper).should('have.css', 'background-color', 'rgba(50, 40, 145, 0.1)');
+        cy.get(HtmlContent).should('have.css', 'color', 'rgb(50, 40, 145)');
+    });
+
+    it('renders a callout block with strong appearance', () => {
+        const [CalloutBlockWithStubs] = withAppBridgeBlockStubs(CalloutBlock, {
+            blockSettings: {
+                textValue: 'This is a note',
+                type: Type.Note,
+                appearance: Appearance.Strong,
+            },
+        });
+
+        mount(<CalloutBlockWithStubs />);
+        cy.document().then((doc) => {
+            const style = doc.createElement('style');
+            style.innerHTML = ':root {--f-theme-settings-accent-color-note-color: rgba(50, 40, 145, 1);';
+            doc.head.appendChild(style);
+        });
+
+        cy.get(CalloutWrapper).should('have.css', 'background-color', 'rgb(50, 40, 145)');
+        cy.get(HtmlContent).should('have.css', 'color', 'rgb(255, 255, 255)');
     });
 });

--- a/packages/callout-block/src/CalloutBlock.tsx
+++ b/packages/callout-block/src/CalloutBlock.tsx
@@ -8,7 +8,6 @@ import {
     THEME_PREFIX,
     getDefaultPluginsWithLinkChooser,
     hasRichTextValue,
-    isDark,
     joinClassNames,
     radiusStyleMap,
     setAlpha,
@@ -16,6 +15,7 @@ import {
 import { CSSProperties, ReactElement } from 'react';
 import 'tailwindcss/tailwind.css';
 import { CalloutIcon } from './components/CalloutIcon';
+import { getTextColor } from './helpers/getTextColor';
 import { ICON_ASSET_ID } from './settings';
 import { Appearance, BlockSettings, Icon, Type, Width, alignmentMap, outerWidthMap, paddingMap } from './types';
 
@@ -33,7 +33,7 @@ export const CalloutBlock = ({ appBridge }: BlockProps): ReactElement => {
         blockSettings.width === Width.HugContents && alignmentMap[blockSettings.alignment],
     ]);
 
-    const getAccentColor = (type: Type) => {
+    const getAccentColor = (type: Type): string => {
         const style = getComputedStyle(document.body);
         switch (type) {
             case Type.Info:
@@ -47,22 +47,21 @@ export const CalloutBlock = ({ appBridge }: BlockProps): ReactElement => {
         }
     };
 
-    const customPaddingStyle = {
-        padding: blockSettings.hasCustomPadding
-            ? `${blockSettings.paddingTop} ${blockSettings.paddingRight} ${blockSettings.paddingBottom} ${blockSettings.paddingLeft}`
-            : '',
-    };
-    const color = getAccentColor(blockSettings.type);
-    const backgroundColor = blockSettings.appearance === Appearance.Strong ? color : setAlpha(0.1, color);
-
-    const defaultTextColor = isDark(color) ? 'white' : 'black';
-    const textColor = blockSettings.appearance === Appearance.Light ? color : defaultTextColor;
+    const accentColor = getAccentColor(blockSettings.type);
+    const backgroundColor = blockSettings.appearance === Appearance.Strong ? accentColor : setAlpha(0.1, accentColor);
+    const textColor = getTextColor(blockSettings.appearance, accentColor, backgroundColor);
 
     const textDivClassNames = joinClassNames([
         'tw-flex tw-items-center',
         blockSettings.width === Width.FullWidth && alignmentMap[blockSettings.alignment],
         !blockSettings.hasCustomPadding && paddingMap[blockSettings.paddingChoice],
     ]);
+
+    const customPaddingStyle = {
+        padding: blockSettings.hasCustomPadding
+            ? `${blockSettings.paddingTop} ${blockSettings.paddingRight} ${blockSettings.paddingBottom} ${blockSettings.paddingLeft}`
+            : '',
+    };
 
     const customCornerRadiusStyle = {
         borderRadius: blockSettings.hasExtendedCustomRadius

--- a/packages/callout-block/src/helpers/getTextColor.ts
+++ b/packages/callout-block/src/helpers/getTextColor.ts
@@ -1,0 +1,15 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { getReadableColor, isDark } from '@frontify/guideline-blocks-shared';
+import { Appearance } from '../types';
+
+export const getTextColor = (appearance: Appearance, color: string, backgroundColor: string): string => {
+    const isDarkColor = isDark(color);
+    const defaultTextColor = isDarkColor ? 'white' : 'black';
+
+    if (appearance === Appearance.Light) {
+        return isDarkColor ? color : getReadableColor(color, backgroundColor);
+    }
+
+    return defaultTextColor;
+};

--- a/packages/shared/src/utilities/color/getReadableColor.spec.ts
+++ b/packages/shared/src/utilities/color/getReadableColor.spec.ts
@@ -1,0 +1,32 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import tinycolor from 'tinycolor2';
+import { describe, expect, test } from 'vitest';
+import { getReadableColor } from './getReadableColor';
+
+describe('getReadableColor', () => {
+    const data = [
+        {
+            textColor: { r: 255, g: 255, b: 255 },
+            backgroundColor: { r: 0, g: 0, b: 0 },
+        },
+        {
+            textColor: { r: 255, g: 255, b: 255 },
+            backgroundColor: { r: 255, g: 255, b: 255 },
+        },
+        {
+            textColor: { r: 230, g: 230, b: 0 },
+            backgroundColor: { r: 229, g: 229, b: 10 },
+        },
+        {
+            textColor: { r: 120, g: 120, b: 120 },
+            backgroundColor: { r: 120, g: 120, b: 120, a: 0.1 },
+        },
+    ];
+
+    test.each(data)('validates against expected values', ({ textColor, backgroundColor }) => {
+        const result = getReadableColor(textColor, backgroundColor);
+        const readability = tinycolor.readability(result, backgroundColor);
+        expect(readability).toBeGreaterThan(4.5);
+    });
+});

--- a/packages/shared/src/utilities/color/getReadableColor.ts
+++ b/packages/shared/src/utilities/color/getReadableColor.ts
@@ -1,0 +1,34 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { Color } from '@frontify/guideline-blocks-settings';
+import tinycolor, { ColorInput } from 'tinycolor2';
+import { toShortRgba } from './toShortRgba';
+
+/**
+ * Returns darkened text color for a given background color, so that it is readable and has enough contrast (above 4.5)
+ *
+ * @param {Object} textColor Object of RGBA values
+ * @param {Object} backgroundColor Object of RGBA values
+ * @returns {string} To be used as css value
+ */
+
+const isRgbaLongFormat = (value: unknown): value is Color => {
+    const requiredKeys = ['red', 'green', 'blue'];
+    return typeof value === 'object' && requiredKeys.every((i) => value?.hasOwnProperty(i));
+};
+
+export const getReadableColor = (textColor: unknown, backgroundColor: unknown): string => {
+    const inputTextColor = isRgbaLongFormat(textColor) ? toShortRgba(textColor) : (textColor as ColorInput);
+    const inputBackgroundColor = isRgbaLongFormat(backgroundColor)
+        ? toShortRgba(backgroundColor)
+        : (backgroundColor as ColorInput);
+    const parsedTextColor = tinycolor(inputTextColor);
+    const parsedBackgroundColor = tinycolor(inputBackgroundColor);
+
+    // darken the text color until readability is good
+    while (tinycolor.readability(parsedTextColor, parsedBackgroundColor) < 4.5) {
+        parsedTextColor.darken(2);
+    }
+
+    return parsedTextColor.toRgbString();
+};

--- a/packages/shared/src/utilities/color/index.ts
+++ b/packages/shared/src/utilities/color/index.ts
@@ -6,3 +6,4 @@ export * from './toHexString';
 export * from './toRgbaString';
 export * from './setAlpha';
 export * from './toColorObject';
+export * from './getReadableColor';


### PR DESCRIPTION
When a light color (white, lightblue etc.) is defined in the theme settings, the text color would be unreadable in the callout block with `appearance: light` (see issue mentioned [here](https://app.clickup.com/t/2523021/TASK-7595?comment=90100014900142&threadedComment=90100014912760) and/or loom [here](https://www.loom.com/share/ab1c45bb3f3b44d4822966a24ca57c78)).

This PR adds a new utility, which returns a darkened text color with a contrast ratio of at least 4.5 to the background. Also added some test for it.