### PR TITLE
fix(CalloutBlock): text alignment

### DIFF
--- a/packages/callout-block/src/CalloutBlock.tsx
+++ b/packages/callout-block/src/CalloutBlock.tsx
@@ -52,7 +52,11 @@ export const CalloutBlock = ({ appBridge }: BlockProps): ReactElement => {
     const textColor = getTextColor(blockSettings.appearance, accentColor, backgroundColor);
 
     const textDivClassNames = joinClassNames([
-        'callout-block tw-flex tw-items-center',
+        'tw-flex tw-items-center',
+        '[&>div>*:last-child]:tw-my-0', // Remove margin from last child in view mode
+        '[&>div>*:last-child>span]:!tw-my-0',
+        '[&>div>div>*:last-child]:tw-my-0', // Remove margin from last child in edit mode
+        '[&>div>div>*:last-child>span]:!tw-my-0',
         blockSettings.width === Width.FullWidth && alignmentMap[blockSettings.alignment],
         !blockSettings.hasCustomPadding && paddingMap[blockSettings.paddingChoice],
     ]);
@@ -117,19 +121,6 @@ export const CalloutBlock = ({ appBridge }: BlockProps): ReactElement => {
                     plugins={getDefaultPluginsWithLinkChooser(appBridge)}
                 />
             </div>
-
-            {/* Hacky way to remove margin from the last element, so that the text is vertically centered in the callout block */}
-            <style>{`
-                .callout-block > div > *:last-child,
-                .callout-block > div > div > *:last-child {
-                    margin-bottom: 0;
-                }
-
-                .callout-block > div > *:last-child > span,
-                .callout-block > div > div > *:last-child > span {
-                    margin-bottom: 0 !important;
-                }
-            `}</style>
         </div>
     );
 };

--- a/packages/callout-block/src/CalloutBlock.tsx
+++ b/packages/callout-block/src/CalloutBlock.tsx
@@ -52,7 +52,7 @@ export const CalloutBlock = ({ appBridge }: BlockProps): ReactElement => {
     const textColor = getTextColor(blockSettings.appearance, accentColor, backgroundColor);
 
     const textDivClassNames = joinClassNames([
-        'tw-flex tw-items-center',
+        'callout-block tw-flex tw-items-center',
         blockSettings.width === Width.FullWidth && alignmentMap[blockSettings.alignment],
         !blockSettings.hasCustomPadding && paddingMap[blockSettings.paddingChoice],
     ]);
@@ -117,6 +117,19 @@ export const CalloutBlock = ({ appBridge }: BlockProps): ReactElement => {
                     plugins={getDefaultPluginsWithLinkChooser(appBridge)}
                 />
             </div>
+
+            {/* Hacky way to remove margin from the last element, so that the text is vertically centered in the callout block */}
+            <style>{`
+                .callout-block > div > *:last-child,
+                .callout-block > div > div > *:last-child {
+                    margin-bottom: 0;
+                }
+
+                .callout-block > div > *:last-child > span,
+                .callout-block > div > div > *:last-child > span {
+                    margin-bottom: 0 !important;
+                }
+            `}</style>
         </div>
     );
 };

--- a/packages/callout-block/src/CalloutBlock.tsx
+++ b/packages/callout-block/src/CalloutBlock.tsx
@@ -53,10 +53,14 @@ export const CalloutBlock = ({ appBridge }: BlockProps): ReactElement => {
 
     const textDivClassNames = joinClassNames([
         'tw-flex tw-items-center',
-        '[&>div>*:last-child]:tw-my-0', // Remove margin from last child in view mode
-        '[&>div>*:last-child>span]:!tw-my-0',
-        '[&>div>div>*:last-child]:tw-my-0', // Remove margin from last child in edit mode
-        '[&>div>div>*:last-child>span]:!tw-my-0',
+        '[&>div>*:first-child]:tw-mt-0', // Remove margin top from first child in view mode
+        '[&>div>*:first-child>span]:!tw-mt-0',
+        '[&>div>div>*:first-child]:tw-mt-0', // Remove margin top from first child in edit mode
+        '[&>div>div>*:first-child>span]:!tw-mt-0',
+        '[&>div>*:last-child]:tw-mb-0', // Remove margin bottom from last child in view mode
+        '[&>div>*:last-child>span]:!tw-mb-0',
+        '[&>div>div>*:last-child]:tw-mb-0', // Remove margin bottom from last child in edit mode
+        '[&>div>div>*:last-child>span]:!tw-mb-0',
         blockSettings.width === Width.FullWidth && alignmentMap[blockSettings.alignment],
         !blockSettings.hasCustomPadding && paddingMap[blockSettings.paddingChoice],
     ]);

--- a/packages/shared/src/components/RichTextEditor/SerializedText.tsx
+++ b/packages/shared/src/components/RichTextEditor/SerializedText.tsx
@@ -19,7 +19,7 @@ export const SerializedText = ({ value = '', gap, columns, show = true, plugins 
     }
 
     return html !== null ? (
-        <div data-test-id="rte-content-html" dangerouslySetInnerHTML={{ __html: html }} />
+        <div className="tw-w-full" data-test-id="rte-content-html" dangerouslySetInnerHTML={{ __html: html }} />
     ) : (
         <div className="tw-rounded-sm tw-bg-base-alt tw-animate-pulse tw-h-full tw-min-h-[10px] tw-w-full" />
     );


### PR DESCRIPTION
- Fix horizontal alignment of text, which wasn't working in view mode, because the content wasn't taking over 100% of the width
- Request from Martin: Remove margin of last text element inside the block, so that the content is also vertically centered inside the block

Before:
![Bildschirmfoto 2023-06-07 um 13 05 25](https://github.com/Frontify/guideline-blocks/assets/11270687/c93c0bad-38f0-4414-93d9-a2a7c30f6fbe)

After:
![Bildschirmfoto 2023-06-07 um 13 05 45](https://github.com/Frontify/guideline-blocks/assets/11270687/629340f9-21fa-4eb5-a585-f49590b5d69d)
