### PR TITLE
feat(ImageBlock): fix ux review

### DIFF
--- a/packages/image-block/src/ImageBlock.spec.ct.tsx
+++ b/packages/image-block/src/ImageBlock.spec.ct.tsx
@@ -21,6 +21,7 @@ const ImageBlockCaption = '[data-test-id="image-caption"]';
 const PlaceholderSelector = '[data-test-id="block-inject-button"]';
 const DownloadSelector = '[data-test-id="download-button"]';
 const AttachmentsSelector = '[data-test-id="attachments-flyout-button"]';
+const ButtonsWrapper = '[data-test-id="buttons-wrapper"]';
 
 describe('Image Block', () => {
     it('renders an image block', () => {
@@ -208,5 +209,51 @@ describe('Image Block', () => {
         });
         mount(<ImageBlockWithStubs />);
         cy.get(ImageBlockImageWrapperSelector).should('have.class', mapAlignmentClasses[Alignment.Right]);
+    });
+
+    it('should add padding to buttons when padding is added to image', () => {
+        const [ImageBlockWithStubs] = withAppBridgeBlockStubs(ImageBlock, {
+            blockSettings: {
+                hasCustomPadding: true,
+                paddingCustom: '16px',
+            },
+            blockAssets: {
+                [IMAGE_ID]: [AssetDummy.with(1)],
+            },
+        });
+        mount(<ImageBlockWithStubs />);
+        cy.get(ButtonsWrapper).should('have.css', 'padding-top', '16px').and('have.css', 'padding-right', '16px');
+    });
+
+    it('should add padding to buttons when border is added to image', () => {
+        const [ImageBlockWithStubs] = withAppBridgeBlockStubs(ImageBlock, {
+            blockSettings: {
+                hasBorder: true,
+                borderWidth: '12px',
+            },
+            blockAssets: {
+                [IMAGE_ID]: [AssetDummy.with(1)],
+            },
+        });
+        mount(<ImageBlockWithStubs />);
+        cy.get(ButtonsWrapper).should('have.css', 'padding-top', '12px').and('have.css', 'padding-right', '12px');
+    });
+
+    it('should add padding to buttons when padding and border is added to image', () => {
+        const [ImageBlockWithStubs] = withAppBridgeBlockStubs(ImageBlock, {
+            blockSettings: {
+                hasBorder: true,
+                borderWidth: '12px',
+                borderColor: { r: 0, g: 0, b: 255 },
+                borderStyle: 'solid',
+                hasCustomPadding: true,
+                paddingCustom: '16px',
+            },
+            blockAssets: {
+                [IMAGE_ID]: [AssetDummy.with(1)],
+            },
+        });
+        mount(<ImageBlockWithStubs />);
+        cy.get(ButtonsWrapper).should('have.css', 'padding-top', '28px').and('have.css', 'padding-right', '28px');
     });
 });

