### PR TITLE
fix(shared): margin causes wrong outline

### DIFF
--- a/packages/shared/src/components/Attachments/Attachments.tsx
+++ b/packages/shared/src/components/Attachments/Attachments.tsx
@@ -146,10 +146,11 @@ export const Attachments = ({
                                 placement={FlyoutPlacement.BottomRight}
                                 onOpenChange={(isOpen) => setIsFlyoutOpen(!!draggedItem ? true : isOpen)}
                                 isOpen={isFlyoutOpen}
+                                hug={false}
                                 fitContent
                                 legacyFooter={false}
                                 trigger={
-                                    <div className="tw-flex -tw-mx-3 tw-text-[13px] tw-font-body tw-items-center tw-gap-1 tw-rounded-full tw-bg-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-inverse-hover active:tw-bg-box-neutral-strong-inverse-pressed tw-text-box-neutral-strong tw-outline tw-outline-1 tw-outline-offset-[1px] tw-p-[6px] tw-outline-line">
+                                    <div className="tw-flex tw-text-[13px] tw-font-body tw-items-center tw-gap-1 tw-rounded-full tw-bg-box-neutral-strong-inverse hover:tw-bg-box-neutral-strong-inverse-hover active:tw-bg-box-neutral-strong-inverse-pressed tw-text-box-neutral-strong tw-outline tw-outline-1 tw-outline-offset-[1px] tw-p-[6px] tw-outline-line">
                                         <IconPaperclip16 />
                                         <div>{items.length > 0 ? items.length : 'Add'}</div>
                                         <IconCaretDown12 />


### PR DESCRIPTION
Before/after:

![image](https://github.com/Frontify/guideline-blocks/assets/30796791/5b7d9165-857f-45f1-8568-1952acddee43)

![image](https://github.com/Frontify/guideline-blocks/assets/30796791/178237bb-f814-4e7a-84c7-ae990cb1c1d7)
