### PR TITLE
chore: bump guideline-block-settings

### DIFF
--- a/examples/asset-upload/package.json
+++ b/examples/asset-upload/package.json
@@ -13,7 +13,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@frontify/guideline-blocks-shared": "workspace:*",
@@ -31,9 +31,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     },
     "devDependencies": {
         "@4tw/cypress-drag-drop": "^2.2.4",
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@cypress/vite-dev-server": "^5.0.6",
         "@testing-library/react": "^14.0.0",
         "@types/node": "^20.5.9",
@@ -39,7 +39,7 @@
         "vitest": "^0.34.4"
     },
     "dependencies": {
-        "@frontify/fondue": "12.0.0-beta.316",
+        "@frontify/fondue": "12.0.0-beta.321",
         "glob": "^10.3.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/animation-curve-block/package.json
+++ b/packages/animation-curve-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/react": "^18.2.21",
@@ -34,9 +34,9 @@
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/asset-kit-block/package.json
+++ b/packages/asset-kit-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/react": "^18.2.21",
@@ -32,9 +32,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/audio-block/package.json
+++ b/packages/audio-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/react": "^18.2.21",
@@ -32,9 +32,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/brand-positioning-block/package.json
+++ b/packages/brand-positioning-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/react": "^18.2.21",
@@ -31,9 +31,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/callout-block/package.json
+++ b/packages/callout-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/react": "^18.2.21",
@@ -31,9 +31,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/checklist-block/package.json
+++ b/packages/checklist-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@react-types/shared": "^3.19.0",
@@ -33,9 +33,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/checkbox": "^3.10.0",
         "@react-aria/focus": "^3.14.0",

--- a/packages/code-snippet-block/package.json
+++ b/packages/code-snippet-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/react": "^18.2.21",
@@ -35,9 +35,9 @@
         "@codemirror/language": "^6.9.0",
         "@codemirror/state": "^6.2.1",
         "@codemirror/view": "^6.17.0",
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@uiw/codemirror-extensions-langs": "^4.21.12",
         "@uiw/codemirror-themes-all": "^4.21.12",

--- a/packages/color-block/package.json
+++ b/packages/color-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/react": "^18.2.21",
@@ -32,9 +32,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dnd": "^16.0.1",

--- a/packages/color-kit-block/package.json
+++ b/packages/color-kit-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/react": "^18.2.21",
@@ -31,9 +31,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/color-scale-block/package.json
+++ b/packages/color-scale-block/package.json
@@ -15,7 +15,7 @@
     },
     "devDependencies": {
         "@4tw/cypress-drag-drop": "^2.2.4",
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/react": "^18.2.21",
@@ -32,9 +32,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dnd": "^16.0.1",

--- a/packages/compare-slider-block/package.json
+++ b/packages/compare-slider-block/package.json
@@ -12,7 +12,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/react": "^18.2.21",
@@ -28,9 +28,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-compare-slider": "^2.2.0",

--- a/packages/divider-block/package.json
+++ b/packages/divider-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/react": "^18.2.21",
@@ -31,9 +31,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/dos-donts-block/package.json
+++ b/packages/dos-donts-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/autosize": "^4.0.1",
@@ -34,9 +34,9 @@
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "autosize": "^5.0.2",
         "react": "^18.2.0",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/react": "^18.2.21",
@@ -31,9 +31,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/figma-block/package.json
+++ b/packages/figma-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/react": "^18.2.21",
@@ -31,9 +31,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/glyphs-block/package.json
+++ b/packages/glyphs-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@react-aria/interactions": "^3.17.0",
@@ -33,9 +33,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/gradient-block/package.json
+++ b/packages/gradient-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@react-aria/interactions": "^3.17.0",
@@ -33,9 +33,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/image-block/package.json
+++ b/packages/image-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/lodash-es": "^4.17.9",
@@ -32,9 +32,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/focus": "^3.14.0",
         "react": "^18.2.0",

--- a/packages/personal-note-block/package.json
+++ b/packages/personal-note-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/react": "^18.2.21",
@@ -31,9 +31,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "dayjs": "^1.11.6",
         "react": "^18.2.0",

--- a/packages/quote-block/package.json
+++ b/packages/quote-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/react": "^18.2.21",
@@ -31,9 +31,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,7 +15,7 @@
     "private": true,
     "author": "Frontify Developers <developers@frontify.com>",
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-typescript": "0.16.1",
         "@testing-library/react": "^14.0.0",
         "@types/node": "^20.5.9",
@@ -41,8 +41,8 @@
         "vitest": "^0.34.4"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
         "@uiw/codemirror-extensions-langs": "^4.21.12",
         "@uiw/react-codemirror": "^4.21.12"
     },

--- a/packages/sketchfab-block/package.json
+++ b/packages/sketchfab-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/react": "^18.2.21",
@@ -31,9 +31,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/storybook-block/package.json
+++ b/packages/storybook-block/package.json
@@ -13,7 +13,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/react": "^18.2.21",
@@ -30,9 +30,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/interactions": "^3.17.0",
         "react": "^18.2.0",

--- a/packages/text-block/package.json
+++ b/packages/text-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/lodash-es": "^4.17.9",
@@ -32,9 +32,9 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "lodash-es": "^4.17.21",
         "react": "^18.2.0",

--- a/packages/thumbnail-grid-block/package.json
+++ b/packages/thumbnail-grid-block/package.json
@@ -14,7 +14,7 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@babel/core": "^7.22.15",
+        "@babel/core": "^7.22.17",
         "@frontify/eslint-config-react": "0.16.1",
         "@frontify/frontify-cli": "^5.3.17",
         "@types/lodash-es": "^4.17.9",
@@ -37,9 +37,9 @@
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
-        "@frontify/app-bridge": "^3.0.0-beta.90",
-        "@frontify/fondue": "12.0.0-beta.316",
-        "@frontify/guideline-blocks-settings": "^0.29.5",
+        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "lodash-es": "^4.17.21",
         "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       glob:
         specifier: ^10.3.4
         version: 10.3.4
@@ -25,7 +25,7 @@ importers:
         specifier: ^2.2.4
         version: 2.2.4(cypress@13.2.0)
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@cypress/vite-dev-server':
         specifier: ^5.0.6
