### PR TITLE
chore: appBridge deprecation notices

### DIFF
--- a/examples/asset-upload/src/ExampleAssetUploadBlock.tsx
+++ b/examples/asset-upload/src/ExampleAssetUploadBlock.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import type { Asset } from '@frontify/app-bridge';
-import { useAssetUpload, useBlockAssets, useFileInput } from '@frontify/app-bridge';
+import { useAssetChooser, useAssetUpload, useBlockAssets, useFileInput } from '@frontify/app-bridge';
 import { Button } from '@frontify/fondue';
 
 import { BlockProps } from '@frontify/guideline-blocks-settings';
@@ -11,6 +11,7 @@ import { IMAGE_SETTING_ID } from './settings';
 
 export const ExampleAssetUploadBlock = ({ appBridge }: BlockProps): ReactElement => {
     const { blockAssets, updateAssetIdsFromKey } = useBlockAssets(appBridge);
+    const { openAssetChooser, closeAssetChooser } = useAssetChooser(appBridge);
 
     // Manual upload demo
     const [loading, setLoading] = useState(false);
@@ -40,11 +41,11 @@ export const ExampleAssetUploadBlock = ({ appBridge }: BlockProps): ReactElement
 
     // Asset chooser demo
     const onOpenAssetChooser = () => {
-        appBridge.openAssetChooser(
+        openAssetChooser(
             (result: Asset[]) => {
                 const resultId = result[0].id;
                 updateAssetIdsFromKey(IMAGE_SETTING_ID, [resultId]);
-                appBridge.closeAssetChooser();
+                closeAssetChooser();
             },
             {
                 selectedValueId: blockAssets[IMAGE_SETTING_ID]?.[0]?.id,

--- a/packages/asset-kit-block/src/components/AssetSelection.tsx
+++ b/packages/asset-kit-block/src/components/AssetSelection.tsx
@@ -4,7 +4,7 @@ import { BlockInjectButton } from '@frontify/guideline-blocks-settings';
 import { IconPlus24 } from '@frontify/fondue';
 import { useEffect, useState } from 'react';
 import { ASSET_SETTINGS_ID } from '../settings';
-import { AssetChooserObjectType, useAssetUpload, useFileInput } from '@frontify/app-bridge';
+import { AssetChooserObjectType, useAssetChooser, useAssetUpload, useFileInput } from '@frontify/app-bridge';
 import { AssetSelectionProps } from '../types';
 
 export const AssetSelection = ({
@@ -15,6 +15,7 @@ export const AssetSelection = ({
     saveDownloadUrl,
     currentAssets,
 }: AssetSelectionProps) => {
+    const { openAssetChooser, closeAssetChooser } = useAssetChooser(appBridge);
     const [openFileDialog, { selectedFiles }] = useFileInput({ multiple: true });
     const [droppedFiles, setDroppedFiles] = useState<FileList | null>(null);
     const [uploadFile, { results: uploadResults, doneAll }] = useAssetUpload({
@@ -22,13 +23,13 @@ export const AssetSelection = ({
     });
 
     const onOpenAssetChooser = () => {
-        appBridge.openAssetChooser(
+        openAssetChooser(
             (assetsObject) => {
                 setIsUploadingAssets(true);
                 const assetsIds = Array.from(assetsObject).map((asset) => asset.id);
                 saveDownloadUrl('');
                 addAssetIdsToKey(ASSET_SETTINGS_ID, assetsIds).then(() => setIsUploadingAssets(false));
-                appBridge.closeAssetChooser();
+                closeAssetChooser();
             },
             {
                 multiSelection: true,

--- a/packages/asset-kit-block/src/components/ThumbnailItem.tsx
+++ b/packages/asset-kit-block/src/components/ThumbnailItem.tsx
@@ -4,22 +4,29 @@ import { useEffect, useState } from 'react';
 import { Settings, ThumbnailItemProps } from '../types';
 import { IconArrowCircleUp20, IconImageStack20, IconTrashBin16, LoadingCircle } from '@frontify/fondue';
 import { BlockItemWrapper } from '@frontify/guideline-blocks-settings';
-import { AssetChooserObjectType, useAssetUpload, useBlockSettings, useFileInput } from '@frontify/app-bridge';
+import {
+    AssetChooserObjectType,
+    useAssetChooser,
+    useAssetUpload,
+    useBlockSettings,
+    useFileInput,
+} from '@frontify/app-bridge';
 import { getSmallPreviewUrl, thumbnailStyle } from '../helpers';
 
 export const ThumbnailItem = ({ asset, isEditing, appBridge, onRemoveAsset, onReplaceAsset }: ThumbnailItemProps) => {
     const [isUploading, setIsUploading] = useState(false);
     const [blockSettings] = useBlockSettings<Settings>(appBridge);
+    const { openAssetChooser, closeAssetChooser } = useAssetChooser(appBridge);
     const [openFileDialog, { selectedFiles }] = useFileInput({ accept: 'image/*' });
     const [uploadFile, { results: uploadResults, doneAll }] = useAssetUpload({
         onUploadProgress: () => !isUploading && setIsUploading(true),
     });
 
-    const openAssetChooser = () => {
-        appBridge.openAssetChooser(
+    const onOpenAssetChooser = () => {
+        openAssetChooser(
             async (result) => {
                 onReplaceAsset(asset.id, result[0].id);
-                appBridge.closeAssetChooser();
+                closeAssetChooser();
             },
             {
                 objectTypes: [AssetChooserObjectType.ImageVideo],
@@ -54,7 +61,7 @@ export const ThumbnailItem = ({ asset, isEditing, appBridge, onRemoveAsset, onRe
                     {
                         title: 'Replace with asset',
                         icon: <IconImageStack20 />,
-                        onClick: openAssetChooser,
+                        onClick: onOpenAssetChooser,
                     },
                 ],
             ]}

--- a/packages/audio-block/src/AudioBlock.tsx
+++ b/packages/audio-block/src/AudioBlock.tsx
@@ -5,6 +5,7 @@ import {
     AssetChooserObjectType,
     FileExtension,
     FileExtensionSets,
+    useAssetChooser,
     useAssetUpload,
     useBlockAssets,
     useBlockSettings,
@@ -38,6 +39,7 @@ export const AudioBlock = ({ appBridge }: BlockProps) => {
     const [isLoading, setIsLoading] = useState(false);
     const isEditing = useEditorState(appBridge);
     const [blockSettings, setBlockSettings] = useBlockSettings<BlockSettings>(appBridge);
+    const { openAssetChooser, closeAssetChooser } = useAssetChooser(appBridge);
     const { blockAssets, deleteAssetIdsFromKey, updateAssetIdsFromKey } = useBlockAssets(appBridge);
     const [openFileDialog, { selectedFiles }] = useFileInput({ accept: 'audio/*' });
     const { assetDownloadEnabled } = usePrivacySettings(appBridge);
@@ -56,12 +58,12 @@ export const AudioBlock = ({ appBridge }: BlockProps) => {
         setIsLoading(false);
     };
 
-    const openAssetChooser = () => {
-        appBridge.openAssetChooser(
+    const onOpenAssetChooser = () => {
+        openAssetChooser(
             async (result) => {
                 setIsLoading(true);
                 updateAudioAsset(result[0]);
-                appBridge.closeAssetChooser();
+                closeAssetChooser();
             },
             {
                 selectedValueId: blockAssets[AUDIO_ID]?.[0]?.id,
@@ -115,14 +117,14 @@ export const AudioBlock = ({ appBridge }: BlockProps) => {
                     isEditing={isEditing}
                     isLoading={isLoading}
                     openFileDialog={openFileDialog}
-                    openAssetChooser={openAssetChooser}
+                    openAssetChooser={onOpenAssetChooser}
                     onRemoveAsset={onRemoveAsset}
                 />
             ) : (
                 isEditing && (
                     <UploadPlaceholder
                         onUploadClick={openFileDialog}
-                        onAssetChooseClick={openAssetChooser}
+                        onAssetChooseClick={onOpenAssetChooser}
                         onFilesDrop={onFilesDrop}
                         loading={isLoading}
                     />

--- a/packages/compare-slider-block/src/CompareSliderBlock.tsx
+++ b/packages/compare-slider-block/src/CompareSliderBlock.tsx
@@ -6,6 +6,7 @@ import { ReactCompareSlider } from 'react-compare-slider';
 import {
     AssetChooserObjectType,
     FileExtensionSets,
+    useAssetChooser,
     useAssetUpload,
     useBlockAssets,
     useBlockSettings,
@@ -35,6 +36,7 @@ import { BlockProps, THEME_PREFIX, radiusStyleMap, toRgbaString } from '@frontif
 
 export const CompareSliderBlock = ({ appBridge }: BlockProps) => {
     const [blockSettings, setBlockSettings] = useBlockSettings<BlockSettings>(appBridge);
+    const { openAssetChooser, closeAssetChooser } = useAssetChooser(appBridge);
     const { blockAssets, updateAssetIdsFromKey, deleteAssetIdsFromKey } = useBlockAssets(appBridge);
     const isEditing = useEditorState(appBridge);
     const [openFileDialog, { selectedFiles }] = useFileInput({ accept: 'image/*', multiple: false });
@@ -165,8 +167,8 @@ export const CompareSliderBlock = ({ appBridge }: BlockProps) => {
         deleteAssetIdsFromKey(key, [id]);
     };
 
-    const openAssetChooser = (slot: SliderImageSlot) => {
-        appBridge.openAssetChooser(
+    const onOpenAssetChooser = (slot: SliderImageSlot) => {
+        openAssetChooser(
             async (result) => {
                 if (slot === SliderImageSlot.First) {
                     setIsFirstAssetLoading(true);
@@ -174,7 +176,7 @@ export const CompareSliderBlock = ({ appBridge }: BlockProps) => {
                     setIsSecondAssetLoading(true);
                 }
                 updateAssetIdsFromKey(slot === SliderImageSlot.First ? 'firstAsset' : 'secondAsset', [result[0].id]);
-                appBridge.closeAssetChooser();
+                closeAssetChooser();
             },
             {
                 objectTypes: [AssetChooserObjectType.ImageVideo],
@@ -312,7 +314,7 @@ export const CompareSliderBlock = ({ appBridge }: BlockProps) => {
                     alignment={alignment}
                     isFirstAssetLoading={isFirstAssetLoading}
                     isSecondAssetLoading={isSecondAssetLoading}
-                    openAssetChooser={openAssetChooser}
+                    openAssetChooser={onOpenAssetChooser}
                     startDragAndDropUpload={startDragAndDropUpload}
                     startFileDialogUpload={startFileDialogUpload}
                     firstAssetPreviewUrl={firstAssetPreviewUrl}
@@ -354,7 +356,7 @@ export const CompareSliderBlock = ({ appBridge }: BlockProps) => {
                     {isEditing && (
                         <EditorOverlay
                             alignment={alignment}
-                            openAssetChooser={openAssetChooser}
+                            openAssetChooser={onOpenAssetChooser}
                             startFileDialogUpload={startFileDialogUpload}
                             firstAsset={firstAsset}
                             secondAsset={secondAsset}

--- a/packages/dos-donts-block/src/DoDontItem.tsx
+++ b/packages/dos-donts-block/src/DoDontItem.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { useSortable } from '@dnd-kit/sortable';
-import { Asset, useAssetUpload, useBlockAssets, useFileInput } from '@frontify/app-bridge';
+import { Asset, useAssetChooser, useAssetUpload, useBlockAssets, useFileInput } from '@frontify/app-bridge';
 import {
     IconArrowCircleUp20,
     IconArrowMove16,
@@ -74,6 +74,7 @@ export const DoDontItem = React.forwardRef<HTMLDivElement, DoDontItemProps>(
         const doColorString = toRgbaString(doColor);
         const dontColorString = toRgbaString(dontColor);
         const { blockAssets, updateAssetIdsFromKey } = useBlockAssets(appBridge);
+        const { openAssetChooser, closeAssetChooser } = useAssetChooser(appBridge);
         const { itemImages } = blockAssets;
         const titleRef = useRef<HTMLTextAreaElement>(null);
 
@@ -96,7 +97,7 @@ export const DoDontItem = React.forwardRef<HTMLDivElement, DoDontItemProps>(
         };
 
         const onOpenAssetChooser = () => {
-            appBridge.openAssetChooser(
+            openAssetChooser(
                 (result: Asset[]) => {
                     setIsUploadLoading(true);
                     const imageId = result[0]?.id;
@@ -106,7 +107,7 @@ export const DoDontItem = React.forwardRef<HTMLDivElement, DoDontItemProps>(
                         onChangeItem(id, imageId, 'imageId');
                         setIsUploadLoading(false);
                     });
-                    appBridge.closeAssetChooser();
+                    closeAssetChooser();
                 },
                 {
                     multiSelection: false,

--- a/packages/dos-donts-block/src/DosDontsBlock.tsx
+++ b/packages/dos-donts-block/src/DosDontsBlock.tsx
@@ -4,6 +4,7 @@ import {
     Asset,
     AssetChooserObjectType,
     rgbStringToRgbObject,
+    useAssetChooser,
     useAssetUpload,
     useBlockAssets,
     useBlockSettings,
@@ -45,6 +46,7 @@ export const DONT_COLOR_DEFAULT_VALUE = { red: 255, green: 55, blue: 90, alpha: 
 export const DosDontsBlock: FC<BlockProps> = ({ appBridge }) => {
     const [blockSettings, setBlockSettings] = useBlockSettings<Settings>(appBridge);
     const { blockAssets, updateAssetIdsFromKey } = useBlockAssets(appBridge);
+    const { openAssetChooser, closeAssetChooser } = useAssetChooser(appBridge);
     const isEditing = useEditorState(appBridge);
     const wrapperRef = useRef<HTMLDivElement>(null);
     const [isUploadLoading, setIsUploadLoading] = useState(false);
@@ -297,11 +299,11 @@ export const DosDontsBlock: FC<BlockProps> = ({ appBridge }) => {
         borderWidth,
     });
 
-    const openAssetChooser = () => {
-        appBridge.openAssetChooser(
+    const onOpenAssetChooser = () => {
+        openAssetChooser(
             (result) => {
                 setSelectedAssets(result);
-                appBridge.closeAssetChooser();
+                closeAssetChooser();
             },
             {
                 multiSelection: true,
@@ -361,7 +363,7 @@ export const DosDontsBlock: FC<BlockProps> = ({ appBridge }) => {
                                 secondaryLabel="Or drop them here"
                                 icon={<IconPlus20 />}
                                 onUploadClick={openFileDialog}
-                                onAssetChooseClick={openAssetChooser}
+                                onAssetChooseClick={onOpenAssetChooser}
                                 onDrop={setSelectedFiles}
                                 isLoading={isUploadLoading}
                             />

--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -4,6 +4,7 @@ import {
     Asset,
     AssetChooserObjectType,
     FileExtensionSets,
+    useAssetChooser,
     useAssetUpload,
     useBlockAssets,
     useBlockSettings,
@@ -38,6 +39,7 @@ import { UploadPlaceholder } from './components/UploadPlaceholder';
 
 export const ImageBlock = ({ appBridge }: BlockProps) => {
     const [blockSettings, setBlockSettings] = useBlockSettings<Settings>(appBridge);
+    const { openAssetChooser, closeAssetChooser } = useAssetChooser(appBridge);
     const isEditing = useEditorState(appBridge);
     const blockId = appBridge.getBlockId().toString();
     const [showAltTextMenu, setShowAltTextMenu] = useState(false);
@@ -59,12 +61,12 @@ export const ImageBlock = ({ appBridge }: BlockProps) => {
         setIsLoading(false);
     };
 
-    const openAssetChooser = () => {
-        appBridge.openAssetChooser(
+    const onOpenAssetChooser = () => {
+        openAssetChooser(
             async (result) => {
                 setIsLoading(true);
                 updateImage(result[0]);
-                appBridge.closeAssetChooser();
+                closeAssetChooser();
             },
             {
                 selectedValueId: blockAssets[IMAGE_ID]?.[0]?.id,
@@ -136,7 +138,7 @@ export const ImageBlock = ({ appBridge }: BlockProps) => {
                                 {
                                     title: 'Replace with asset',
                                     icon: <IconImageStack20 />,
-                                    onClick: openAssetChooser,
+                                    onClick: onOpenAssetChooser,
                                 },
                             ],
                             [
@@ -177,7 +179,7 @@ export const ImageBlock = ({ appBridge }: BlockProps) => {
                             loading={isLoading}
                             onUploadClick={openFileDialog}
                             onFilesDrop={onFilesDrop}
-                            onAssetChooseClick={openAssetChooser}
+                            onAssetChooseClick={onOpenAssetChooser}
                         />
                     )
                 )}

--- a/packages/image-block/src/components/Image.tsx
+++ b/packages/image-block/src/components/Image.tsx
@@ -10,7 +10,7 @@ import {
 } from '@frontify/guideline-blocks-settings';
 import { downloadAsset } from '@frontify/guideline-blocks-shared';
 import { useFocusRing } from '@react-aria/focus';
-import { AppBridgeBlock, Asset, usePrivacySettings } from '@frontify/app-bridge';
+import { AppBridgeBlock, Asset, useAssetViewer, usePrivacySettings } from '@frontify/app-bridge';
 import { ATTACHMENTS_ASSET_ID } from '../settings';
 import { getImageStyle, getTotalImagePadding } from './helpers';
 import { FOCUS_STYLE } from '@frontify/fondue';
@@ -23,6 +23,7 @@ type ImageProps = {
 };
 
 export const ImageComponent = ({ image, blockSettings, isEditing, appBridge }: ImageProps) => {
+    const { open } = useAssetViewer(appBridge);
     const link = blockSettings?.hasLink && blockSettings?.linkObject?.link && blockSettings?.linkObject;
     const imageStyle = getImageStyle(blockSettings, image.width);
     const { isFocused, focusProps } = useFocusRing();
@@ -59,7 +60,7 @@ export const ImageComponent = ({ image, blockSettings, isEditing, appBridge }: I
                             {Image}
                         </a>
                     ) : (
-                        <button {...props} onClick={() => appBridge.openAssetViewer(image.token)}>
+                        <button {...props} onClick={() => open(image)}>
                             {Image}
                         </button>
                     )}

--- a/packages/thumbnail-grid-block/src/ThumbnailGridBlock.tsx
+++ b/packages/thumbnail-grid-block/src/ThumbnailGridBlock.tsx
@@ -11,6 +11,7 @@ import {
     Asset,
     AssetChooserObjectType,
     FileExtensionSets,
+    useAssetChooser,
     useAssetUpload,
     useBlockAssets,
     useBlockSettings,
@@ -27,7 +28,7 @@ import { Grid, ImageWrapper, Item, RichTextEditors, SortableItem, UploadPlacehol
 
 export const ThumbnailGridBlock = ({ appBridge }: BlockProps) => {
     const isEditing = useEditorState(appBridge);
-
+    const { openAssetChooser, closeAssetChooser } = useAssetChooser(appBridge);
     const [blockSettings, setBlockSettings] = useBlockSettings<Settings>(appBridge);
     const [itemsState, setItemsState] = useState(blockSettings.items ?? []);
     const [draggedItem, setDraggedItem] = useState<Thumbnail | undefined>(undefined);
@@ -36,11 +37,12 @@ export const ThumbnailGridBlock = ({ appBridge }: BlockProps) => {
     const [openFileDialog, { selectedFiles }] = useFileInput({ accept: 'image/*', multiple: true });
     const [uploadId, setUploadId] = useState<string | undefined>(undefined);
     const [uploadFile, { results: uploadResults, doneAll }] = useAssetUpload();
-    const openAssetChooser = (id?: string) => {
-        appBridge.openAssetChooser(
+
+    const onOpenAssetChooser = (id?: string) => {
+        openAssetChooser(
             async (uploadResults: Asset[]) => {
                 updateImages([...uploadResults], id);
-                appBridge.closeAssetChooser();
+                closeAssetChooser();
             },
             {
                 multiSelection: id ? false : true,
@@ -155,7 +157,7 @@ export const ThumbnailGridBlock = ({ appBridge }: BlockProps) => {
         showGrabHandle: isEditing && itemsState.length > 1,
         setUploadedId: setUploadId,
         onFilesDrop,
-        openAssetChooser,
+        openAssetChooser: onOpenAssetChooser,
         openFileDialog,
         onRemoveAsset,
         updateItemWith,
@@ -213,7 +215,7 @@ export const ThumbnailGridBlock = ({ appBridge }: BlockProps) => {
                             isLoading={loadingIds.includes('placeholder')}
                             openFileDialog={openFileDialog}
                             onFilesDrop={onFilesDrop}
-                            openAssetChooser={openAssetChooser}
+                            openAssetChooser={onOpenAssetChooser}
                         />
                     </ImageWrapper>
                     <RichTextEditors isEditing={isEditing} updateItemWith={updateItemWith} appBridge={appBridge} />


### PR DESCRIPTION
change all blocks that used deprecated function of the `AppBridge`, so the use the hooks as it should be 