### PR TITLE
feat(CodeSnippetBlock): adjust default styling

### DIFF
--- a/packages/code-snippet-block/src/CodeSnippetBlock.tsx
+++ b/packages/code-snippet-block/src/CodeSnippetBlock.tsx
@@ -154,7 +154,10 @@ export const CodeSnippetBlock: FC<BlockProps> = ({ appBridge }) => {
                         <button
                             data-test-id="header-copy-button"
                             className="tw-items-center tw-justify-end tw-gap-1 tw-flex"
-                            style={getStyle()}
+                            style={{
+                                ...getStyle(),
+                                color: blockSettings.theme === 'default' ? '#000000' : getStyle().color,
+                            }}
                             onClick={handleCopy}
                         >
                             {getCopyButtonText()}
@@ -169,7 +172,6 @@ export const CodeSnippetBlock: FC<BlockProps> = ({ appBridge }) => {
                     readOnly={!isEditing}
                     basicSetup={{
                         lineNumbers: withRowNumbers,
-                        foldGutter: false,
                         searchKeymap: false,
                         highlightActiveLineGutter: false,
                         highlightActiveLine: false,


### PR DESCRIPTION
Adjust styling of default theme to match the one in the gradient block, see ticket: https://app.clickup.com/t/865c454z3

Before: 
<img width="832" alt="before" src="https://github.com/Frontify/guideline-blocks/assets/11270687/a18567c7-7570-4ae9-9bc3-ecbc1d6e339c">


After:
<img width="831" alt="after" src="https://github.com/Frontify/guideline-blocks/assets/11270687/a16f1efe-8dbf-4dff-a001-f70387e4d3ad">