@@ -76,14 +76,14 @@ importers:
   examples/asset-upload:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -92,7 +92,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -152,14 +152,14 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2(@dnd-kit/core@6.0.8)(react@18.2.0)
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -171,7 +171,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -219,14 +219,14 @@ importers:
   packages/asset-kit-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -238,7 +238,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -289,14 +289,14 @@ importers:
   packages/audio-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -308,7 +308,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -359,14 +359,14 @@ importers:
   packages/brand-positioning-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -378,7 +378,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -426,14 +426,14 @@ importers:
   packages/callout-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -445,7 +445,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -493,14 +493,14 @@ importers:
   packages/checklist-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -530,7 +530,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -593,14 +593,14 @@ importers:
         specifier: ^6.17.0
         version: 6.18.0
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -621,7 +621,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -672,14 +672,14 @@ importers:
   packages/color-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -697,7 +697,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -748,14 +748,14 @@ importers:
   packages/color-kit-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -767,7 +767,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -815,14 +815,14 @@ importers:
   packages/color-scale-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -843,7 +843,7 @@ importers:
         specifier: ^2.2.4
         version: 2.2.4(cypress@13.2.0)
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -891,14 +891,14 @@ importers:
   packages/compare-slider-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -913,7 +913,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -958,14 +958,14 @@ importers:
   packages/divider-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -977,7 +977,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -1034,14 +1034,14 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2(@dnd-kit/core@6.0.8)(react@18.2.0)
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1056,7 +1056,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -1104,14 +1104,14 @@ importers:
   packages/example:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1123,7 +1123,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -1171,14 +1171,14 @@ importers:
   packages/figma-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1190,7 +1190,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -1238,14 +1238,14 @@ importers:
   packages/glyphs-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1257,7 +1257,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -1311,14 +1311,14 @@ importers:
   packages/gradient-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1330,7 +1330,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -1384,14 +1384,14 @@ importers:
   packages/image-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1406,7 +1406,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -1457,14 +1457,14 @@ importers:
   packages/personal-note-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1479,7 +1479,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -1527,14 +1527,14 @@ importers:
   packages/quote-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1546,7 +1546,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -1594,11 +1594,11 @@ importers:
   packages/shared:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@uiw/codemirror-extensions-langs':
         specifier: ^4.21.12
         version: 4.21.13(@codemirror/autocomplete@6.9.0)(@codemirror/language-data@6.3.1)(@codemirror/language@6.9.0)(@codemirror/legacy-modes@6.3.3)(@codemirror/state@6.2.1)(@codemirror/view@6.18.0)(@lezer/common@1.0.4)(@lezer/highlight@1.1.6)(@lezer/javascript@1.4.7)(@lezer/lr@1.3.10)
@@ -1607,7 +1607,7 @@ importers:
         version: 4.21.13(@babel/runtime@7.22.15)(@codemirror/autocomplete@6.9.0)(@codemirror/language@6.9.0)(@codemirror/lint@6.4.1)(@codemirror/search@6.5.2)(@codemirror/state@6.2.1)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.18.0)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-typescript':
         specifier: 0.16.1
@@ -1682,14 +1682,14 @@ importers:
   packages/sketchfab-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1701,7 +1701,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -1749,14 +1749,14 @@ importers:
   packages/storybook-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1771,7 +1771,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -1819,14 +1819,14 @@ importers:
   packages/text-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1841,7 +1841,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -1904,14 +1904,14 @@ importers:
         specifier: ^3.2.1
         version: 3.2.1(react@18.2.0)
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.90
+        specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.316
-        version: 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: 12.0.0-beta.321
+        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.5
-        version: 0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)
+        specifier: ^0.29.6
+        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1926,7 +1926,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
+        specifier: ^7.22.17
         version: 7.22.17
       '@frontify/eslint-config-react':
         specifier: 0.16.1
@@ -2049,7 +2049,7 @@ packages:
       '@babel/traverse': 7.22.17
       '@babel/types': 7.22.17
       convert-source-map: 1.9.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2127,7 +2127,7 @@ packages:
       '@babel/core': 7.22.17
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.4
     transitivePeerDependencies:
@@ -3305,28 +3305,10 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.22.16
       '@babel/types': 7.22.17
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/traverse@7.22.17(supports-color@5.5.0):
-    resolution: {integrity: sha512-xK4Uwm0JnAMvxYZxOVecss85WxTEIbTa7bnGyf/+EgCL5Zt3U7htUpEOWv9detPlamGKuRzCqw74xVglDWpPdg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.22.13
-      '@babel/generator': 7.22.15
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-function-name': 7.22.5
-      '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.22.16
-      '@babel/types': 7.22.17
-      debug: 4.3.4(supports-color@5.5.0)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@babel/types@7.22.17:
     resolution: {integrity: sha512-YSQPHLFtQNE5xN9tHuZnzu8vPr61wVTBZdfv1meex1NBosa4iT05k/Jw06ddJugi4bk7The/oSwQGFcksmEJQg==}
@@ -3673,7 +3655,7 @@ packages:
   /@cypress/vite-dev-server@5.0.6:
     resolution: {integrity: sha512-vqa6ImiMPnANJD1qQLytiLKi0oSZ2z+ZbYCybtGUmgZng/ITfZfsrNr7xd8Z8lUJboEXucK2eA3mPMdQvj05YQ==}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       find-up: 6.3.0
       node-html-parser: 5.3.3
       semver: 7.5.4
@@ -3771,14 +3753,6 @@ packages:
 
   /@emotion/memoize@0.8.1:
     resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
-    dev: false
-
-  /@emotion/stylis@0.8.5:
-    resolution: {integrity: sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==}
-    dev: false
-
-  /@emotion/unitless@0.7.5:
-    resolution: {integrity: sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==}
     dev: false
 
   /@emotion/unitless@0.8.1:
@@ -4003,7 +3977,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.21.0
       ignore: 5.2.4
@@ -4223,21 +4197,20 @@ packages:
       - ts-node
     dev: false
 
-  /@frontify/fondue@12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1):
-    resolution: {integrity: sha512-LzNOGZBt1U+iqFZzlanut6ykgjyypuiv75tVVUGjTStkesEcgw24zzg4oGn9NxoJccq22t5i1J++Sy6MaihnuQ==}
-    engines: {node: '>=16', npm: <=0, pnpm: '>=8'}
+  /@frontify/fondue@12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2):
+    resolution: {integrity: sha512-FgbF7cJv23y5QrGrFUCy8hpGmytPyVLo0As0hD0Bn7GjIfUpMPUrFsjYazWqCD2UQ+4c73jlMCC/sVSKVo0JhA==}
+    engines: {node: '>=16'}
     peerDependencies:
