### PR TITLE
feat(CalloutBlock): adjust color logic

### DIFF
--- a/packages/callout-block/src/helpers/getTextColor.ts
+++ b/packages/callout-block/src/helpers/getTextColor.ts
@@ -4,7 +4,7 @@ import { getReadableColor, isDark } from '@frontify/guideline-blocks-shared';
 import { Appearance } from '../types';
 
 export const getTextColor = (appearance: Appearance, color: string, backgroundColor: string): string => {
-    const isDarkColor = isDark(color, 150);
+    const isDarkColor = isDark(color, 185);
     const defaultTextColor = isDarkColor ? 'white' : 'black';
 
     if (appearance === Appearance.Light) {


### PR DESCRIPTION
Adjust color logic, so that default colors in new guidelines are kept and not darkened.

Before:
<img width="832" alt="Bildschirmfoto 2023-06-14 um 10 58 32" src="https://github.com/Frontify/guideline-blocks/assets/11270687/88f4f0f6-c597-41e0-9aa4-891b97170746">

After:
<img width="845" alt="Bildschirmfoto 2023-06-14 um 10 58 21" src="https://github.com/Frontify/guideline-blocks/assets/11270687/e00569e7-fd2c-43fe-9e0c-418630406f04">