--- a/packages/image-block/src/components/Image.tsx
+++ b/packages/image-block/src/components/Image.tsx
@@ -12,7 +12,7 @@ import {
 import { useFocusRing } from '@react-aria/focus';
 import { AppBridgeBlock, Asset, usePrivacySettings } from '@frontify/app-bridge';
 import { ATTACHMENTS_ASSET_ID } from '../settings';
-import { getImageStyle } from './helpers';
+import { getImageStyle, getTotalImagePadding } from './helpers';
 import { FOCUS_STYLE } from '@frontify/fondue';
 
 type ImageProps = {
@@ -78,9 +78,9 @@ export const Image = ({ image, appBridge, blockSettings, isEditing }: ImageProps
     return (
         <div
             data-test-id="image-block-img-wrapper"
-            className={joinClassNames(['tw-relative tw-flex tw-h-auto', mapAlignmentClasses[blockSettings.alignment]])}
+            className={joinClassNames(['tw-flex tw-h-auto', mapAlignmentClasses[blockSettings.alignment]])}
         >
-            <div className="tw-flex tw-items-start">
+            <div className="tw-relative ">
                 <ImageComponent
                     appBridge={appBridge}
                     blockSettings={blockSettings}
@@ -88,7 +88,7 @@ export const Image = ({ image, appBridge, blockSettings, isEditing }: ImageProps
                     isEditing={isEditing}
                 />
                 <div className="tw-absolute tw-top-2 tw-right-2 tw-z-50">
-                    <div className="tw-flex tw-gap-2">
+                    <div className="tw-flex tw-gap-2" style={getTotalImagePadding(blockSettings)}>
                         {isDownloadable(blockSettings.security, blockSettings.downloadable, assetDownloadEnabled) && (
                             <DownloadButton onDownload={() => downloadAsset(image)} />
                         )}

--- a/packages/image-block/src/components/Image.tsx
+++ b/packages/image-block/src/components/Image.tsx
@@ -81,6 +81,12 @@ export const Image = ({ image, appBridge, blockSettings, isEditing }: ImageProps
             className={joinClassNames(['tw-relative tw-flex tw-h-auto', mapAlignmentClasses[blockSettings.alignment]])}
         >
             <div className="tw-flex tw-items-start">
+                <ImageComponent
+                    appBridge={appBridge}
+                    blockSettings={blockSettings}
+                    image={image}
+                    isEditing={isEditing}
+                />
                 <div className="tw-absolute tw-top-2 tw-right-2 tw-z-50">
                     <div className="tw-flex tw-gap-2">
                         {isDownloadable(blockSettings.security, blockSettings.downloadable, assetDownloadEnabled) && (
@@ -99,12 +105,6 @@ export const Image = ({ image, appBridge, blockSettings, isEditing }: ImageProps
                         />
                     </div>
                 </div>
-                <ImageComponent
-                    appBridge={appBridge}
-                    blockSettings={blockSettings}
-                    image={image}
-                    isEditing={isEditing}
-                />
             </div>
         </div>
     );

--- a/packages/image-block/src/components/Image.tsx
+++ b/packages/image-block/src/components/Image.tsx
@@ -88,7 +88,11 @@ export const Image = ({ image, appBridge, blockSettings, isEditing }: ImageProps
                     isEditing={isEditing}
                 />
                 <div className="tw-absolute tw-top-2 tw-right-2 tw-z-50">
-                    <div className="tw-flex tw-gap-2" style={getTotalImagePadding(blockSettings)}>
+                    <div
+                        className="tw-flex tw-gap-2"
+                        data-test-id="buttons-wrapper"
+                        style={getTotalImagePadding(blockSettings)}
+                    >
                         {isDownloadable(blockSettings.security, blockSettings.downloadable, assetDownloadEnabled) && (
                             <DownloadButton onDownload={() => downloadAsset(image)} />
                         )}

--- a/packages/image-block/src/components/helpers.ts
+++ b/packages/image-block/src/components/helpers.ts
@@ -74,6 +74,19 @@ export const getCaptionPlugins = (appBridge: AppBridgeBlock) =>
             new ResetFormattingPlugin(),
         ]);
 
+export const getTotalImagePadding = (blockSettings: Settings): CSSProperties => {
+    const border = blockSettings.hasBorder ? blockSettings.borderWidth?.replace('px', '') : undefined;
+    const totalPadding = Number(border ?? 0) + Number(getPadding(blockSettings)?.replace('px', ''));
+
+    return {
+        paddingTop: `${totalPadding}px`,
+        paddingRight: `${totalPadding}px`,
+    };
+};
+
+const getPadding = (blockSettings: Settings): string =>
+    blockSettings.hasCustomPadding ? blockSettings.paddingCustom : paddingValues[blockSettings.paddingChoice];
+
 export const getImageStyle = (blockSettings: Settings, width: string): CSSProperties => {
     const borderRadius = blockSettings.hasRadius_cornerRadius
         ? blockSettings.radiusValue_cornerRadius
@@ -82,12 +95,8 @@ export const getImageStyle = (blockSettings: Settings, width: string): CSSProper
         ? `${blockSettings.borderWidth} ${blockSettings.borderStyle} ${toRgbaString(blockSettings.borderColor)}`
         : undefined;
 
-    const padding = blockSettings.hasCustomPadding
-        ? blockSettings.paddingCustom
-        : paddingValues[blockSettings.paddingChoice];
-
     return {
-        padding,
+        padding: getPadding(blockSettings),
         border,
         maxWidth: width,
         borderRadius: borderRadius ?? radiusValues[CornerRadius.None],

--- a/packages/image-block/src/components/helpers.ts
+++ b/packages/image-block/src/components/helpers.ts
@@ -76,7 +76,7 @@ export const getCaptionPlugins = (appBridge: AppBridgeBlock) =>
 
 export const getTotalImagePadding = (blockSettings: Settings): CSSProperties => {
     const border = blockSettings.hasBorder ? blockSettings.borderWidth?.replace('px', '') : undefined;
-    const totalPadding = Number(border ?? 0) + Number(getPadding(blockSettings)?.replace('px', ''));
+    const totalPadding = Number(border ?? 0) + Number(getPadding(blockSettings)?.replace('px', '') ?? 0);
 
     return {
         paddingTop: `${totalPadding}px`,


### PR DESCRIPTION
tickets: [image block general](https://app.clickup.com/t/86783gd9e) and [accessibility](https://app.clickup.com/t/86782x7u0)

* Attachment button same size as download button
* Buttons now always stays on top of image (despite it's padding or image size)
* Focusing order corrected