-      '@udecode/plate': ^21.5.0
-      framer-motion: ^10
       react: ^17 || ^18
       react-dom: ^17 || ^18
     dependencies:
+      '@ctrl/tinycolor': 4.0.2
       '@dnd-kit/core': 6.0.8(react-dom@18.2.0)(react@18.2.0)
       '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.0.8)(react@18.2.0)
       '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.0.8)(react@18.2.0)
       '@dnd-kit/utilities': 3.2.1(react@18.2.0)
       '@frontify/fondue-tokens': 3.3.0-next.5(ts-node@10.9.1)
-      '@popperjs/core': 2.11.6
+      '@popperjs/core': 2.11.8
       '@react-aria/accordion': 3.0.0-alpha.17(react@18.2.0)
       '@react-aria/aria-modal-polyfill': 3.7.1(react@18.2.0)
       '@react-aria/breadcrumbs': 3.5.2(react@18.2.0)
@@ -4273,43 +4246,59 @@ packages:
       '@react-types/dialog': 3.4.5(react@18.2.0)
       '@react-types/shared': 3.16.0(react@18.2.0)
       '@tailwindcss/forms': 0.5.6(tailwindcss@3.3.3)
-      '@udecode/plate': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/zustood': 1.1.3(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(zustand@3.7.2)
       '@xstate/immer': 0.3.1(immer@9.0.12)(xstate@4.28.1)
       '@xstate/react': 1.6.3(@types/react@18.2.21)(react@18.2.0)(xstate@4.28.1)
-      date-fns: 2.29.3
+      date-fns: 2.30.0
       escape-html: 1.0.3
       framer-motion: 10.16.4(react-dom@18.2.0)(react@18.2.0)
       immer: 9.0.12
       is-hotkey: 0.2.0
       react: 18.2.0
       react-colorful: 5.6.1(react-dom@18.2.0)(react@18.2.0)
-      react-datepicker: 4.8.0(react-dom@18.2.0)(react@18.2.0)
+      react-datepicker: 4.17.0(react-dom@18.2.0)(react@18.2.0)
       react-dnd: 16.0.1(@types/node@20.6.0)(@types/react@18.2.21)(react@18.2.0)
-      react-dnd-html5-backend: 15.1.2
+      react-dnd-html5-backend: 15.1.3
       react-dom: 18.2.0(react@18.2.0)
       react-fast-compare: 3.2.2
       react-is: 18.2.0
-      react-popper: 2.3.0(@popperjs/core@2.11.6)(react-dom@18.2.0)(react@18.2.0)
-      react-textarea-autosize: 8.4.0(@types/react@18.2.21)(react@18.2.0)
+      react-popper: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0)(react@18.2.0)
+      react-textarea-autosize: 8.5.3(@types/react@18.2.21)(react@18.2.0)
       remark-gfm: 3.0.1
-      remark-parse: 10.0.1
+      remark-parse: 10.0.2
       scheduler: 0.23.0
       slate: 0.94.1
-      slate-react: 0.98.2(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-      tinycolor2: 1.4.2
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       unified: 10.1.2
       unist-util-visit: 4.1.2
       xstate: 4.28.1
+      yaml: 2.3.2
     transitivePeerDependencies:
       - '@babel/core'
+      - '@babel/template'
       - '@types/hoist-non-react-statics'
       - '@types/node'
       - '@types/react'
+      - '@types/react-dom'
       - '@xstate/fsm'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-native
+      - slate-history
+      - slate-hyperscript
+      - styled-components
       - supports-color
       - tailwindcss
       - ts-node
+      - zustand
     dev: false
 
   /@frontify/frontify-cli@5.3.17(@types/node@20.6.0):
@@ -4342,8 +4331,8 @@ packages:
       - terser
     dev: true
 
-  /@frontify/guideline-blocks-settings@0.29.5(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@10.16.4)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1):
-    resolution: {integrity: sha512-RlfJhdaWhpn3BlQTNHFcrhomvOPMNjK4eWvtxeLkViTKRb/+OAY1Wzubho263zGW3WDoufg7uOpoO9rgSYP2ZA==}
+  /@frontify/guideline-blocks-settings@0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2):
+    resolution: {integrity: sha512-hZK7dB+0BltZa9MIEpKmKE7seqqpFEgZWjwP/MPCIvdBvdVJngdDT231ZFbQ44dEZdsOpSQ/E9r2+PYgWlLoAw==}
     peerDependencies:
       react: ^18
       react-dom: ^18
@@ -4353,8 +4342,8 @@ packages:
       '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.0.8)(react@18.2.0)
       '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.0.8)(react@18.2.0)
       '@frontify/app-bridge': 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
