### PR TITLE
feat(shared): block item wrapper overlaps on top

### DIFF
--- a/packages/shared/src/components/BlockItemWrapper/BlockItemWrapper.tsx
+++ b/packages/shared/src/components/BlockItemWrapper/BlockItemWrapper.tsx
@@ -56,7 +56,7 @@ export const BlockItemWrapper = ({
                     bottom: `calc(100% - ${2 + outlineOffset}px)`,
                 }}
                 className={joinClassNames([
-                    'tw-absolute tw-bottom-[calc(100%-4px)] tw-right-[-3px] tw-w-full tw-opacity-0 tw-z-10',
+                    'tw-pointer-events-none tw-absolute tw-bottom-[calc(100%-4px)] tw-right-[-3px] tw-w-full tw-opacity-0 tw-z-10',
                     'group-hover:tw-opacity-100 group-focus:tw-opacity-100 focus-within:tw-opacity-100',
                     (isFlyoutOpen || shouldBeShown) && 'tw-opacity-100',
                 ])}

--- a/packages/shared/src/components/BlockItemWrapper/Toolbar.tsx
+++ b/packages/shared/src/components/BlockItemWrapper/Toolbar.tsx
@@ -16,7 +16,7 @@ import { DEFAULT_DRAGGING_TOOLTIP, DEFAULT_DRAG_TOOLTIP } from './constants';
 const Toolbar = ({ items, flyoutItems, isFlyoutOpen, setIsFlyoutOpen, isDragging, isFlyoutDisabled }: ToolbarProps) => {
     return (
         <div data-test-id="block-item-wrapper-toolbar" className="tw-flex tw-justify-end">
-            <div className="tw-bg-white tw-text-box-selected-inverse tw-flex tw-flex-shrink-0 tw-gap-[2px] tw-px-[1px] tw-spacing tw-items-center tw-h-7 tw-self-start tw-border tw-border-box-selected-inverse tw-rounded">
+            <div className="tw-bg-white tw-text-box-selected-inverse tw-pointer-events-auto tw-flex tw-flex-shrink-0 tw-gap-[2px] tw-px-[1px] tw-spacing tw-items-center tw-h-7 tw-self-start tw-border tw-border-box-selected-inverse tw-rounded">
                 {items.map((item, i) =>
                     'draggableProps' in item ? (
                         <Tooltip


### PR DESCRIPTION
![image](https://github.com/Frontify/guideline-blocks/assets/30796791/79675e71-d72f-49aa-babe-a6b463cc5911)

Previously the BlockItemWrapper toolbar overlapped the 100% of the width, so clicking the "Test description" was not possible, because the toolbar was on top of it.

I added pointer-events-none to the whole div, and added pointer-events-auto to the toolbar inside it, so only that part is clickable.