### PR TITLE
chore: a11y lint plugin

### DIFF
--- a/examples/asset-upload/.eslintrc.js
+++ b/examples/asset-upload/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/examples/asset-upload/package.json
+++ b/examples/asset-upload/package.json
@@ -22,6 +22,7 @@
         "autoprefixer": "^10.4.15",
         "cypress": "^13.1.0",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/examples/asset-upload/src/ExampleAssetUploadBlock.tsx
+++ b/examples/asset-upload/src/ExampleAssetUploadBlock.tsx
@@ -74,7 +74,7 @@ export const ExampleAssetUploadBlock = ({ appBridge }: BlockProps): ReactElement
                 {blockAssets[IMAGE_SETTING_ID] ? (
                     blockAssets[IMAGE_SETTING_ID].map((asset: Asset) => (
                         <div key={asset.id}>
-                            <img src={asset.previewUrl} data-test-id="example-asset-upload-image" />
+                            <img src={asset.previewUrl} alt={asset.title} data-test-id="example-asset-upload-image" />
                             <div className="tw-flex tw-flex-col tw-gap-4">
                                 <strong>{asset.title}</strong>
                                 <div className="tw-flex tw-gap-4">

--- a/packages/animation-curve-block/.eslintrc.js
+++ b/packages/animation-curve-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/animation-curve-block/package.json
+++ b/packages/animation-curve-block/package.json
@@ -23,6 +23,7 @@
         "cypress": "^13.1.0",
         "cypress-real-events": "^1.10.1",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/asset-kit-block/.eslintrc.js
+++ b/packages/asset-kit-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/asset-kit-block/package.json
+++ b/packages/asset-kit-block/package.json
@@ -23,6 +23,7 @@
         "cypress": "^13.1.0",
         "cypress-real-events": "^1.10.1",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/audio-block/.eslintrc.js
+++ b/packages/audio-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/audio-block/package.json
+++ b/packages/audio-block/package.json
@@ -23,6 +23,7 @@
         "cypress": "^13.1.0",
         "cypress-real-events": "^1.10.1",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/audio-block/src/components/AudioPlayer.tsx
+++ b/packages/audio-block/src/components/AudioPlayer.tsx
@@ -51,6 +51,7 @@ export const AudioPlayer = ({
                 <LoadingCircle />
             </div>
         ) : (
+            // eslint-disable-next-line jsx-a11y/media-has-caption
             <audio
                 data-test-id="audio-block-audio-tag"
                 key={audio.id}

--- a/packages/brand-positioning-block/.eslintrc.js
+++ b/packages/brand-positioning-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/brand-positioning-block/package.json
+++ b/packages/brand-positioning-block/package.json
@@ -22,6 +22,7 @@
         "autoprefixer": "^10.4.15",
         "cypress": "^13.1.0",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/callout-block/.eslintrc.js
+++ b/packages/callout-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/callout-block/package.json
+++ b/packages/callout-block/package.json
@@ -22,6 +22,7 @@
         "autoprefixer": "^10.4.15",
         "cypress": "^13.1.0",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/callout-block/src/components/CalloutIcon.tsx
+++ b/packages/callout-block/src/components/CalloutIcon.tsx
@@ -30,5 +30,5 @@ export const calloutIconMap = (iconUrl?: string): Record<Icon, ReactNode> => ({
     info: <IconInfo20 data-test-id="callout-icon-info" />,
     lightbulb: <IconLightbulb20 />,
     megaphone: <IconMegaphone20 />,
-    custom: <img data-test-id="callout-icon-custom" src={iconUrl} />,
+    custom: <img data-test-id="callout-icon-custom" src={iconUrl} alt="custom callout icon" />,
 });

--- a/packages/checklist-block/.eslintrc.js
+++ b/packages/checklist-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/checklist-block/package.json
+++ b/packages/checklist-block/package.json
@@ -24,6 +24,7 @@
         "cypress": "^13.1.0",
         "cypress-real-events": "^1.10.1",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/checklist-block/src/components/Checkbox.tsx
+++ b/packages/checklist-block/src/components/Checkbox.tsx
@@ -53,6 +53,7 @@ export const Checkbox: FC<CheckboxProps> = ({
     };
 
     return (
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
         <label
             className={joinClassNames([
                 'tw-flex tw-select-none tw-outline-none tw-self-start tw-items-start',

--- a/packages/code-snippet-block/.eslintrc.js
+++ b/packages/code-snippet-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/code-snippet-block/package.json
+++ b/packages/code-snippet-block/package.json
@@ -23,6 +23,7 @@
         "cypress": "^13.1.0",
         "cypress-real-events": "^1.10.1",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/color-block/.eslintrc.js
+++ b/packages/color-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/color-block/package.json
+++ b/packages/color-block/package.json
@@ -23,6 +23,7 @@
         "cypress": "^13.1.0",
         "cypress-real-events": "^1.10.1",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/color-block/src/components/cards/CardsItem.tsx
+++ b/packages/color-block/src/components/cards/CardsItem.tsx
@@ -74,6 +74,7 @@ export const CardsItem = ({ color, colorSpaces, isEditing, onBlur, onUpdate, onD
                     }
                     triggerElement={
                         <div className="tw-overflow-hidden tw-rounded-t tw-bg-[url('https://cdn.frontify.com/img/transparent.png')] tw-bg-[length:10px_10px]">
+                            {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
                             <div
                                 data-test-id="color-tooltip-trigger"
                                 className="tw-w-full tw-h-[60px] tw-cursor-pointer tw-shadow-inner-line tw-transition-all group-hover:tw-shadow-inner-line-x-strong"
@@ -138,6 +139,7 @@ export const CardsItem = ({ color, colorSpaces, isEditing, onBlur, onUpdate, onD
                                                 />
                                             }
                                             triggerElement={
+                                                // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
                                                 <div
                                                     data-test-id="color-space-value-trigger"
                                                     className="tw-cursor-pointer tw-text-s tw-text-black-80 tw-truncate"

--- a/packages/color-block/src/components/drops/DropsItem.tsx
+++ b/packages/color-block/src/components/drops/DropsItem.tsx
@@ -73,6 +73,7 @@ export const DropsItem = ({ color, colorSpaces, isEditing, onBlur, onUpdate, onD
                     }
                     triggerElement={
                         <div className="tw-mb-3 tw-overflow-hidden tw-rounded-full tw-bg-[url('https://cdn.frontify.com/img/transparent.png')] tw-bg-[length:10px_10px]">
+                            {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
                             <div
                                 data-test-id="color-tooltip-trigger"
                                 className="tw-relative tw-w-[100px] tw-h-[100px] tw-cursor-pointer tw-rounded-full tw-shadow-inner-line tw-transition-all group-hover:tw-shadow-inner-line-x-strong"
@@ -137,6 +138,7 @@ export const DropsItem = ({ color, colorSpaces, isEditing, onBlur, onUpdate, onD
                                             />
                                         }
                                         triggerElement={
+                                            // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
                                             <div
                                                 data-test-id="color-space-value-trigger"
                                                 className="tw-cursor-pointer tw-text-s tw-text-black-80 tw-truncate"

--- a/packages/color-block/src/components/list/ListItem.tsx
+++ b/packages/color-block/src/components/list/ListItem.tsx
@@ -62,6 +62,7 @@ export const ListItem = ({ color, colorSpaces, isEditing, onBlur, onUpdate, onDe
                     }
                     triggerElement={
                         <div className="tw-h-full tw-mr-9 tw-bg-[url('https://cdn.frontify.com/img/transparent.png')] tw-bg-[length:10px_10px]">
+                            {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
                             <div
                                 data-test-id="color-tooltip-trigger"
                                 className="tw-w-[120px] tw-h-full tw-min-h-[60px] tw-cursor-pointer tw-shadow-t-inner-line tw-transition-all group-hover:tw-shadow-y-inner-line-x-strong"
@@ -141,6 +142,7 @@ export const ListItem = ({ color, colorSpaces, isEditing, onBlur, onUpdate, onDe
                                         />
                                     }
                                     triggerElement={
+                                        // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
                                         <div
                                             data-test-id="color-space-value-trigger"
                                             className="tw-w-28 tw-ml-3 tw-overflow-hidden tw-cursor-pointer tw-whitespace-nowrap tw-text-s tw-text-black-80 tw-overflow-ellipsis"

--- a/packages/color-kit-block/.eslintrc.js
+++ b/packages/color-kit-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/color-kit-block/package.json
+++ b/packages/color-kit-block/package.json
@@ -22,6 +22,7 @@
         "autoprefixer": "^10.4.15",
         "cypress": "^13.1.0",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/color-kit-block/src/Color.tsx
+++ b/packages/color-kit-block/src/Color.tsx
@@ -27,6 +27,7 @@ export const Color = ({ isEditing, color, colorsLength }: ColorProps): ReactElem
 
     const ColorBox = () => (
         <div className="tw-bg-[url('https://cdn.frontify.com/img/transparent.png')] tw-bg-[length:10px_10px]">
+            {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
             <div
                 key={color.id}
                 data-test-id="color"

--- a/packages/color-scale-block/.eslintrc.js
+++ b/packages/color-scale-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/color-scale-block/package.json
+++ b/packages/color-scale-block/package.json
@@ -23,6 +23,7 @@
         "autoprefixer": "^10.4.15",
         "cypress": "^13.1.0",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/color-scale-block/src/ColorScaleBlock.tsx
+++ b/packages/color-scale-block/src/ColorScaleBlock.tsx
@@ -416,6 +416,7 @@ export const ColorScaleBlock: FC<BlockProps> = ({ appBridge }) => {
                 data-test-id="color-scale-block"
                 className="tw-w-full tw-p-px tw-mb-4 tw-border tw-border-line tw-rounded"
             >
+                {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
                 <div
                     ref={colorScaleBlockInnerRef}
                     style={{

--- a/packages/color-scale-block/src/components/ColorSquare.tsx
+++ b/packages/color-scale-block/src/components/ColorSquare.tsx
@@ -118,7 +118,10 @@ export const ColorSquare = ({
                             }
                             hoverDelay={0}
                             position={TooltipPosition.Right}
-                            triggerElement={<div className="tw-w-full tw-h-full" onClick={copyColor} />}
+                            triggerElement={
+                                // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+                                <div className="tw-w-full tw-h-full" onClick={copyColor} />
+                            }
                             withArrow
                         />
                     )}

--- a/packages/color-scale-block/src/components/DragHandle.tsx
+++ b/packages/color-scale-block/src/components/DragHandle.tsx
@@ -8,6 +8,7 @@ export const DragHandle = ({ index, onResizeStart }: DragHandleProps) => {
     const handleMouseDown: MouseEventHandler = (event: MouseEvent) => onResizeStart?.(event, index);
 
     return (
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
         <div
             className="tw-absolute tw-opacity-0 hover:tw-opacity-100 group-hover:tw-flex tw-w-2 tw-flex tw-h-full tw-items-center tw-right-[0px] tw-cursor-ew-resize tw-z-[99]"
             // Note: onMouseUp and onDrag are defined here intentionally, instead of being in the DragHandle component.

--- a/packages/compare-slider-block/.eslintrc.js
+++ b/packages/compare-slider-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/compare-slider-block/package.json
+++ b/packages/compare-slider-block/package.json
@@ -20,6 +20,7 @@
         "autoprefixer": "^10.4.15",
         "cypress": "^13.1.0",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/compare-slider-block/src/CompareSliderBlock.tsx
+++ b/packages/compare-slider-block/src/CompareSliderBlock.tsx
@@ -317,8 +317,10 @@ export const CompareSliderBlock = ({ appBridge }: BlockProps) => {
                     openAssetChooser={onOpenAssetChooser}
                     startDragAndDropUpload={startDragAndDropUpload}
                     startFileDialogUpload={startFileDialogUpload}
-                    firstAsset={firstAsset[0]}
-                    secondAsset={secondAsset[0]}
+                    firstAssetPreviewUrl={firstAssetPreviewUrl}
+                    firstAssetTitle={firstAssetTitle}
+                    secondAssetPreviewUrl={secondAssetPreviewUrl}
+                    secondAssetTitle={secondAssetTitle}
                 />
             </div>
         );

--- a/packages/compare-slider-block/src/CompareSliderBlock.tsx
+++ b/packages/compare-slider-block/src/CompareSliderBlock.tsx
@@ -317,8 +317,8 @@ export const CompareSliderBlock = ({ appBridge }: BlockProps) => {
                     openAssetChooser={onOpenAssetChooser}
                     startDragAndDropUpload={startDragAndDropUpload}
                     startFileDialogUpload={startFileDialogUpload}
-                    firstAssetPreviewUrl={firstAssetPreviewUrl}
-                    secondAssetPreviewUrl={secondAssetPreviewUrl}
+                    firstAsset={firstAsset[0]}
+                    secondAsset={secondAsset[0]}
                 />
             </div>
         );

--- a/packages/compare-slider-block/src/components/UploadView/UploadView.tsx
+++ b/packages/compare-slider-block/src/components/UploadView/UploadView.tsx
@@ -6,8 +6,10 @@ import { Alignment, SliderImageSlot, UploadViewProps } from '../../types';
 
 export const UploadView = ({
     alignment,
-    firstAsset,
-    secondAsset,
+    firstAssetPreviewUrl,
+    firstAssetTitle,
+    secondAssetPreviewUrl,
+    secondAssetTitle,
     openAssetChooser,
     startFileDialogUpload,
     startDragAndDropUpload,
@@ -21,12 +23,12 @@ export const UploadView = ({
                 alignment === Alignment.Vertical ? 'tw-grid-cols-1 tw-grid-rows-2' : 'tw-grid-cols-2',
             ])}
         >
-            {firstAsset ? (
+            {firstAssetPreviewUrl ? (
                 <img
                     loading="lazy"
                     className="tw-w-full tw-h-full tw-object-cover tw-object-left"
-                    src={firstAsset?.previewUrl}
-                    alt={firstAsset?.title}
+                    src={firstAssetPreviewUrl}
+                    alt={firstAssetTitle}
                 />
             ) : (
                 <BlockInjectButton
@@ -41,12 +43,12 @@ export const UploadView = ({
                 />
             )}
 
-            {secondAsset ? (
+            {secondAssetPreviewUrl ? (
                 <img
                     loading="lazy"
                     className="tw-w-full tw-h-full tw-object-cover tw-object-right"
-                    src={secondAsset.previewUrl}
-                    alt={secondAsset.title}
+                    src={secondAssetPreviewUrl}
+                    alt={secondAssetTitle}
                 />
             ) : (
                 <BlockInjectButton

--- a/packages/compare-slider-block/src/components/UploadView/UploadView.tsx
+++ b/packages/compare-slider-block/src/components/UploadView/UploadView.tsx
@@ -6,8 +6,8 @@ import { Alignment, SliderImageSlot, UploadViewProps } from '../../types';
 
 export const UploadView = ({
     alignment,
-    firstAssetPreviewUrl,
-    secondAssetPreviewUrl,
+    firstAsset,
+    secondAsset,
     openAssetChooser,
     startFileDialogUpload,
     startDragAndDropUpload,
@@ -21,11 +21,12 @@ export const UploadView = ({
                 alignment === Alignment.Vertical ? 'tw-grid-cols-1 tw-grid-rows-2' : 'tw-grid-cols-2',
             ])}
         >
-            {firstAssetPreviewUrl ? (
+            {firstAsset ? (
                 <img
                     loading="lazy"
                     className="tw-w-full tw-h-full tw-object-cover tw-object-left"
-                    src={firstAssetPreviewUrl}
+                    src={firstAsset?.previewUrl}
+                    alt={firstAsset?.title}
                 />
             ) : (
                 <BlockInjectButton
@@ -40,11 +41,12 @@ export const UploadView = ({
                 />
             )}
 
-            {secondAssetPreviewUrl ? (
+            {secondAsset ? (
                 <img
                     loading="lazy"
                     className="tw-w-full tw-h-full tw-object-cover tw-object-right"
-                    src={secondAssetPreviewUrl}
+                    src={secondAsset.previewUrl}
+                    alt={secondAsset.title}
                 />
             ) : (
                 <BlockInjectButton

--- a/packages/compare-slider-block/src/types.ts
+++ b/packages/compare-slider-block/src/types.ts
@@ -143,8 +143,8 @@ export type HandleProps = {
 
 export type UploadViewProps = {
     alignment: Alignment;
-    firstAssetPreviewUrl?: string;
-    secondAssetPreviewUrl?: string;
+    firstAsset?: Asset;
+    secondAsset?: Asset;
     openAssetChooser: (slot: SliderImageSlot) => void;
     startFileDialogUpload: (slot: SliderImageSlot) => void;
     startDragAndDropUpload: (files: FileList, slot: SliderImageSlot) => void;

--- a/packages/compare-slider-block/src/types.ts
+++ b/packages/compare-slider-block/src/types.ts
@@ -143,8 +143,10 @@ export type HandleProps = {
 
 export type UploadViewProps = {
     alignment: Alignment;
-    firstAsset?: Asset;
-    secondAsset?: Asset;
+    firstAssetPreviewUrl?: string;
+    firstAssetTitle: string;
+    secondAssetPreviewUrl?: string;
+    secondAssetTitle: string;
     openAssetChooser: (slot: SliderImageSlot) => void;
     startFileDialogUpload: (slot: SliderImageSlot) => void;
     startDragAndDropUpload: (files: FileList, slot: SliderImageSlot) => void;

--- a/packages/divider-block/.eslintrc.js
+++ b/packages/divider-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/divider-block/package.json
+++ b/packages/divider-block/package.json
@@ -22,6 +22,7 @@
         "autoprefixer": "^10.4.15",
         "cypress": "^13.1.0",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/dos-donts-block/.eslintrc.js
+++ b/packages/dos-donts-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/dos-donts-block/src/components/ImageComponent.tsx
+++ b/packages/dos-donts-block/src/components/ImageComponent.tsx
@@ -59,6 +59,7 @@ const ImageComponent = ({
                                 'tw-object-contain',
                         ])}
                         src={src.replace('{width}', width.toString())}
+                        alt=""
                     />
                     {hasStrikethrough && (
                         <div

--- a/packages/example/.eslintrc.js
+++ b/packages/example/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -22,6 +22,7 @@
         "autoprefixer": "^10.4.15",
         "cypress": "^13.1.0",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/figma-block/.eslintrc.js
+++ b/packages/figma-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/figma-block/package.json
+++ b/packages/figma-block/package.json
@@ -22,6 +22,7 @@
         "autoprefixer": "^10.4.15",
         "cypress": "^13.1.0",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/figma-block/src/FigmaBlock.tsx
+++ b/packages/figma-block/src/FigmaBlock.tsx
@@ -103,6 +103,7 @@ export const FigmaBlock = ({ appBridge }: BlockProps): ReactElement => {
     };
 
     const FigmaEmptyBlock = () => (
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
         <div
             data-test-id="figma-empty-block"
             className="tw-group tw-py-16 tw-px-4 tw-border-dashed tw-border tw-cursor-pointer tw-text-center tw-border-line-x-strong hover:tw-border-black"
@@ -198,7 +199,11 @@ export const FigmaBlock = ({ appBridge }: BlockProps): ReactElement => {
                         />
                     </div>
                 )}
-                <iframe src={asset?.externalUrl ?? undefined} className="tw-h-full tw-w-full tw-border-none" />
+                <iframe
+                    src={asset?.externalUrl ?? undefined}
+                    className="tw-h-full tw-w-full tw-border-none"
+                    title="figma-iframe"
+                />
             </div>
         ),
         [
@@ -240,6 +245,7 @@ export const FigmaBlock = ({ appBridge }: BlockProps): ReactElement => {
                         src={asset?.externalUrl ?? undefined}
                         className="tw-h-full tw-w-full tw-border-none"
                         loading="lazy"
+                        title={asset.title}
                     />
                 </div>
             </div>

--- a/packages/figma-block/src/FigmaBlock.tsx
+++ b/packages/figma-block/src/FigmaBlock.tsx
@@ -103,17 +103,16 @@ export const FigmaBlock = ({ appBridge }: BlockProps): ReactElement => {
     };
 
     const FigmaEmptyBlock = () => (
-        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-        <div
+        <button
             data-test-id="figma-empty-block"
-            className="tw-group tw-py-16 tw-px-4 tw-border-dashed tw-border tw-cursor-pointer tw-text-center tw-border-line-x-strong hover:tw-border-black"
+            className="tw-group tw-w-full tw-py-16 tw-px-4 tw-border-dashed tw-border tw-cursor-pointer tw-text-center tw-border-line-x-strong hover:tw-border-black"
             onClick={onOpenAssetChooser}
         >
             <div className="tw-text-xl tw-mb-4 tw-flex tw-justify-center tw-text-black-40 group-hover:tw-text-violet-60">
                 <IconSuitcase size={IconSize.Size32} />
             </div>
             <span className="tw-text-text-x-weak group-hover:tw-text-black">Choose Figma asset</span>
-        </div>
+        </button>
     );
 
     const ShowFigmaLink = useCallback(

--- a/packages/figma-block/src/tests/BlockContainerStub.tsx
+++ b/packages/figma-block/src/tests/BlockContainerStub.tsx
@@ -37,6 +37,7 @@ export const BlockContainerStub = ({ height, padding = 0 }: { height: string; pa
                     height="100%"
                     style={{ position: 'relative' }}
                     onLoad={() => setIsImageLoaded(true)}
+                    alt=""
                 />
             </div>
         </div>

--- a/packages/glyphs-block/.eslintrc.js
+++ b/packages/glyphs-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/glyphs-block/package.json
+++ b/packages/glyphs-block/package.json
@@ -24,6 +24,7 @@
         "cypress": "^13.1.0",
         "cypress-real-events": "^1.10.1",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/gradient-block/.eslintrc.js
+++ b/packages/gradient-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/gradient-block/package.json
+++ b/packages/gradient-block/package.json
@@ -24,6 +24,7 @@
         "cypress": "^13.1.0",
         "cypress-real-events": "^1.10.1",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/gradient-block/src/components/AddColorButton.tsx
+++ b/packages/gradient-block/src/components/AddColorButton.tsx
@@ -15,6 +15,7 @@ export const AddColorButton = ({
     };
 
     return (
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
         <div
             data-test-id="add-color-button"
             className="tw-absolute tw-top-1/2 -tw-translate-y-1/2 tw-bg-box-selected-strong tw-flex tw-items-center tw-justify-center tw-rounded tw-cursor-pointer tw-h-4 tw-w-4"

--- a/packages/gradient-block/src/components/ColorFlyout.tsx
+++ b/packages/gradient-block/src/components/ColorFlyout.tsx
@@ -76,6 +76,7 @@ export const ColorFlyout = ({
             fixedHeader={
                 <div className="tw-flex tw-justify-between tw-items-center tw-font-bold tw-text-s tw-py-3 tw-px-6 tw-bg-white tw-border-b tw-border-b-black-10">
                     <span>Configure Color</span>
+                    {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
                     <span
                         className="hover:tw-bg-box-neutral-hover hover:tw-cursor-pointer tw-rounded-sm tw-p-0.5 tw-text-strong"
                         onClick={() => setShowColorModal(false)}

--- a/packages/gradient-block/src/components/SquareBadge.tsx
+++ b/packages/gradient-block/src/components/SquareBadge.tsx
@@ -70,6 +70,7 @@ export const SquareBadge = ({ gradientColor, gradientOrientation, index, blockWi
                 right: isOutOfBounds ? '0%' : 'auto',
             }}
         >
+            {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
             <div
                 className="tw-flex tw-items-center tw-h-5 tw-bg-base tw-border-line hover:tw-line-box-selected-strong tw-border tw-rounded tw-group tw-cursor-pointer"
                 onClick={() => copy(toHexString(gradientColor.color))}

--- a/packages/image-block/.eslintrc.js
+++ b/packages/image-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/image-block/package.json
+++ b/packages/image-block/package.json
@@ -23,6 +23,7 @@
         "autoprefixer": "^10.4.15",
         "cypress": "^13.1.0",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/personal-note-block/.eslintrc.js
+++ b/packages/personal-note-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/personal-note-block/package.json
+++ b/packages/personal-note-block/package.json
@@ -22,6 +22,7 @@
         "autoprefixer": "^10.4.15",
         "cypress": "^13.1.0",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/personal-note-block/src/components/NoteHeader.tsx
+++ b/packages/personal-note-block/src/components/NoteHeader.tsx
@@ -21,7 +21,9 @@ export const NoteHeader: FC<NoteHeaderProps> = ({
         className={`tw-flex tw-items-center tw-space-x-4 ${hasAvatarName || hasDateEdited ? 'tw-mb-4' : ''}`}
         data-test-id="personal-note-header"
     >
-        {hasAvatarName && avatar && <img src={avatar} width="32" height="32" className="tw-rounded-full" />}
+        {hasAvatarName && avatar && (
+            <img src={avatar} alt="avatar" width="32" height="32" className="tw-rounded-full" />
+        )}
         <div className="tw-flex tw-flex-col tw-text-s">
             {hasAvatarName && <span className={useLightText ? 'tw-text-white' : 'tw-text-black'}>{name}</span>}
             {hasDateEdited && dateEdited && (

--- a/packages/quote-block/.eslintrc.js
+++ b/packages/quote-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/quote-block/package.json
+++ b/packages/quote-block/package.json
@@ -22,6 +22,7 @@
         "autoprefixer": "^10.4.15",
         "cypress": "^13.1.0",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/shared/.eslintrc.js
+++ b/packages/shared/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -24,6 +24,7 @@
         "@types/sinon": "^10.0.16",
         "cypress": "^13.1.0",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "happy-dom": "^10.11.2",
         "mitt": "^3.0.1",

--- a/packages/sketchfab-block/.eslintrc.js
+++ b/packages/sketchfab-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/sketchfab-block/package.json
+++ b/packages/sketchfab-block/package.json
@@ -22,6 +22,7 @@
         "autoprefixer": "^10.4.15",
         "cypress": "^13.1.0",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/sketchfab-block/src/SketchfabBlock.tsx
+++ b/packages/sketchfab-block/src/SketchfabBlock.tsx
@@ -143,49 +143,6 @@ export const SketchfabBlock: FC<BlockProps> = ({ appBridge }) => {
     }, [blockSettings]);
 
     return (
-<<<<<<< HEAD
-        <div data-test-id="sketchfab-block" className="tw-relative">
-            {iframeUrl && (
-                <div>
-                    <iframe
-                        className={joinClassNames(['tw-w-full', !hasRadius && radiusClassMap[radiusChoice]])}
-                        style={{
-                            ...(hasBorder ? getIframeBorderStyles(borderStyle, borderWidth, borderColor) : {}),
-                            borderRadius: hasRadius ? radiusValue : '',
-                        }}
-                        height={isCustomHeight ? customHeight : heights[height]}
-                        src={iframeUrl.toString()}
-                        frameBorder="0"
-                        data-test-id="sketchfab-iframe"
-                        title="sketchfab-iframe"
-                    />
-                </div>
-            )}
-            {isEditing && !iframeUrl && (
-                <div
-                    className="tw-flex tw-flex-col tw-items-center tw-bg-black-5 tw-p-20 tw-gap-8"
-                    data-test-id="sketchfab-empty-block-edit"
-                >
-                    <Text color="x-weak">Enter a URL to your 3D model from Sketchfab.</Text>
-                    <div className="tw-text-text-x-weak tw-flex tw-items-start tw-gap-3 tw-w-full tw-justify-center">
-                        <div className="tw-flex-none tw-mt-[2px]">
-                            <IconLinkBox size={IconSize.Size32} />
-                        </div>
-                        <div className="tw-w-full tw-max-w-sm">
-                            <FormControl
-                                helper={inputError ? { text: SKETCHFAB_RULE_ERROR } : undefined}
-                                style={inputError ? FormControlStyle.Danger : FormControlStyle.Primary}
-                            >
-                                <TextInput
-                                    value={localUrl}
-                                    onChange={setLocalUrl}
-                                    onEnterPressed={saveLink}
-                                    placeholder={URL_INPUT_PLACEHOLDER}
-                                />
-                            </FormControl>
-                        </div>
-                        <Button onClick={saveLink}>Confirm</Button>
-=======
         <div className="sketchfab-block">
             <div data-test-id="sketchfab-block" className="tw-relative">
                 {iframeUrl && (
@@ -200,8 +157,8 @@ export const SketchfabBlock: FC<BlockProps> = ({ appBridge }) => {
                             src={iframeUrl.toString()}
                             frameBorder="0"
                             data-test-id="sketchfab-iframe"
+                            title="3D model from Sketchfab"
                         />
->>>>>>> main
                     </div>
                 )}
                 {isEditing && !iframeUrl && (

--- a/packages/sketchfab-block/src/SketchfabBlock.tsx
+++ b/packages/sketchfab-block/src/SketchfabBlock.tsx
@@ -156,6 +156,7 @@ export const SketchfabBlock: FC<BlockProps> = ({ appBridge }) => {
                         src={iframeUrl.toString()}
                         frameBorder="0"
                         data-test-id="sketchfab-iframe"
+                        title="sketchfab-iframe"
                     />
                 </div>
             )}

--- a/packages/sketchfab-block/src/helpers/settings.spec.ct.ts
+++ b/packages/sketchfab-block/src/helpers/settings.spec.ct.ts
@@ -49,7 +49,7 @@ describe('parseSketchfabSettingsUrl', () => {
                 getBlock: () => ({
                     value: args,
                 }),
-                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-explicit-any
                 getAppBridge(): any {},
             } as Bundle;
             parseSketchfabSettingsUrl(bundle);

--- a/packages/storybook-block/.eslintrc.js
+++ b/packages/storybook-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/storybook-block/package.json
+++ b/packages/storybook-block/package.json
@@ -21,6 +21,7 @@
         "autoprefixer": "^10.4.15",
         "cypress": "^13.1.0",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/storybook-block/src/StorybookBlock.tsx
+++ b/packages/storybook-block/src/StorybookBlock.tsx
@@ -100,6 +100,7 @@ export const StorybookBlock: FC<BlockProps> = ({ appBridge }) => {
             frameBorder="0"
             loading="lazy"
             data-test-id="storybook-iframe"
+            title="storybook-iframe"
         />
     );
 

--- a/packages/text-block/.eslintrc.js
+++ b/packages/text-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/text-block/package.json
+++ b/packages/text-block/package.json
@@ -23,6 +23,7 @@
         "autoprefixer": "^10.4.15",
         "cypress": "^13.1.0",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/packages/thumbnail-grid-block/.eslintrc.js
+++ b/packages/thumbnail-grid-block/.eslintrc.js
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    extends: ['@frontify/eslint-config-react'],
+    extends: ['@frontify/eslint-config-react', 'plugin:jsx-a11y/recommended'],
     plugins: ['notice'],
     settings: {
         react: {

--- a/packages/thumbnail-grid-block/package.json
+++ b/packages/thumbnail-grid-block/package.json
@@ -24,6 +24,7 @@
         "cypress": "^13.1.0",
         "cypress-real-events": "^1.10.1",
         "eslint": "^8.48.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-notice": "^0.9.10",
         "postcss": "^8.4.29",
         "prettier": "^3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -197,6 +200,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -261,6 +267,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -328,6 +337,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -392,6 +404,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -456,6 +471,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -544,6 +562,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -629,6 +650,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -702,6 +726,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -766,6 +793,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -839,6 +869,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -906,6 +939,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -967,6 +1003,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -1110,6 +1149,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -1174,6 +1216,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -1244,6 +1289,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -1314,6 +1362,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -1384,6 +1435,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -1451,6 +1505,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -1515,6 +1572,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -1576,6 +1636,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -1667,6 +1730,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -1734,6 +1800,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -1804,6 +1873,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -1889,6 +1961,9 @@ importers:
       eslint:
         specifier: ^8.48.0
         version: 8.48.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.7.1
+        version: 6.7.1(eslint@8.48.0)
       eslint-plugin-notice:
         specifier: ^0.9.10
         version: 0.9.10(eslint@8.48.0)
@@ -4208,7 +4283,7 @@ packages:
       '@react-types/dialog': 3.4.5(react@18.2.0)
       '@react-types/shared': 3.16.0(react@18.2.0)
       '@tailwindcss/forms': 0.5.6(tailwindcss@3.3.3)
-      '@udecode/plate': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
       '@xstate/immer': 0.3.1(immer@9.0.12)(xstate@4.28.1)
       '@xstate/react': 1.6.3(@types/react@18.2.21)(react@18.2.0)(xstate@4.28.1)
       date-fns: 2.29.3
@@ -8068,6 +8143,43 @@ packages:
       - supports-color
     dev: false
 
+  /@udecode/plate-styled-components@21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-+ooCADdk3O1b+yaMe09e8M/Yxf9++Lk6YVMjHxSGS0pwTKIyfdTGwcbZ9oImCYxhlv1yGDOOgPEvuoog0cX3tw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      react-is: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      clsx: 1.2.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-is: 18.2.0
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-native
+      - scheduler
+    dev: false
+
   /@udecode/plate-styled-components@21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-+ooCADdk3O1b+yaMe09e8M/Yxf9++Lk6YVMjHxSGS0pwTKIyfdTGwcbZ9oImCYxhlv1yGDOOgPEvuoog0cX3tw==}
     peerDependencies:
@@ -8235,6 +8347,45 @@ packages:
       - scheduler
     dev: false
 
+  /@udecode/plate-ui-alignment@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-tCqLx6dxkUFesi3OfMFv4RFJFk4tIfIu07KpCzSpaX0B7u+cgV1rBWXeV+HvDquPKC4lsrVJ6lh3Yyx7LDdPBw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-alignment': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - '@types/react-dom'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
   /@udecode/plate-ui-alignment@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-tCqLx6dxkUFesi3OfMFv4RFJFk4tIfIu07KpCzSpaX0B7u+cgV1rBWXeV+HvDquPKC4lsrVJ6lh3Yyx7LDdPBw==}
     peerDependencies:
@@ -8274,6 +8425,43 @@ packages:
       - scheduler
     dev: false
 
+  /@udecode/plate-ui-block-quote@21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-5YOjAeejfJ3zp3vpYr2G+TzpveZbdv8VLUe9YpcSNlPF/r/wAzojeUwbCEkN6WuVALWCGv8ylddNUZ/DNxpg8g==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-block-quote': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
   /@udecode/plate-ui-block-quote@21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-5YOjAeejfJ3zp3vpYr2G+TzpveZbdv8VLUe9YpcSNlPF/r/wAzojeUwbCEkN6WuVALWCGv8ylddNUZ/DNxpg8g==}
     peerDependencies:
@@ -8293,6 +8481,43 @@ packages:
       slate-history: 0.93.0(slate@0.94.1)
       slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       styled-components: 6.0.7(react-dom@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-button@21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-HVIIPshNJoDcjVs71zGCMOj5pC6OQfaiItxKggiG/EYw9eFXm4l/pCCGdny74vIQdTywWYj15yEYcMg0w1eY1Q==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-button': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8348,6 +8573,45 @@ packages:
       - scheduler
     dev: false
 
+  /@udecode/plate-ui-code-block@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-xN62xPasT5IVzi9k/pbdoR1U3ZobbolXVWDVqjvYaiPWgVtyt4VNxwaIjfqhtb2lTtQZakwV5XjaQcIcjeZO1g==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-code-block': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - '@types/react-dom'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
   /@udecode/plate-ui-code-block@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-xN62xPasT5IVzi9k/pbdoR1U3ZobbolXVWDVqjvYaiPWgVtyt4VNxwaIjfqhtb2lTtQZakwV5XjaQcIcjeZO1g==}
     peerDependencies:
@@ -8387,6 +8651,45 @@ packages:
       - scheduler
     dev: false
 
+  /@udecode/plate-ui-combobox@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-QJys2QEc+KlslbKQ1M+PxhYl7JoYr4Lr948iaPIOuYyQQAPSZIR5DFTsKgwst8vDL9TqXQIb/lL/jcUCyC8GWw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-combobox': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-floating': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - '@types/react-dom'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
   /@udecode/plate-ui-combobox@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-QJys2QEc+KlslbKQ1M+PxhYl7JoYr4Lr948iaPIOuYyQQAPSZIR5DFTsKgwst8vDL9TqXQIb/lL/jcUCyC8GWw==}
     peerDependencies:
@@ -8407,6 +8710,46 @@ packages:
       slate-history: 0.93.0(slate@0.94.1)
       slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       styled-components: 6.0.7(react-dom@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - '@types/react-dom'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-comments@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-+XjpARWNGt/xXWIEb+wEjD47piKSw3Fh7Y4P1fO9zl5FwIJXBankhW6V2HJQP6nw9WkTYx/DABI/C4OFAHr19w==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-comments': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8466,6 +8809,42 @@ packages:
       - scheduler
     dev: false
 
+  /@udecode/plate-ui-cursor@21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-/0ASgCw09m864FvtrMlTLz7OPCztos+h8t/6pnxI6lfJGzgG55wV1MOL5nVEhcEs5GO7sLEKPWYJt9hKxG54vQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
   /@udecode/plate-ui-cursor@21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-/0ASgCw09m864FvtrMlTLz7OPCztos+h8t/6pnxI6lfJGzgG55wV1MOL5nVEhcEs5GO7sLEKPWYJt9hKxG54vQ==}
     peerDependencies:
@@ -8488,6 +8867,47 @@ packages:
       - '@babel/core'
       - '@babel/template'
       - '@types/react'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-emoji@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-EzweF/YUbs6KEyGAnyBHHuduK1iW03fuPrT07YcN83RFxIu+sFPLDFbHmOVklVG1xOuo1k6WYyE37OvaNXEkeA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-combobox': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-emoji': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - '@types/react-dom'
       - jotai-devtools
       - jotai-immer
       - jotai-optics
@@ -8543,6 +8963,45 @@ packages:
       - scheduler
     dev: false
 
+  /@udecode/plate-ui-find-replace@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-b21VoIiKJbj60rMC8MPrTkayysZlGEoksJ+QpAwPi8whDtq/DCWeCY/8brGJPD/ivRKLmvlttnAkPQGCsL12JQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-find-replace': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - '@types/react-dom'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
   /@udecode/plate-ui-find-replace@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-b21VoIiKJbj60rMC8MPrTkayysZlGEoksJ+QpAwPi8whDtq/DCWeCY/8brGJPD/ivRKLmvlttnAkPQGCsL12JQ==}
     peerDependencies:
@@ -8563,6 +9022,46 @@ packages:
       slate-history: 0.93.0(slate@0.94.1)
       slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       styled-components: 6.0.7(react-dom@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - '@types/react-dom'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-font@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-wGy1TXSSF2KpWauKqpW7RBZ5EPgc16ds1r3bPNrw8utHO3WH4vuluGnWKJdIemguJeeTgiPiOp9LyVEA9PPZjQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-font': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8622,6 +9121,45 @@ packages:
       - scheduler
     dev: false
 
+  /@udecode/plate-ui-line-height@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-ddkxbNark/DbQLc2gNPfVnlA+5YUWuLeEMGl0nEAmuvq5IZCBZXz2icSccMjv+EqcioQVKBrHi+PqP0EUYMY2w==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-line-height': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - '@types/react-dom'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
   /@udecode/plate-ui-line-height@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-ddkxbNark/DbQLc2gNPfVnlA+5YUWuLeEMGl0nEAmuvq5IZCBZXz2icSccMjv+EqcioQVKBrHi+PqP0EUYMY2w==}
     peerDependencies:
@@ -8642,6 +9180,46 @@ packages:
       slate-history: 0.93.0(slate@0.94.1)
       slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       styled-components: 6.0.7(react-dom@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - '@types/react-dom'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-link@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-kk3gNmSqTFGfna/+fHDPl1iQ3jClOk44zrVgHanN72d4dWHzgyUSocrHrldUuQkECfFhCg4S5gIn82rKBK5rYg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-link': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8701,6 +9279,45 @@ packages:
       - scheduler
     dev: false
 
+  /@udecode/plate-ui-list@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-dtq4fMH3aJOxkq8klBC7AHLZgQDu9gD0ObFbvahqLFxyyHbRZmWWtKnOVZauCSvvU/Dsi6oK96wSBHHNezi3/w==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-list': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - '@types/react-dom'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
   /@udecode/plate-ui-list@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-dtq4fMH3aJOxkq8klBC7AHLZgQDu9gD0ObFbvahqLFxyyHbRZmWWtKnOVZauCSvvU/Dsi6oK96wSBHHNezi3/w==}
     peerDependencies:
@@ -8721,6 +9338,49 @@ packages:
       slate-history: 0.93.0(slate@0.94.1)
       slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       styled-components: 6.0.7(react-dom@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - '@types/react-dom'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-media@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-QYByExzxchHeXflxdMz/aI5reUeTHyPILj3vaunObE1b2q2Vi5TDFW2kBl/ikA5FtcJWgqFq6SH1cKUztSlVPg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-floating': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-link': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-media': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-link': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      js-video-url-parser: 0.5.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8783,6 +9443,46 @@ packages:
       - scheduler
     dev: false
 
+  /@udecode/plate-ui-mention@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-dD5QV/05oY9DJrF4Ls8rYlhZrZTqYD2oS2+eY31fo9TKsvbEArypVA9gbLAB+JtY3flWTF/XK8ZtQDK4Ky/Srw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-combobox': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-mention': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - '@types/react-dom'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
   /@udecode/plate-ui-mention@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-dD5QV/05oY9DJrF4Ls8rYlhZrZTqYD2oS2+eY31fo9TKsvbEArypVA9gbLAB+JtY3flWTF/XK8ZtQDK4Ky/Srw==}
     peerDependencies:
@@ -8809,6 +9509,42 @@ packages:
       - '@babel/template'
       - '@types/react'
       - '@types/react-dom'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-placeholder@21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-scZVD6/fWGMRYYAmlJ2OLGvYCeTD4zEOj2EPWeI5ztspqbVjqmGkOB/N54cSZkEZne2rwCfqNmJ8wkZr91T8Ig==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
       - jotai-devtools
       - jotai-immer
       - jotai-optics
@@ -8859,6 +9595,47 @@ packages:
       - scheduler
     dev: false
 
+  /@udecode/plate-ui-table@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-7ZN/RMbkINTFMV5i/3KD9UnAqHRTUlJ9NA554ahoRio3+GNzXfnf2wXF98Q4NnELz245nasqkOqZ3qj18u/l3Q==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-floating': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-table': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - '@types/react-dom'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
   /@udecode/plate-ui-table@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-7ZN/RMbkINTFMV5i/3KD9UnAqHRTUlJ9NA554ahoRio3+GNzXfnf2wXF98Q4NnELz245nasqkOqZ3qj18u/l3Q==}
     peerDependencies:
@@ -8881,6 +9658,47 @@ packages:
       slate-history: 0.93.0(slate@0.94.1)
       slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       styled-components: 6.0.7(react-dom@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - '@types/react-dom'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+    dev: false
+
+  /@udecode/plate-ui-toolbar@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-V5Z/Y64RtAyeoeZGqz+xTKKdiKE3M0CC23kF9tQx0ciHRSM+/VdV58Xp20Oe6RKlIe91BXNQrprIezbabZA1HA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@tippyjs/react': 4.2.6(react-dom@18.2.0)(react@18.2.0)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-floating': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-use: 17.4.0(react-dom@18.2.0)(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8939,6 +9757,69 @@ packages:
       - react-is
       - react-native
       - scheduler
+    dev: false
+
+  /@udecode/plate-ui@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-F5Llhi04azilhnq8AmuwoalDCGsK0HHQyzPsQ0G0GpZfjSf6sRN3dxfBE7AZ6WzK7hShS1CFdN+SV/2LF/K+qw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dnd: '>=14.0.0'
+      react-dnd-html5-backend: '>=14.0.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-hyperscript: '>=0.66.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-headless': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-alignment': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-block-quote': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-code-block': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-comments': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-cursor': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-emoji': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-find-replace': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-font': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-line-height': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-link': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-list': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-media': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-mention': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-placeholder': 21.5.0(@babel/core@7.22.15)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-table': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dnd: 16.0.1(@types/node@20.5.9)(@types/react@18.2.21)(react@18.2.0)
+      react-dnd-html5-backend: 16.0.1
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-hyperscript: 0.77.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+      use-context-selector: 1.4.1(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - '@types/react-dom'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-is
+      - react-native
+      - scheduler
+      - supports-color
     dev: false
 
   /@udecode/plate-ui@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
@@ -9039,6 +9920,48 @@ packages:
       - jotai-zustand
       - react-native
       - scheduler
+    dev: false
+
+  /@udecode/plate@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+    resolution: {integrity: sha512-uKAmKHwPgzo/XzrYWrbJ0FuqJRvU394aXZMkx4bXnHzVuCvQT4HNxZM4yM+RagdRHXr6xKZxdxQG70xKF2/5Jg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      slate: '>=0.94.0'
+      slate-history: '>=0.93.0'
+      slate-hyperscript: '>=0.66.0'
+      slate-react: '>=0.94.0'
+      styled-components: '>=5.0.0'
+    dependencies:
+      '@udecode/plate-headless': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)
+      '@udecode/plate-ui': 21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-history: 0.93.0(slate@0.94.1)
+      slate-hyperscript: 0.77.0(slate@0.94.1)
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      styled-components: 5.3.6(@babel/core@7.22.15)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/react'
+      - '@types/react-dom'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-dnd
+      - react-dnd-html5-backend
+      - react-is
+      - react-native
+      - scheduler
+      - supports-color
     dev: false
 
   /@udecode/plate@21.5.0(@babel/core@7.22.15)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
@@ -10092,6 +11015,10 @@ packages:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
 
+  /ast-types-flow@0.0.7:
+    resolution: {integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==}
+    dev: true
+
   /astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
@@ -10169,6 +11096,17 @@ packages:
 
   /aws4@1.12.0:
     resolution: {integrity: sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==}
+    dev: true
+
+  /axe-core@4.8.0:
+    resolution: {integrity: sha512-ZtlVZobOeDQhb/y2lMK6mznDw7TJHDNcKx5/bbBkFvArIQ5CVFhSI6hWWQnMx9I8cNmNmZ30wpDyOC2E2nvgbQ==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /axobject-query@3.2.1:
+    resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
+    dependencies:
+      dequal: 2.0.3
     dev: true
 
   /b4a@1.6.4:
@@ -10805,6 +11743,10 @@ packages:
       yauzl: 2.10.0
     dev: true
 
+  /damerau-levenshtein@1.0.8:
+    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+    dev: true
+
   /dashdash@1.14.1:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
     engines: {node: '>=0.10'}
@@ -10975,7 +11917,6 @@ packages:
   /dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
-    dev: false
 
   /detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
@@ -11135,7 +12076,6 @@ packages:
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-    dev: false
 
   /end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
@@ -11371,6 +12311,31 @@ packages:
       eslint: 8.48.0
       jsonc-eslint-parser: 2.3.0
       natural-compare: 1.4.0
+    dev: true
+
+  /eslint-plugin-jsx-a11y@6.7.1(eslint@8.48.0):
+    resolution: {integrity: sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+    dependencies:
+      '@babel/runtime': 7.22.11
+      aria-query: 5.1.3
+      array-includes: 3.1.6
+      array.prototype.flatmap: 1.3.1
+      ast-types-flow: 0.0.7
+      axe-core: 4.8.0
+      axobject-query: 3.2.1
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 8.48.0
+      has: 1.0.3
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.5
+      minimatch: 3.1.2
+      object.entries: 1.1.7
+      object.fromentries: 2.0.7
+      semver: 6.3.1
     dev: true
 
   /eslint-plugin-lodash@7.4.0(eslint@8.48.0):
@@ -12988,6 +13953,16 @@ packages:
 
   /kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+    dev: true
+
+  /language-subtag-registry@0.3.22:
+    resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==}
+    dev: true
+
+  /language-tags@1.0.5:
+    resolution: {integrity: sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==}
+    dependencies:
+      language-subtag-registry: 0.3.22
     dev: true
 
   /lazy-ass@1.6.0:


### PR DESCRIPTION
Activated `eslint-plugin-jsx-a11y` on all blocks

disabled all errors on color, color-kit, checklist and color-scale as they need to be overhauled anyway before they are finished.
disabled all errors on the gradient-block as there is already worked on it https://github.com/Frontify/guideline-blocks/pull/609

Fixed a lot of the errors.