-      '@frontify/fondue': 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
-      '@frontify/sidebar-settings': 0.6.8(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+      '@frontify/fondue': 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+      '@frontify/sidebar-settings': 0.6.9(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@react-aria/focus': 3.14.1(react@18.2.0)
       '@react-stately/overlays': 3.6.2(react@18.2.0)
       '@udecode/plate': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
@@ -4370,7 +4359,6 @@ packages:
       - '@types/react'
       - '@types/react-dom'
       - '@xstate/fsm'
-      - framer-motion
       - jotai-devtools
       - jotai-immer
       - jotai-optics
@@ -4392,30 +4380,45 @@ packages:
       - supports-color
       - tailwindcss
       - ts-node
+      - zustand
     dev: false
 
-  /@frontify/sidebar-settings@0.6.8(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1):
-    resolution: {integrity: sha512-Kz1HzJR6BDlWj1sc7Vjv7nXAhEWACHc6Fh8Dok6RyfEOcET4RrSMiLr6PqI2+EgnZ4TKj5U5xOVUlNGpguGOCw==}
+  /@frontify/sidebar-settings@0.6.9(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2):
+    resolution: {integrity: sha512-aUKgnD8eYrHC0TINnFv5RLbsUKw+/moSUe0GswtEy5pJmO6O3dF0Qpcsz3yTstrKQTqU3KEled9E0PlFNftqhw==}
     peerDependencies:
       react: ^18
       react-dom: ^18
     dependencies:
       '@frontify/app-bridge': 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
-      '@frontify/fondue': 12.0.0-beta.316(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react@18.2.21)(@udecode/plate@21.5.0)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.3)(ts-node@10.9.1)
+      '@frontify/fondue': 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
+      - '@babel/template'
       - '@types/hoist-non-react-statics'
       - '@types/node'
       - '@types/react'
-      - '@udecode/plate'
+      - '@types/react-dom'
       - '@xstate/fsm'
-      - framer-motion
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-native
       - sinon
+      - slate-history
+      - slate-hyperscript
+      - styled-components
       - supports-color
       - tailwindcss
       - ts-node
+      - zustand
     dev: false
 
   /@humanwhocodes/config-array@0.11.11:
@@ -4423,7 +4426,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -4683,7 +4686,7 @@ packages:
       '@open-draft/until': 1.0.3
       '@types/debug': 4.1.8
       '@xmldom/xmldom': 0.8.10
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       headers-polyfill: 3.2.3
       outvariant: 1.4.0
       strict-event-emitter: 0.2.8
@@ -4751,10 +4754,6 @@ packages:
       picocolors: 1.0.0
       tslib: 2.6.2
     dev: true
-
-  /@popperjs/core@2.11.6:
-    resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
-    dev: false
 
   /@popperjs/core@2.11.8:
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
@@ -5325,7 +5324,7 @@ packages:
       '@react-aria/label': 3.7.0(react@18.2.0)
       '@react-aria/toggle': 3.8.0(react@18.2.0)
       '@react-aria/utils': 3.20.0(react@18.2.0)
-      '@react-stately/checkbox': 3.3.2(react@18.2.0)
+      '@react-stately/checkbox': 3.5.0(react@18.2.0)
       '@react-stately/toggle': 3.6.2(react@18.2.0)
       '@react-types/checkbox': 3.5.1(react@18.2.0)
       '@react-types/shared': 3.20.0(react@18.2.0)
@@ -5345,7 +5344,7 @@ packages:
       '@react-aria/live-announcer': 3.3.1
       '@react-aria/menu': 3.7.0(react-dom@18.2.0)(react@18.2.0)
       '@react-aria/overlays': 3.12.0(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/selection': 3.12.0(react@18.2.0)
+      '@react-aria/selection': 3.16.2(react@18.2.0)
       '@react-aria/textfield': 3.12.0(react@18.2.0)
       '@react-aria/utils': 3.20.0(react@18.2.0)
       '@react-stately/collections': 3.10.1(react@18.2.0)
@@ -5512,7 +5511,7 @@ packages:
       '@react-aria/focus': 3.14.1(react@18.2.0)
       '@react-aria/interactions': 3.18.0(react@18.2.0)
       '@react-aria/label': 3.7.0(react@18.2.0)
-      '@react-aria/selection': 3.12.0(react@18.2.0)
+      '@react-aria/selection': 3.16.2(react@18.2.0)
       '@react-aria/utils': 3.20.0(react@18.2.0)
       '@react-stately/collections': 3.10.1(react@18.2.0)
       '@react-stately/list': 3.9.2(react@18.2.0)
@@ -5537,10 +5536,10 @@ packages:
       '@react-aria/i18n': 3.8.2(react@18.2.0)
       '@react-aria/interactions': 3.18.0(react@18.2.0)
       '@react-aria/overlays': 3.12.0(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/selection': 3.12.0(react@18.2.0)
+      '@react-aria/selection': 3.16.2(react@18.2.0)
       '@react-aria/utils': 3.20.0(react@18.2.0)
       '@react-stately/collections': 3.10.1(react@18.2.0)
-      '@react-stately/menu': 3.4.4(react@18.2.0)
+      '@react-stately/menu': 3.5.5(react@18.2.0)
       '@react-stately/tree': 3.7.2(react@18.2.0)
       '@react-types/button': 3.8.0(react@18.2.0)
       '@react-types/menu': 3.9.4(react@18.2.0)
@@ -5599,7 +5598,7 @@ packages:
       '@react-aria/label': 3.7.0(react@18.2.0)
       '@react-aria/listbox': 3.7.1(react@18.2.0)
       '@react-aria/menu': 3.7.0(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/selection': 3.12.0(react@18.2.0)
+      '@react-aria/selection': 3.16.2(react@18.2.0)
       '@react-aria/utils': 3.20.0(react@18.2.0)
       '@react-aria/visually-hidden': 3.6.0(react@18.2.0)
       '@react-stately/select': 3.5.4(react@18.2.0)
@@ -5663,7 +5662,7 @@ packages:
       '@react-aria/i18n': 3.8.2(react@18.2.0)
       '@react-aria/interactions': 3.18.0(react@18.2.0)
       '@react-aria/live-announcer': 3.3.1
-      '@react-aria/selection': 3.12.0(react@18.2.0)
+      '@react-aria/selection': 3.16.2(react@18.2.0)
       '@react-aria/utils': 3.20.0(react@18.2.0)
       '@react-stately/table': 3.11.1(react@18.2.0)
       '@react-stately/virtualizer': 3.6.2(react@18.2.0)
@@ -5758,16 +5757,16 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@react-dnd/asap@4.0.0:
-    resolution: {integrity: sha512-0XhqJSc6pPoNnf8DhdsPHtUhRzZALVzYMTzRwV4VI6DJNJ/5xxfL9OQUwb8IH5/2x7lSf7nAZrnzUD+16VyOVQ==}
+  /@react-dnd/asap@4.0.1:
+    resolution: {integrity: sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==}
     dev: false
 
   /@react-dnd/asap@5.0.2:
     resolution: {integrity: sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==}
     dev: false
 
-  /@react-dnd/invariant@3.0.0:
-    resolution: {integrity: sha512-keberJRIqPX15IK3SWS/iO1t/kGETiL1oczKrDitAaMnQ+kpHf81l3MrRmFjvfqcnApE+izEvwM6GsyoIcpsVA==}
+  /@react-dnd/invariant@3.0.1:
+    resolution: {integrity: sha512-blqduwV86oiKw2Gr44wbe3pj3Z/OsXirc7ybCv9F/pLAR+Aih8F3rjeJzK0ANgtYKv5lCpkGVoZAeKitKDaD/g==}
     dev: false
 
   /@react-dnd/invariant@4.0.2:
@@ -5830,9 +5829,9 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.22.15
-      '@react-stately/list': 3.5.4(react@18.2.0)
-      '@react-stately/menu': 3.4.4(react@18.2.0)
-      '@react-stately/select': 3.3.2(react@18.2.0)
+      '@react-stately/list': 3.9.2(react@18.2.0)
+      '@react-stately/menu': 3.5.5(react@18.2.0)
+      '@react-stately/select': 3.5.4(react@18.2.0)
       '@react-stately/utils': 3.7.0(react@18.2.0)
       '@react-types/combobox': 3.8.0(react@18.2.0)
       '@react-types/shared': 3.20.0(react@18.2.0)
@@ -5895,7 +5894,7 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.22.15
-      '@react-stately/collections': 3.4.4(react@18.2.0)
+      '@react-stately/collections': 3.10.1(react@18.2.0)
       '@react-stately/selection': 3.13.4(react@18.2.0)
       '@react-stately/utils': 3.7.0(react@18.2.0)
       '@react-types/shared': 3.20.0(react@18.2.0)
@@ -5993,9 +5992,9 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.22.15
-      '@react-stately/collections': 3.4.4(react@18.2.0)
-      '@react-stately/list': 3.5.4(react@18.2.0)
-      '@react-stately/menu': 3.4.4(react@18.2.0)
+      '@react-stately/collections': 3.10.1(react@18.2.0)
+      '@react-stately/list': 3.9.2(react@18.2.0)
+      '@react-stately/menu': 3.5.5(react@18.2.0)
       '@react-stately/selection': 3.13.4(react@18.2.0)
       '@react-stately/utils': 3.7.0(react@18.2.0)
       '@react-types/select': 3.8.3(react@18.2.0)
@@ -6054,7 +6053,7 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.22.15
-      '@react-stately/collections': 3.4.4(react@18.2.0)
+      '@react-stately/collections': 3.10.1(react@18.2.0)
       '@react-stately/grid': 3.8.1(react@18.2.0)
       '@react-stately/selection': 3.13.4(react@18.2.0)
       '@react-types/grid': 3.2.1(react@18.2.0)
@@ -6093,7 +6092,7 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.22.15
-      '@react-stately/overlays': 3.4.2(react@18.2.0)
+      '@react-stately/overlays': 3.6.2(react@18.2.0)
       '@react-stately/utils': 3.7.0(react@18.2.0)
       '@react-types/tooltip': 3.4.4(react@18.2.0)
       react: 18.2.0
@@ -6117,7 +6116,7 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.22.15
-      '@react-stately/collections': 3.4.4(react@18.2.0)
+      '@react-stately/collections': 3.10.1(react@18.2.0)
       '@react-stately/selection': 3.13.4(react@18.2.0)
       '@react-stately/utils': 3.7.0(react@18.2.0)
       '@react-types/shared': 3.20.0(react@18.2.0)
@@ -6728,7 +6727,7 @@ packages:
       '@typescript-eslint/type-utils': 6.6.0(eslint@8.49.0)(typescript@5.2.2)
       '@typescript-eslint/utils': 6.6.0(eslint@8.49.0)(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 6.6.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.49.0
       graphemer: 1.4.0
       ignore: 5.2.4
@@ -6754,7 +6753,7 @@ packages:
       '@typescript-eslint/types': 6.6.0
       '@typescript-eslint/typescript-estree': 6.6.0(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 6.6.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.49.0
       typescript: 5.2.2
     transitivePeerDependencies:
@@ -6781,7 +6780,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.6.0(typescript@5.2.2)
       '@typescript-eslint/utils': 6.6.0(eslint@8.49.0)(typescript@5.2.2)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.49.0
       ts-api-utils: 1.0.3(typescript@5.2.2)
       typescript: 5.2.2
@@ -6805,7 +6804,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.6.0
       '@typescript-eslint/visitor-keys': 6.6.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
@@ -8133,43 +8132,6 @@ packages:
       - supports-color
     dev: false
 
-  /@udecode/plate-styled-components@21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-+ooCADdk3O1b+yaMe09e8M/Yxf9++Lk6YVMjHxSGS0pwTKIyfdTGwcbZ9oImCYxhlv1yGDOOgPEvuoog0cX3tw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      react-is: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      clsx: 1.2.1
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-is: 18.2.0
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-native
-      - scheduler
-    dev: false
-
   /@udecode/plate-styled-components@21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-+ooCADdk3O1b+yaMe09e8M/Yxf9++Lk6YVMjHxSGS0pwTKIyfdTGwcbZ9oImCYxhlv1yGDOOgPEvuoog0cX3tw==}
     peerDependencies:
@@ -8337,45 +8299,6 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-alignment@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-tCqLx6dxkUFesi3OfMFv4RFJFk4tIfIu07KpCzSpaX0B7u+cgV1rBWXeV+HvDquPKC4lsrVJ6lh3Yyx7LDdPBw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-alignment': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
   /@udecode/plate-ui-alignment@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-tCqLx6dxkUFesi3OfMFv4RFJFk4tIfIu07KpCzSpaX0B7u+cgV1rBWXeV+HvDquPKC4lsrVJ6lh3Yyx7LDdPBw==}
     peerDependencies:
@@ -8415,43 +8338,6 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-block-quote@21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-5YOjAeejfJ3zp3vpYr2G+TzpveZbdv8VLUe9YpcSNlPF/r/wAzojeUwbCEkN6WuVALWCGv8ylddNUZ/DNxpg8g==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-block-quote': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
   /@udecode/plate-ui-block-quote@21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-5YOjAeejfJ3zp3vpYr2G+TzpveZbdv8VLUe9YpcSNlPF/r/wAzojeUwbCEkN6WuVALWCGv8ylddNUZ/DNxpg8g==}
     peerDependencies:
@@ -8471,43 +8357,6 @@ packages:
       slate-history: 0.93.0(slate@0.94.1)
       slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       styled-components: 6.0.7(react-dom@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-button@21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-HVIIPshNJoDcjVs71zGCMOj5pC6OQfaiItxKggiG/EYw9eFXm4l/pCCGdny74vIQdTywWYj15yEYcMg0w1eY1Q==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-button': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8563,45 +8412,6 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-code-block@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-xN62xPasT5IVzi9k/pbdoR1U3ZobbolXVWDVqjvYaiPWgVtyt4VNxwaIjfqhtb2lTtQZakwV5XjaQcIcjeZO1g==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-code-block': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
   /@udecode/plate-ui-code-block@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-xN62xPasT5IVzi9k/pbdoR1U3ZobbolXVWDVqjvYaiPWgVtyt4VNxwaIjfqhtb2lTtQZakwV5XjaQcIcjeZO1g==}
     peerDependencies:
@@ -8641,45 +8451,6 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-combobox@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-QJys2QEc+KlslbKQ1M+PxhYl7JoYr4Lr948iaPIOuYyQQAPSZIR5DFTsKgwst8vDL9TqXQIb/lL/jcUCyC8GWw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-combobox': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-floating': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
   /@udecode/plate-ui-combobox@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-QJys2QEc+KlslbKQ1M+PxhYl7JoYr4Lr948iaPIOuYyQQAPSZIR5DFTsKgwst8vDL9TqXQIb/lL/jcUCyC8GWw==}
     peerDependencies:
@@ -8700,46 +8471,6 @@ packages:
       slate-history: 0.93.0(slate@0.94.1)
       slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       styled-components: 6.0.7(react-dom@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-comments@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-+XjpARWNGt/xXWIEb+wEjD47piKSw3Fh7Y4P1fO9zl5FwIJXBankhW6V2HJQP6nw9WkTYx/DABI/C4OFAHr19w==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-comments': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -8799,42 +8530,6 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-cursor@21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-/0ASgCw09m864FvtrMlTLz7OPCztos+h8t/6pnxI6lfJGzgG55wV1MOL5nVEhcEs5GO7sLEKPWYJt9hKxG54vQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
   /@udecode/plate-ui-cursor@21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-/0ASgCw09m864FvtrMlTLz7OPCztos+h8t/6pnxI6lfJGzgG55wV1MOL5nVEhcEs5GO7sLEKPWYJt9hKxG54vQ==}
     peerDependencies:
@@ -8857,47 +8552,6 @@ packages:
       - '@babel/core'
       - '@babel/template'
       - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-emoji@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-EzweF/YUbs6KEyGAnyBHHuduK1iW03fuPrT07YcN83RFxIu+sFPLDFbHmOVklVG1xOuo1k6WYyE37OvaNXEkeA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-combobox': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-emoji': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
       - jotai-devtools
       - jotai-immer
       - jotai-optics
@@ -8953,45 +8607,6 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-find-replace@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-b21VoIiKJbj60rMC8MPrTkayysZlGEoksJ+QpAwPi8whDtq/DCWeCY/8brGJPD/ivRKLmvlttnAkPQGCsL12JQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-find-replace': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
   /@udecode/plate-ui-find-replace@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-b21VoIiKJbj60rMC8MPrTkayysZlGEoksJ+QpAwPi8whDtq/DCWeCY/8brGJPD/ivRKLmvlttnAkPQGCsL12JQ==}
     peerDependencies:
@@ -9012,46 +8627,6 @@ packages:
       slate-history: 0.93.0(slate@0.94.1)
       slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       styled-components: 6.0.7(react-dom@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-font@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-wGy1TXSSF2KpWauKqpW7RBZ5EPgc16ds1r3bPNrw8utHO3WH4vuluGnWKJdIemguJeeTgiPiOp9LyVEA9PPZjQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-font': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9111,45 +8686,6 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-line-height@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-ddkxbNark/DbQLc2gNPfVnlA+5YUWuLeEMGl0nEAmuvq5IZCBZXz2icSccMjv+EqcioQVKBrHi+PqP0EUYMY2w==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-line-height': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
   /@udecode/plate-ui-line-height@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-ddkxbNark/DbQLc2gNPfVnlA+5YUWuLeEMGl0nEAmuvq5IZCBZXz2icSccMjv+EqcioQVKBrHi+PqP0EUYMY2w==}
     peerDependencies:
@@ -9170,46 +8706,6 @@ packages:
       slate-history: 0.93.0(slate@0.94.1)
       slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       styled-components: 6.0.7(react-dom@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-link@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-kk3gNmSqTFGfna/+fHDPl1iQ3jClOk44zrVgHanN72d4dWHzgyUSocrHrldUuQkECfFhCg4S5gIn82rKBK5rYg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-link': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9269,45 +8765,6 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-list@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-dtq4fMH3aJOxkq8klBC7AHLZgQDu9gD0ObFbvahqLFxyyHbRZmWWtKnOVZauCSvvU/Dsi6oK96wSBHHNezi3/w==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-list': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
   /@udecode/plate-ui-list@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-dtq4fMH3aJOxkq8klBC7AHLZgQDu9gD0ObFbvahqLFxyyHbRZmWWtKnOVZauCSvvU/Dsi6oK96wSBHHNezi3/w==}
     peerDependencies:
@@ -9328,49 +8785,6 @@ packages:
       slate-history: 0.93.0(slate@0.94.1)
       slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       styled-components: 6.0.7(react-dom@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-media@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-QYByExzxchHeXflxdMz/aI5reUeTHyPILj3vaunObE1b2q2Vi5TDFW2kBl/ikA5FtcJWgqFq6SH1cKUztSlVPg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-floating': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-link': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-media': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-link': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      js-video-url-parser: 0.5.1
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9433,46 +8847,6 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-mention@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-dD5QV/05oY9DJrF4Ls8rYlhZrZTqYD2oS2+eY31fo9TKsvbEArypVA9gbLAB+JtY3flWTF/XK8ZtQDK4Ky/Srw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-combobox': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-mention': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
   /@udecode/plate-ui-mention@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-dD5QV/05oY9DJrF4Ls8rYlhZrZTqYD2oS2+eY31fo9TKsvbEArypVA9gbLAB+JtY3flWTF/XK8ZtQDK4Ky/Srw==}
     peerDependencies:
@@ -9499,42 +8873,6 @@ packages:
       - '@babel/template'
       - '@types/react'
       - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-placeholder@21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-scZVD6/fWGMRYYAmlJ2OLGvYCeTD4zEOj2EPWeI5ztspqbVjqmGkOB/N54cSZkEZne2rwCfqNmJ8wkZr91T8Ig==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
       - jotai-devtools
       - jotai-immer
       - jotai-optics
@@ -9585,47 +8923,6 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-table@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-7ZN/RMbkINTFMV5i/3KD9UnAqHRTUlJ9NA554ahoRio3+GNzXfnf2wXF98Q4NnELz245nasqkOqZ3qj18u/l3Q==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-floating': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-table': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
   /@udecode/plate-ui-table@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-7ZN/RMbkINTFMV5i/3KD9UnAqHRTUlJ9NA554ahoRio3+GNzXfnf2wXF98Q4NnELz245nasqkOqZ3qj18u/l3Q==}
     peerDependencies:
