### PR TITLE
fix(AssetKitBlock): tailwind styles were overriden

### DIFF
--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -95,83 +95,87 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
         currentAssets.length === 0;
 
     return (
-        <div
-            data-test-id="asset-kit-block"
-            className={joinClassNames([
-                'tw-w-full tw-space-y-8',
-                (hasBorder_blocks || hasBackgroundBlocks) && 'tw-p-5 sm:tw-p-8',
-            ])}
-            style={{
-                ...blockStyle(blockSettings),
-            }}
-        >
-            <div className="sm:tw-flex tw-gap-8 tw-space-y-3 md:tw-space-y-0">
-                <InformationSection
-                    description={description}
-                    isEditing={isEditing}
-                    setBlockSettings={setBlockSettings}
-                    title={title}
-                    appBridge={appBridge}
-                />
-                <div className="tw-flex-none">
-                    <button
-                        data-test-id="asset-kit-block-download-button"
-                        disabled={isButtonDisabled}
-                        onClick={isEditing ? undefined : startDownload}
-                        onMouseEnter={() => setButtonHover(true)}
-                        onMouseLeave={() => setButtonHover(false)}
-                        style={{
-                            ...BlockStyles.buttonPrimary,
-                            ...(buttonHover ? BlockStyles.buttonPrimary?.hover : null),
-                            ...(isButtonDisabled ? { opacity: 0.5 } : null),
-                        }}
-                    >
-                        <RichTextEditor
-                            id="asset-kit-block-download-button-text"
-                            value={
-                                hasRichTextValue(buttonText) ? buttonText : convertToRteValue('p', 'Download package')
-                            }
-                            isEditing={isEditing}
-                            plugins={new PluginComposer({ noToolbar: true }).setPlugin()}
-                            onTextChange={(buttonText) => setBlockSettings({ buttonText })}
-                        />
-                        <span
-                            data-test-id="asset-kit-block-screen-reader"
-                            ref={screenReaderRef}
-                            role="status"
-                            className="tw-absolute -tw-left-[10000px] tw-top-auto tw-w-1 tw-h-1 tw-overflow-hidden"
-                        />
-                    </button>
-                </div>
-            </div>
-
-            {![BulkDownloadState.Init, BulkDownloadState.Ready].includes(status) && (
-                <DownloadMessage blockStyle={blockStyle(blockSettings)} status={status} />
-            )}
-
-            <div>
-                <AssetGrid
-                    appBridge={appBridge}
-                    currentAssets={currentAssets}
-                    deleteAssetIdsFromKey={deleteAssetIdsFromKey}
-                    updateAssetIdsFromKey={updateAssetIdsFromKey}
-                    saveDownloadUrl={saveDownloadUrl}
-                    isEditing={isEditing}
-                    showThumbnails={showThumbnails}
-                    showCount={showCount}
-                    countColor={assetCountColor === 'override' ? countCustomColor : undefined}
-                />
-
-                {isEditing && (
-                    <AssetSelection
+        <div className="asset-kit-block">
+            <div
+                data-test-id="asset-kit-block"
+                className={joinClassNames([
+                    'tw-w-full tw-space-y-8',
+                    (hasBorder_blocks || hasBackgroundBlocks) && 'tw-p-5 sm:tw-p-8',
+                ])}
+                style={{
+                    ...blockStyle(blockSettings),
+                }}
+            >
+                <div className="sm:tw-flex tw-gap-8 tw-space-y-3 md:tw-space-y-0">
+                    <InformationSection
+                        description={description}
+                        isEditing={isEditing}
+                        setBlockSettings={setBlockSettings}
+                        title={title}
                         appBridge={appBridge}
-                        isUploadingAssets={isUploadingAssets}
-                        setIsUploadingAssets={setIsUploadingAssets}
-                        addAssetIdsToKey={addAssetIdsToKey}
-                        saveDownloadUrl={saveDownloadUrl}
-                        currentAssets={currentAssets}
                     />
+                    <div className="tw-flex-none">
+                        <button
+                            data-test-id="asset-kit-block-download-button"
+                            disabled={isButtonDisabled}
+                            onClick={isEditing ? undefined : startDownload}
+                            onMouseEnter={() => setButtonHover(true)}
+                            onMouseLeave={() => setButtonHover(false)}
+                            style={{
+                                ...BlockStyles.buttonPrimary,
+                                ...(buttonHover ? BlockStyles.buttonPrimary?.hover : null),
+                                ...(isButtonDisabled ? { opacity: 0.5 } : null),
+                            }}
+                        >
+                            <RichTextEditor
+                                id="asset-kit-block-download-button-text"
+                                value={
+                                    hasRichTextValue(buttonText)
+                                        ? buttonText
+                                        : convertToRteValue('p', 'Download package')
+                                }
+                                isEditing={isEditing}
+                                plugins={new PluginComposer({ noToolbar: true }).setPlugin()}
+                                onTextChange={(buttonText) => setBlockSettings({ buttonText })}
+                            />
+                            <span
+                                data-test-id="asset-kit-block-screen-reader"
+                                ref={screenReaderRef}
+                                role="status"
+                                className="tw-absolute -tw-left-[10000px] tw-top-auto tw-w-1 tw-h-1 tw-overflow-hidden"
+                            />
+                        </button>
+                    </div>
+                </div>
+
+                {![BulkDownloadState.Init, BulkDownloadState.Ready].includes(status) && (
+                    <DownloadMessage blockStyle={blockStyle(blockSettings)} status={status} />
                 )}
+
+                <div>
+                    <AssetGrid
+                        appBridge={appBridge}
+                        currentAssets={currentAssets}
+                        deleteAssetIdsFromKey={deleteAssetIdsFromKey}
+                        updateAssetIdsFromKey={updateAssetIdsFromKey}
+                        saveDownloadUrl={saveDownloadUrl}
+                        isEditing={isEditing}
+                        showThumbnails={showThumbnails}
+                        showCount={showCount}
+                        countColor={assetCountColor === 'override' ? countCustomColor : undefined}
+                    />
+
+                    {isEditing && (
+                        <AssetSelection
+                            appBridge={appBridge}
+                            isUploadingAssets={isUploadingAssets}
+                            setIsUploadingAssets={setIsUploadingAssets}
+                            addAssetIdsToKey={addAssetIdsToKey}
+                            saveDownloadUrl={saveDownloadUrl}
+                            currentAssets={currentAssets}
+                        />
+                    )}
+                </div>
             </div>
         </div>
     );

--- a/packages/asset-kit-block/tailwind.config.js
+++ b/packages/asset-kit-block/tailwind.config.js
@@ -6,4 +6,5 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
+    important: '.asset-kit-block',
 };


### PR DESCRIPTION
https://tailwindcss.com/docs/configuration#selector-strategy

New classes that are stronger:
![image](https://github.com/Frontify/guideline-blocks/assets/30796791/d90fc6c0-c152-4271-8b28-d6b665ac2d39)
