### PR TITLE
chore: renovate fondue

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,11 @@
         {
             "updateTypes": ["major"],
             "labels": ["dependencies", "dependencies-major"]
+        },
+        {
+            "matchPackagePatterns": ["@frontify/fondue"],
+            "groupName": "fondue",
+            "recreateWhen": "never"
         }
     ]
 }


### PR DESCRIPTION
As it suggest to downgrade we should remove fondue from the renovate config, so it doesn't opens its downgrade PR's