@@ -9648,47 +8945,6 @@ packages:
       slate-history: 0.93.0(slate@0.94.1)
       slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       styled-components: 6.0.7(react-dom@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/react'
-      - '@types/react-dom'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-is
-      - react-native
-      - scheduler
-    dev: false
-
-  /@udecode/plate-ui-toolbar@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
-    resolution: {integrity: sha512-V5Z/Y64RtAyeoeZGqz+xTKKdiKE3M0CC23kF9tQx0ciHRSM+/VdV58Xp20Oe6RKlIe91BXNQrprIezbabZA1HA==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.94.0'
-      slate-history: '>=0.93.0'
-      slate-react: '>=0.94.0'
-      styled-components: '>=5.0.0'
-    dependencies:
-      '@tippyjs/react': 4.2.6(react-dom@18.2.0)(react@18.2.0)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-floating': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-use: 17.4.0(react-dom@18.2.0)(react@18.2.0)
-      slate: 0.94.1
-      slate-history: 0.93.0(slate@0.94.1)
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -9749,7 +9005,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+  /@udecode/plate-ui@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-F5Llhi04azilhnq8AmuwoalDCGsK0HHQyzPsQ0G0GpZfjSf6sRN3dxfBE7AZ6WzK7hShS1CFdN+SV/2LF/K+qw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9763,34 +9019,34 @@ packages:
       styled-components: '>=5.0.0'
     dependencies:
       '@udecode/plate-headless': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-alignment': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-block-quote': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-code-block': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-comments': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-cursor': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-emoji': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-find-replace': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-font': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-line-height': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-link': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-list': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-media': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-mention': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-placeholder': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-table': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-alignment': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-block-quote': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-code-block': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-comments': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-cursor': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-emoji': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-find-replace': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-font': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-line-height': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-link': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-list': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-media': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-mention': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-placeholder': 21.5.0(@babel/core@7.22.17)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-table': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
       react: 18.2.0
       react-dnd: 16.0.1(@types/node@20.6.0)(@types/react@18.2.21)(react@18.2.0)
-      react-dnd-html5-backend: 16.0.1
+      react-dnd-html5-backend: 15.1.3
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
       slate-history: 0.93.0(slate@0.94.1)
       slate-hyperscript: 0.77.0(slate@0.94.1)
       slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+      styled-components: 6.0.7(react-dom@18.2.0)(react@18.2.0)
       use-context-selector: 1.4.1(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)
     transitivePeerDependencies:
       - '@babel/core'
@@ -9912,7 +9168,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6):
+  /@udecode/plate@21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7):
     resolution: {integrity: sha512-uKAmKHwPgzo/XzrYWrbJ0FuqJRvU394aXZMkx4bXnHzVuCvQT4HNxZM4yM+RagdRHXr6xKZxdxQG70xKF2/5Jg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -9924,14 +9180,14 @@ packages:
       styled-components: '>=5.0.0'
     dependencies:
       '@udecode/plate-headless': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)
-      '@udecode/plate-ui': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@5.3.6)
+      '@udecode/plate-ui': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
       slate-history: 0.93.0(slate@0.94.1)
       slate-hyperscript: 0.77.0(slate@0.94.1)
       slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+      styled-components: 6.0.7(react-dom@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -11081,7 +10337,7 @@ packages:
     resolution: {integrity: sha512-TAlMYvOuwGyLK3PfBb5WKBXZmXz2fVCgv23d6zZFdle/q3gPjmxBaeuC0pY0Dzs5PWMSgfqqEZkrye19GlDTgw==}
     dependencies:
       archy: 1.0.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       fastq: 1.15.0
     transitivePeerDependencies:
       - supports-color
@@ -11144,21 +10400,6 @@ packages:
       '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.17)
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /babel-plugin-styled-components@2.1.4(@babel/core@7.22.17)(styled-components@5.3.6):
-    resolution: {integrity: sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==}
-    peerDependencies:
-      styled-components: '>= 2'
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-module-imports': 7.22.15
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.22.17)
-      lodash: 4.17.21
-      picomatch: 2.3.1
-      styled-components: 5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
     dev: false
 
   /bail@1.0.5:
@@ -11752,9 +10993,11 @@ packages:
     engines: {node: '>= 12'}
     dev: true
 
-  /date-fns@2.29.3:
-    resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
+  /date-fns@2.30.0:
+    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
+    dependencies:
+      '@babel/runtime': 7.22.15
     dev: false
 
   /dayjs@1.11.9:
@@ -11783,30 +11026,6 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-
-  /debug@4.3.4(supports-color@5.5.0):
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-      supports-color: 5.5.0
-    dev: false
-
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -11818,7 +11037,6 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
-    dev: true
 
   /decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
@@ -11946,11 +11164,11 @@ packages:
   /dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
-  /dnd-core@15.1.1:
-    resolution: {integrity: sha512-Mtj/Sltcx7stVXzeDg4g7roTe/AmzRuIf/FYOxX6F8gULbY54w066BlErBOzQfn9RIJ3gAYLGX7wvVvoBSq7ig==}
+  /dnd-core@15.1.2:
+    resolution: {integrity: sha512-EOec1LyJUuGRFg0LDa55rSRAUe97uNVKVkUo8iyvzQlcECYTuPblVQfRWXWj1OyPseFIeebWpNmKFy0h6BcF1A==}
     dependencies:
-      '@react-dnd/asap': 4.0.0
-      '@react-dnd/invariant': 3.0.0
+      '@react-dnd/asap': 4.0.1
+      '@react-dnd/invariant': 3.0.1
       redux: 4.2.1
     dev: false
 
@@ -12478,7 +11696,7 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.49.0
       lodash: 4.17.21
       natural-compare: 1.4.0
@@ -12527,7 +11745,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -14496,7 +13714,7 @@ packages:
   /micromark@2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -14505,7 +13723,7 @@ packages:
     resolution: {integrity: sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==}
     dependencies:
       '@types/debug': 4.1.8
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -15350,26 +14568,26 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /react-datepicker@4.8.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-u69zXGHMpxAa4LeYR83vucQoUCJQ6m/WBsSxmUMu/M8ahTSVMMyiyQzauHgZA2NUr9y0FUgOAix71hGYUb6tvg==}
+  /react-datepicker@4.17.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-z50H44XbnkYlns7gVHzHK4jWAzLfvQehh5Lvindb09J97yVJKIbsmHs98D0f77tdZc3dSYM7oAqsFY55dBeOGQ==}
     peerDependencies:
       react: ^16.9.0 || ^17 || ^18
       react-dom: ^16.9.0 || ^17 || ^18
     dependencies:
-      '@popperjs/core': 2.11.6
+      '@popperjs/core': 2.11.8
       classnames: 2.3.2
-      date-fns: 2.29.3
+      date-fns: 2.30.0
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-onclickoutside: 6.13.0(react-dom@18.2.0)(react@18.2.0)
-      react-popper: 2.3.0(@popperjs/core@2.11.6)(react-dom@18.2.0)(react@18.2.0)
+      react-popper: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0)(react@18.2.0)
     dev: false
 
-  /react-dnd-html5-backend@15.1.2:
-    resolution: {integrity: sha512-mem9QbutUF+aA2YC1y47G3ECjnYV/sCYKSnu5Jd7cbg3fLMPAwbnTf/JayYdnCH5l3eg9akD9dQt+cD0UdF8QQ==}
+  /react-dnd-html5-backend@15.1.3:
+    resolution: {integrity: sha512-HH/8nOEmrrcRGHMqJR91FOwhnLlx5SRLXmsQwZT3IPcBjx88WT+0pWC5A4tDOYDdoooh9k+KMPvWfxooR5TcOA==}
     dependencies:
-      dnd-core: 15.1.1
+      dnd-core: 15.1.2
     dev: false
 
   /react-dnd-html5-backend@16.0.1:
@@ -15445,14 +14663,14 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /react-popper@2.3.0(@popperjs/core@2.11.6)(react-dom@18.2.0)(react@18.2.0):
+  /react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
     peerDependencies:
       '@popperjs/core': ^2.0.0
       react: ^16.8.0 || ^17 || ^18
       react-dom: ^16.8.0 || ^17 || ^18
     dependencies:
-      '@popperjs/core': 2.11.6
+      '@popperjs/core': 2.11.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-fast-compare: 3.2.2
@@ -15514,20 +14732,6 @@ packages:
       invariant: 2.2.4
       react: 18.2.0
       tslib: 2.6.2
-    dev: false
-
-  /react-textarea-autosize@8.4.0(@types/react@18.2.21)(react@18.2.0):
-    resolution: {integrity: sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.22.15
-      react: 18.2.0
-      use-composed-ref: 1.3.0(react@18.2.0)
-      use-latest: 1.2.1(@types/react@18.2.21)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
     dev: false
 
   /react-textarea-autosize@8.5.3(@types/react@18.2.21)(react@18.2.0):
@@ -15771,8 +14975,8 @@ packages:
       - supports-color
     dev: false
 
-  /remark-parse@10.0.1:
-    resolution: {integrity: sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==}
+  /remark-parse@10.0.2:
+    resolution: {integrity: sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==}
     dependencies:
       '@types/mdast': 3.0.12
       mdast-util-from-markdown: 1.3.1
@@ -16081,27 +15285,6 @@ packages:
       slate: 0.94.1
     dev: false
 
-  /slate-react@0.98.2(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1):
-    resolution: {integrity: sha512-1GOi0DRuGMpzAmkW0DYSebEBHhE4ryffCW/bprlo4B2wdkMgt0dC9NtXHK76B3QjJwtGQZ+OsiFtwT9O3hRamQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      slate: '>=0.65.3'
-    dependencies:
-      '@juggle/resize-observer': 3.4.0
-      '@types/is-hotkey': 0.1.7
-      '@types/lodash': 4.14.198
-      direction: 1.0.4
-      is-hotkey: 0.1.8
-      is-plain-object: 5.0.0
-      lodash: 4.17.21
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      scroll-into-view-if-needed: 2.2.31
-      slate: 0.94.1
-      tiny-invariant: 1.0.6
-    dev: false
-
   /slate-react@0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1):
     resolution: {integrity: sha512-p1BnF9eRyRM0i5hkgOb11KgmpWLQm9Zyp6jVkOAj5fPdIGheKhg48Z7aWKrayeJ4nmRyi/NjRZz/io5hQcphmw==}
     peerDependencies:
@@ -16126,7 +15309,7 @@ packages:
   /slate@0.94.1:
     resolution: {integrity: sha512-GH/yizXr1ceBoZ9P9uebIaHe3dC/g6Plpf9nlUwnvoyf6V1UOYrRwkabtOCd3ZfIGxomY4P7lfgLr7FPH8/BKA==}
     dependencies:
-      immer: 9.0.12
+      immer: 9.0.21
       is-plain-object: 5.0.0
       tiny-warning: 1.0.3
     dev: false
@@ -16397,32 +15580,6 @@ packages:
     resolution: {integrity: sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==}
     dev: false
 
-  /styled-components@5.3.6(@babel/core@7.22.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==}
-    engines: {node: '>=10'}
-    requiresBuild: true
-    peerDependencies:
-      react: '>= 16.8.0'
-      react-dom: '>= 16.8.0'
-      react-is: '>= 16.8.0'
-    dependencies:
-      '@babel/helper-module-imports': 7.22.15
-      '@babel/traverse': 7.22.17(supports-color@5.5.0)
-      '@emotion/is-prop-valid': 1.2.1
-      '@emotion/stylis': 0.8.5
-      '@emotion/unitless': 0.7.5
-      babel-plugin-styled-components: 2.1.4(@babel/core@7.22.17)(styled-components@5.3.6)
-      css-to-react-native: 3.2.0
-      hoist-non-react-statics: 3.3.2
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-is: 18.2.0
-      shallowequal: 1.1.0
-      supports-color: 5.5.0
-    transitivePeerDependencies:
-      - '@babel/core'
-    dev: false
-
   /styled-components@6.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-xIwWuiRMYR43mskVsW9MGTRjSo7ol4bcVjT595fGUp3OLBJOlOgaiKaxsHdC4a2HqWKqKnh0CmcRbk5ogyDjTg==}
     engines: {node: '>= 16'}
@@ -16493,7 +15650,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -16599,10 +15755,6 @@ packages:
   /tinybench@2.5.0:
     resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
     dev: true
-
-  /tinycolor2@1.4.2:
-    resolution: {integrity: sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==}
-    dev: false
 
   /tinypool@0.7.0:
     resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
@@ -17159,7 +16311,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       mlly: 1.4.2
       pathe: 1.1.1
       picocolors: 1.0.0
@@ -17188,7 +16340,7 @@ packages:
       '@microsoft/api-extractor': 7.36.4(@types/node@20.6.0)
       '@rollup/pluginutils': 5.0.4
       '@vue/language-core': 1.8.10(typescript@5.2.2)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       kolorist: 1.8.0
       typescript: 5.2.2
       vite: 4.4.9(@types/node@20.6.0)
@@ -17291,7 +16443,7 @@ packages:
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.8
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       local-pkg: 0.4.3
       magic-string: 0.30.3
       pathe: 1.1.1


### PR DESCRIPTION
Also bumped `fondue`, `babel/core` and `app-bridge`