### PR TITLE
chore: rename OrderableList component to LegacyOrderableList

### DIFF
--- a/examples/asset-upload/package.json
+++ b/examples/asset-upload/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     }

--- a/examples/asset-upload/package.json
+++ b/examples/asset-upload/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/examples/asset-upload/package.json
+++ b/examples/asset-upload/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "react": "^18.2.0",

--- a/examples/asset-upload/package.json
+++ b/examples/asset-upload/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "vitest": "^0.34.4"
     },
     "dependencies": {
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "glob": "^10.3.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "vitest": "^0.34.4"
     },
     "dependencies": {
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "glob": "^10.3.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/animation-curve-block/package.json
+++ b/packages/animation-curve-block/package.json
@@ -35,7 +35,7 @@
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/animation-curve-block/package.json
+++ b/packages/animation-curve-block/package.json
@@ -35,7 +35,7 @@
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/animation-curve-block/package.json
+++ b/packages/animation-curve-block/package.json
@@ -36,7 +36,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/animation-curve-block/package.json
+++ b/packages/animation-curve-block/package.json
@@ -34,7 +34,7 @@
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/asset-kit-block/package.json
+++ b/packages/asset-kit-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/asset-kit-block/package.json
+++ b/packages/asset-kit-block/package.json
@@ -32,7 +32,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/asset-kit-block/package.json
+++ b/packages/asset-kit-block/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/asset-kit-block/package.json
+++ b/packages/asset-kit-block/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/audio-block/package.json
+++ b/packages/audio-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/audio-block/package.json
+++ b/packages/audio-block/package.json
@@ -32,7 +32,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/audio-block/package.json
+++ b/packages/audio-block/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/audio-block/package.json
+++ b/packages/audio-block/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/brand-positioning-block/package.json
+++ b/packages/brand-positioning-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/brand-positioning-block/package.json
+++ b/packages/brand-positioning-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/brand-positioning-block/package.json
+++ b/packages/brand-positioning-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/brand-positioning-block/package.json
+++ b/packages/brand-positioning-block/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/callout-block/package.json
+++ b/packages/callout-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/callout-block/package.json
+++ b/packages/callout-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/callout-block/package.json
+++ b/packages/callout-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/callout-block/package.json
+++ b/packages/callout-block/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/checklist-block/package.json
+++ b/packages/checklist-block/package.json
@@ -33,7 +33,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/checklist-block/package.json
+++ b/packages/checklist-block/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/checkbox": "^3.10.0",
         "@react-aria/focus": "^3.14.0",

--- a/packages/checklist-block/package.json
+++ b/packages/checklist-block/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/checkbox": "^3.10.0",

--- a/packages/checklist-block/package.json
+++ b/packages/checklist-block/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/checkbox": "^3.10.0",

--- a/packages/checklist-block/src/ChecklistBlock.spec.ct.tsx
+++ b/packages/checklist-block/src/ChecklistBlock.spec.ct.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { withAppBridgeBlockStubs } from '@frontify/app-bridge';
-import { OrderableListItem } from '@frontify/fondue';
+import { LegacyOrderableListItem } from '@frontify/fondue';
 import { toRgbaString } from '@frontify/guideline-blocks-settings';
 import { mount } from 'cypress/react18';
 import { ChecklistBlock } from './ChecklistBlock';
@@ -34,8 +34,8 @@ const CHECKBOX_DATE = '[data-test-id="checkbox-date"]';
 const DRAGGABLE_ITEM = '[data-test-id=draggable-item]';
 const INSERTION_INDICATOR = '[data-test-id=insertion-indicator]';
 
-const createContentArray = (length: number, fixedParams?: Partial<OrderableListItem<ChecklistContent>>) => {
-    const createRandomItem = (fixedParams?: Partial<OrderableListItem<ChecklistContent>>) => {
+const createContentArray = (length: number, fixedParams?: Partial<LegacyOrderableListItem<ChecklistContent>>) => {
+    const createRandomItem = (fixedParams?: Partial<LegacyOrderableListItem<ChecklistContent>>) => {
         const item = createItem('text', null);
 
         item.completed = Math.random() > 0.5;

--- a/packages/checklist-block/src/ChecklistBlock.tsx
+++ b/packages/checklist-block/src/ChecklistBlock.tsx
@@ -5,13 +5,13 @@ import {
     Button,
     ButtonEmphasis,
     ButtonSize,
-    DragProperties,
     IconEye,
     IconEyeOff,
     IconSize,
-    ItemDragState,
-    OrderableList,
-    OrderableListItem,
+    LegacyDragProperties,
+    LegacyItemDragState,
+    LegacyOrderableList,
+    LegacyOrderableListItem,
 } from '@frontify/fondue';
 
 import { BlockProps, joinClassNames, toHex8String } from '@frontify/guideline-blocks-settings';
@@ -69,8 +69,8 @@ export const ChecklistBlock: FC<BlockProps> = ({ appBridge }) => {
     };
 
     const renderChecklistItem = (
-        { text, id, completed, updatedAt }: OrderableListItem<ChecklistContent>,
-        { componentDragState, isFocusVisible }: DragProperties,
+        { text, id, completed, updatedAt }: LegacyOrderableListItem<ChecklistContent>,
+        { componentDragState, isFocusVisible }: LegacyDragProperties,
     ) => {
         const index = findIndexById(displayableItems, id);
         displayableItems.sort((previousItem, currentItem) => previousItem.sort - currentItem.sort);
@@ -96,7 +96,7 @@ export const ChecklistBlock: FC<BlockProps> = ({ appBridge }) => {
             />
         );
         // Preview is rendered in external DOM, requires own context provider
-        return componentDragState === ItemDragState.Preview ? (
+        return componentDragState === LegacyItemDragState.Preview ? (
             <SettingsContext.Provider value={settings}>{content}</SettingsContext.Provider>
         ) : (
             content
@@ -107,7 +107,7 @@ export const ChecklistBlock: FC<BlockProps> = ({ appBridge }) => {
 
     const displayableItems = isEditing || showCompleted ? content : filterCompleteItems(content);
 
-    const handleMove = (modifiedItems: OrderableListItem<ChecklistContent>[]) => {
+    const handleMove = (modifiedItems: LegacyOrderableListItem<ChecklistContent>[]) => {
         const modifiedArray = displayableItems.map((item) => {
             const matchingModifiedItem = modifiedItems.find((modifiedItem) => modifiedItem.id === item.id);
             if (matchingModifiedItem) {
@@ -121,7 +121,7 @@ export const ChecklistBlock: FC<BlockProps> = ({ appBridge }) => {
     };
 
     const orderableListItems = displayableItems.map(
-        ({ id, completed, sort, text, updatedAt }: OrderableListItem<ChecklistContent>, index: number) => {
+        ({ id, completed, sort, text, updatedAt }: LegacyOrderableListItem<ChecklistContent>, index: number) => {
             return {
                 id,
                 text,
@@ -177,7 +177,7 @@ export const ChecklistBlock: FC<BlockProps> = ({ appBridge }) => {
                         </div>
                         <div className="tw-mt-3" data-test-id="checklist-container">
                             {displayableItems.length > 0 && (
-                                <OrderableList
+                                <LegacyOrderableList
                                     items={orderableListItems}
                                     dragDisabled={!isEditing}
                                     renderContent={renderChecklistItem}

--- a/packages/checklist-block/src/components/ChecklistItem.tsx
+++ b/packages/checklist-block/src/components/ChecklistItem.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { ButtonGroup, ButtonSize, IconCaretDown, IconCaretUp, IconCross, ItemDragState } from '@frontify/fondue';
+import { ButtonGroup, ButtonSize, IconCaretDown, IconCaretUp, IconCross, LegacyItemDragState } from '@frontify/fondue';
 import { joinClassNames } from '@frontify/guideline-blocks-settings';
 import { getInteractionModality, useFocusWithin, useHover } from '@react-aria/interactions';
 import { FC, useState } from 'react';
@@ -42,14 +42,14 @@ export const ChecklistItem: FC<ChecklistItemProps> = ({
     const shouldDisplayControlPanel =
         (isHovered || focused || isDragFocusVisible) &&
         mode === ChecklistItemMode.Edit &&
-        dragState === ItemDragState.Idle;
+        dragState === LegacyItemDragState.Idle;
 
     const { completed, updatedAt, id, text } = item || DefaultChecklistItem;
 
     const containerClasses = joinClassNames([
         'tw-relative tw-rounded tw-p-1',
-        dragState === ItemDragState.Preview && 'tw-bg-white',
-        dragState === ItemDragState.Dragging && 'tw-bg-black-5 tw-opacity-70',
+        dragState === LegacyItemDragState.Preview && 'tw-bg-white',
+        dragState === LegacyItemDragState.Dragging && 'tw-bg-black-5 tw-opacity-70',
         shouldDisplayControlPanel && 'tw-bg-black-5',
     ]);
 

--- a/packages/checklist-block/src/helpers/createItem.ts
+++ b/packages/checklist-block/src/helpers/createItem.ts
@@ -1,9 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { OrderableListItem } from '@frontify/fondue';
+import { LegacyOrderableListItem } from '@frontify/fondue';
 import { ChecklistContent } from '../types';
 
-export const createItem = (text: string, index: number | null): OrderableListItem<ChecklistContent> => {
+export const createItem = (text: string, index: number | null): LegacyOrderableListItem<ChecklistContent> => {
     const creationDate = Date.now();
     const id = Math.ceil(Math.random() * creationDate).toString();
 

--- a/packages/checklist-block/src/helpers/filterCompletedItems.ts
+++ b/packages/checklist-block/src/helpers/filterCompletedItems.ts
@@ -1,9 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { OrderableListItem } from '@frontify/fondue';
+import { LegacyOrderableListItem } from '@frontify/fondue';
 import { ChecklistContent } from '../types';
 
 export const filterCompleteItems = (
-    content: OrderableListItem<ChecklistContent>[],
-): OrderableListItem<ChecklistContent>[] =>
-    content.filter(({ completed }: OrderableListItem<ChecklistContent>) => !completed);
+    content: LegacyOrderableListItem<ChecklistContent>[],
+): LegacyOrderableListItem<ChecklistContent>[] =>
+    content.filter(({ completed }: LegacyOrderableListItem<ChecklistContent>) => !completed);

--- a/packages/checklist-block/src/helpers/updateItemById.ts
+++ b/packages/checklist-block/src/helpers/updateItemById.ts
@@ -1,15 +1,15 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { OrderableListItem } from '@frontify/fondue';
+import { LegacyOrderableListItem } from '@frontify/fondue';
 import { ChecklistContent } from '../types';
 
 export const updateItemById = (
-    array: OrderableListItem<ChecklistContent>[],
+    array: LegacyOrderableListItem<ChecklistContent>[],
     idToUpdate: string,
     properties: Partial<ChecklistContent>,
-): OrderableListItem<ChecklistContent>[] =>
+): LegacyOrderableListItem<ChecklistContent>[] =>
     array.reduce(
-        (acc: OrderableListItem<ChecklistContent>[], item: OrderableListItem<ChecklistContent>) =>
+        (acc: LegacyOrderableListItem<ChecklistContent>[], item: LegacyOrderableListItem<ChecklistContent>) =>
             item.id === idToUpdate ? [...acc, { ...item, ...properties }] : [...acc, item],
         [],
     );

--- a/packages/checklist-block/src/types.ts
+++ b/packages/checklist-block/src/types.ts
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { ButtonSize, Color, LegacyItemDragState, OrderableListItem } from '@frontify/fondue';
+import { ButtonSize, Color, LegacyItemDragState, LegacyOrderableListItem } from '@frontify/fondue';
 import { MouseEvent, ReactElement } from 'react';
 
 export type ChecklistItemProps = {
@@ -128,7 +128,7 @@ export type DecorationStyle = {
 };
 
 export type Settings = {
-    content: OrderableListItem<ChecklistContent>[];
+    content: LegacyOrderableListItem<ChecklistContent>[];
     textColor: Color;
     checkboxColor: Color;
     completeTextColor: Color;

--- a/packages/checklist-block/src/types.ts
+++ b/packages/checklist-block/src/types.ts
@@ -1,13 +1,13 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { ButtonSize, Color, ItemDragState, OrderableListItem } from '@frontify/fondue';
+import { ButtonSize, Color, LegacyItemDragState, OrderableListItem } from '@frontify/fondue';
 import { MouseEvent, ReactElement } from 'react';
 
 export type ChecklistItemProps = {
     item?: ChecklistContent;
     toggleCompleted?: (value: boolean) => void;
     isDragFocusVisible?: boolean;
-    dragState?: ItemDragState;
+    dragState?: LegacyItemDragState;
     onTextModified?: (text: string) => void;
     mode: ChecklistItemMode;
     isFirst?: boolean;

--- a/packages/checklist-block/src/utilities/reorderList.ts
+++ b/packages/checklist-block/src/utilities/reorderList.ts
@@ -1,9 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { OrderableListItem } from '@frontify/fondue';
+import { LegacyOrderableListItem } from '@frontify/fondue';
 import { ChecklistContent } from '../types';
 
-export const reorderList = <T extends OrderableListItem<ChecklistContent>>(
+export const reorderList = <T extends LegacyOrderableListItem<ChecklistContent>>(
     array: T[],
     originalIndex: number,
     newIndex: number,

--- a/packages/code-snippet-block/package.json
+++ b/packages/code-snippet-block/package.json
@@ -36,7 +36,7 @@
         "@codemirror/state": "^6.2.1",
         "@codemirror/view": "^6.17.0",
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@uiw/codemirror-extensions-langs": "^4.21.12",

--- a/packages/code-snippet-block/package.json
+++ b/packages/code-snippet-block/package.json
@@ -37,7 +37,7 @@
         "@codemirror/view": "^6.17.0",
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@uiw/codemirror-extensions-langs": "^4.21.12",
         "@uiw/codemirror-themes-all": "^4.21.12",

--- a/packages/code-snippet-block/package.json
+++ b/packages/code-snippet-block/package.json
@@ -35,7 +35,7 @@
         "@codemirror/language": "^6.9.0",
         "@codemirror/state": "^6.2.1",
         "@codemirror/view": "^6.17.0",
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/code-snippet-block/package.json
+++ b/packages/code-snippet-block/package.json
@@ -36,7 +36,7 @@
         "@codemirror/state": "^6.2.1",
         "@codemirror/view": "^6.17.0",
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@uiw/codemirror-extensions-langs": "^4.21.12",

--- a/packages/color-block/package.json
+++ b/packages/color-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dnd": "^16.0.1",

--- a/packages/color-block/package.json
+++ b/packages/color-block/package.json
@@ -32,7 +32,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-block/package.json
+++ b/packages/color-block/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/color-block/package.json
+++ b/packages/color-block/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/color-kit-block/package.json
+++ b/packages/color-kit-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/color-kit-block/package.json
+++ b/packages/color-kit-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/color-kit-block/package.json
+++ b/packages/color-kit-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/color-kit-block/package.json
+++ b/packages/color-kit-block/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-scale-block/package.json
+++ b/packages/color-scale-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dnd": "^16.0.1",

--- a/packages/color-scale-block/package.json
+++ b/packages/color-scale-block/package.json
@@ -32,7 +32,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-scale-block/package.json
+++ b/packages/color-scale-block/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/color-scale-block/package.json
+++ b/packages/color-scale-block/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/color-scale-block/src/components/ColorSquare.tsx
+++ b/packages/color-scale-block/src/components/ColorSquare.tsx
@@ -7,7 +7,7 @@ import {
     ButtonStyle,
     IconSize,
     IconTrashBin,
-    ItemDragState,
+    LegacyItemDragState,
     LegacyTooltip,
     TooltipAlignment,
     TooltipPosition,
@@ -44,7 +44,7 @@ export const ColorSquare = ({
         item: color,
         collect: (monitor) => {
             return {
-                componentDragState: monitor.isDragging() ? ItemDragState.Dragging : ItemDragState.Idle,
+                componentDragState: monitor.isDragging() ? LegacyItemDragState.Dragging : LegacyItemDragState.Idle,
             };
         },
         type: 'color',

--- a/packages/compare-slider-block/package.json
+++ b/packages/compare-slider-block/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-compare-slider": "^2.2.0",

--- a/packages/compare-slider-block/package.json
+++ b/packages/compare-slider-block/package.json
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/compare-slider-block/package.json
+++ b/packages/compare-slider-block/package.json
@@ -28,7 +28,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/compare-slider-block/package.json
+++ b/packages/compare-slider-block/package.json
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/divider-block/package.json
+++ b/packages/divider-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/divider-block/package.json
+++ b/packages/divider-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/divider-block/package.json
+++ b/packages/divider-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/divider-block/package.json
+++ b/packages/divider-block/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/dos-donts-block/package.json
+++ b/packages/dos-donts-block/package.json
@@ -35,7 +35,7 @@
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "autosize": "^5.0.2",

--- a/packages/dos-donts-block/package.json
+++ b/packages/dos-donts-block/package.json
@@ -35,7 +35,7 @@
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "autosize": "^5.0.2",

--- a/packages/dos-donts-block/package.json
+++ b/packages/dos-donts-block/package.json
@@ -36,7 +36,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "autosize": "^5.0.2",
         "react": "^18.2.0",

--- a/packages/dos-donts-block/package.json
+++ b/packages/dos-donts-block/package.json
@@ -34,7 +34,7 @@
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/figma-block/package.json
+++ b/packages/figma-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/figma-block/package.json
+++ b/packages/figma-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/figma-block/package.json
+++ b/packages/figma-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/figma-block/package.json
+++ b/packages/figma-block/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/glyphs-block/package.json
+++ b/packages/glyphs-block/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/glyphs-block/package.json
+++ b/packages/glyphs-block/package.json
@@ -33,7 +33,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/glyphs-block/package.json
+++ b/packages/glyphs-block/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/glyphs-block/package.json
+++ b/packages/glyphs-block/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/gradient-block/package.json
+++ b/packages/gradient-block/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/gradient-block/package.json
+++ b/packages/gradient-block/package.json
@@ -33,7 +33,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/gradient-block/package.json
+++ b/packages/gradient-block/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/gradient-block/package.json
+++ b/packages/gradient-block/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/image-block/package.json
+++ b/packages/image-block/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/focus": "^3.14.0",

--- a/packages/image-block/package.json
+++ b/packages/image-block/package.json
@@ -32,7 +32,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/image-block/package.json
+++ b/packages/image-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/focus": "^3.14.0",
         "react": "^18.2.0",

--- a/packages/image-block/package.json
+++ b/packages/image-block/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/focus": "^3.14.0",

--- a/packages/personal-note-block/package.json
+++ b/packages/personal-note-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "dayjs": "^1.11.6",

--- a/packages/personal-note-block/package.json
+++ b/packages/personal-note-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "dayjs": "^1.11.6",

--- a/packages/personal-note-block/package.json
+++ b/packages/personal-note-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "dayjs": "^1.11.6",
         "react": "^18.2.0",

--- a/packages/personal-note-block/package.json
+++ b/packages/personal-note-block/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/quote-block/package.json
+++ b/packages/quote-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/quote-block/package.json
+++ b/packages/quote-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/quote-block/package.json
+++ b/packages/quote-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/quote-block/package.json
+++ b/packages/quote-block/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -41,7 +41,7 @@
         "vitest": "^0.34.4"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@uiw/codemirror-extensions-langs": "^4.21.12",
         "@uiw/react-codemirror": "^4.21.12"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,7 +42,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@uiw/codemirror-extensions-langs": "^4.21.12",
         "@uiw/react-codemirror": "^4.21.12"
     },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,7 +42,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@uiw/codemirror-extensions-langs": "^4.21.12",
         "@uiw/react-codemirror": "^4.21.12"
     },

--- a/packages/sketchfab-block/package.json
+++ b/packages/sketchfab-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/sketchfab-block/package.json
+++ b/packages/sketchfab-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/sketchfab-block/package.json
+++ b/packages/sketchfab-block/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",

--- a/packages/sketchfab-block/package.json
+++ b/packages/sketchfab-block/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/storybook-block/package.json
+++ b/packages/storybook-block/package.json
@@ -30,7 +30,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/storybook-block/package.json
+++ b/packages/storybook-block/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/interactions": "^3.17.0",

--- a/packages/storybook-block/package.json
+++ b/packages/storybook-block/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/interactions": "^3.17.0",

--- a/packages/storybook-block/package.json
+++ b/packages/storybook-block/package.json
@@ -32,7 +32,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/interactions": "^3.17.0",
         "react": "^18.2.0",

--- a/packages/text-block/package.json
+++ b/packages/text-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "lodash-es": "^4.17.21",
         "react": "^18.2.0",

--- a/packages/text-block/package.json
+++ b/packages/text-block/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "lodash-es": "^4.17.21",

--- a/packages/text-block/package.json
+++ b/packages/text-block/package.json
@@ -32,7 +32,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/text-block/package.json
+++ b/packages/text-block/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "lodash-es": "^4.17.21",

--- a/packages/thumbnail-grid-block/package.json
+++ b/packages/thumbnail-grid-block/package.json
@@ -37,7 +37,7 @@
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
-        "@frontify/app-bridge": "^3.0.0-beta.91",
+        "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/thumbnail-grid-block/package.json
+++ b/packages/thumbnail-grid-block/package.json
@@ -39,7 +39,7 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@frontify/app-bridge": "^3.0.0-beta.93",
         "@frontify/fondue": "12.0.0-beta.323",
-        "@frontify/guideline-blocks-settings": "^0.29.6",
+        "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "lodash-es": "^4.17.21",
         "react": "^18.2.0",

--- a/packages/thumbnail-grid-block/package.json
+++ b/packages/thumbnail-grid-block/package.json
@@ -38,7 +38,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
         "@frontify/app-bridge": "^3.0.0-beta.93",
-        "@frontify/fondue": "12.0.0-beta.323",
+        "@frontify/fondue": "12.0.0-beta.324",
         "@frontify/guideline-blocks-settings": "^0.29.7",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "lodash-es": "^4.17.21",

--- a/packages/thumbnail-grid-block/package.json
+++ b/packages/thumbnail-grid-block/package.json
@@ -38,7 +38,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
         "@frontify/app-bridge": "^3.0.0-beta.91",
-        "@frontify/fondue": "12.0.0-beta.321",
+        "@frontify/fondue": "12.0.0-beta.323",
         "@frontify/guideline-blocks-settings": "^0.29.6",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "lodash-es": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       glob:
         specifier: ^10.3.4
         version: 10.3.4
@@ -79,8 +79,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -155,8 +155,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -222,8 +222,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -292,8 +292,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -362,8 +362,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -429,8 +429,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -496,8 +496,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -596,8 +596,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -675,8 +675,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -751,8 +751,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -818,8 +818,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -894,8 +894,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -961,8 +961,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1037,8 +1037,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1107,8 +1107,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1174,8 +1174,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1241,8 +1241,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1314,8 +1314,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1387,8 +1387,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1460,8 +1460,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1530,8 +1530,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1597,8 +1597,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@uiw/codemirror-extensions-langs':
         specifier: ^4.21.12
         version: 4.21.13(@codemirror/autocomplete@6.9.0)(@codemirror/language-data@6.3.1)(@codemirror/language@6.9.0)(@codemirror/legacy-modes@6.3.3)(@codemirror/state@6.2.1)(@codemirror/view@6.18.0)(@lezer/common@1.0.4)(@lezer/highlight@1.1.6)(@lezer/javascript@1.4.7)(@lezer/lr@1.3.10)
@@ -1685,8 +1685,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1752,8 +1752,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1822,8 +1822,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1907,8 +1907,8 @@ importers:
         specifier: ^3.0.0-beta.93
         version: 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.323
-        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.324
+        version: 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.7
         version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -4212,110 +4212,6 @@ packages:
       tailwindcss: 3.3.3(ts-node@10.9.1)
     transitivePeerDependencies:
       - ts-node
-    dev: false
-
-  /@frontify/fondue@12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2):
-    resolution: {integrity: sha512-RqGgh5F0YTOsIryX8+wAk3vjqvRXHsVPDPXafFDZ3Gq6sjd2yEEtf9Fg+e88wBo4eRi7km5pJ80F6GRYS2P5Aw==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      react: ^17 || ^18
-      react-dom: ^17 || ^18
-    dependencies:
-      '@ctrl/tinycolor': 4.0.2
-      '@dnd-kit/core': 6.0.8(react-dom@18.2.0)(react@18.2.0)
-      '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.0.8)(react@18.2.0)
-      '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.0.8)(react@18.2.0)
-      '@dnd-kit/utilities': 3.2.1(react@18.2.0)
-      '@frontify/fondue-tokens': 3.3.0-next.5(ts-node@10.9.1)
-      '@popperjs/core': 2.11.8
-      '@react-aria/accordion': 3.0.0-alpha.17(react@18.2.0)
-      '@react-aria/aria-modal-polyfill': 3.7.1(react@18.2.0)
-      '@react-aria/breadcrumbs': 3.5.2(react@18.2.0)
-      '@react-aria/button': 3.6.3(react@18.2.0)
-      '@react-aria/checkbox': 3.7.0(react@18.2.0)
-      '@react-aria/combobox': 3.4.3(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/dialog': 3.4.1(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/focus': 3.12.0(react@18.2.0)
-      '@react-aria/interactions': 3.13.0(react@18.2.0)
-      '@react-aria/link': 3.3.5(react@18.2.0)
-      '@react-aria/listbox': 3.7.1(react@18.2.0)
-      '@react-aria/menu': 3.7.0(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/overlays': 3.12.0(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/radio': 3.4.1(react@18.2.0)
-      '@react-aria/select': 3.8.3(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/selection': 3.12.0(react@18.2.0)
-      '@react-aria/table': 3.6.0(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/tooltip': 3.3.3(react@18.2.0)
-      '@react-aria/utils': 3.14.1(react@18.2.0)
-      '@react-aria/visually-hidden': 3.6.0(react@18.2.0)
-      '@react-stately/checkbox': 3.3.2(react@18.2.0)
-      '@react-stately/collections': 3.4.4(react@18.2.0)
-      '@react-stately/combobox': 3.2.2(react@18.2.0)
-      '@react-stately/list': 3.5.4(react@18.2.0)
-      '@react-stately/menu': 3.4.4(react@18.2.0)
-      '@react-stately/overlays': 3.4.2(react@18.2.0)
-      '@react-stately/radio': 3.6.0(react@18.2.0)
-      '@react-stately/select': 3.3.2(react@18.2.0)
-      '@react-stately/table': 3.5.0(react@18.2.0)
-      '@react-stately/toggle': 3.4.2(react@18.2.0)
-      '@react-stately/tooltip': 3.2.2(react@18.2.0)
-      '@react-stately/tree': 3.3.4(react@18.2.0)
-      '@react-types/dialog': 3.4.5(react@18.2.0)
-      '@react-types/shared': 3.16.0(react@18.2.0)
-      '@tailwindcss/forms': 0.5.6(tailwindcss@3.3.3)
-      '@udecode/plate': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
-      '@udecode/zustood': 1.1.3(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(zustand@3.7.2)
-      '@xstate/immer': 0.3.1(immer@9.0.12)(xstate@4.28.1)
-      '@xstate/react': 1.6.3(@types/react@18.2.21)(react@18.2.0)(xstate@4.28.1)
-      date-fns: 2.30.0
-      escape-html: 1.0.3
-      framer-motion: 10.16.4(react-dom@18.2.0)(react@18.2.0)
-      immer: 9.0.12
-      is-hotkey: 0.2.0
-      react: 18.2.0
-      react-colorful: 5.6.1(react-dom@18.2.0)(react@18.2.0)
-      react-datepicker: 4.17.0(react-dom@18.2.0)(react@18.2.0)
-      react-dnd: 16.0.1(@types/node@20.6.0)(@types/react@18.2.21)(react@18.2.0)
-      react-dnd-html5-backend: 15.1.3
-      react-dom: 18.2.0(react@18.2.0)
-      react-fast-compare: 3.2.2
-      react-is: 18.2.0
-      react-popper: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0)(react@18.2.0)
-      react-textarea-autosize: 8.5.3(@types/react@18.2.21)(react@18.2.0)
-      remark-gfm: 3.0.1
-      remark-parse: 10.0.2
-      scheduler: 0.23.0
-      slate: 0.94.1
-      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-      unified: 10.1.2
-      unist-util-visit: 4.1.2
-      xstate: 4.28.1
-      yaml: 2.3.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/hoist-non-react-statics'
-      - '@types/node'
-      - '@types/react'
-      - '@types/react-dom'
-      - '@xstate/fsm'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-native
-      - slate-history
-      - slate-hyperscript
-      - styled-components
-      - supports-color
-      - tailwindcss
-      - ts-node
-      - zustand
     dev: false
 
   /@frontify/fondue@12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       glob:
         specifier: ^10.3.4
         version: 10.3.4
@@ -79,8 +79,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -155,8 +155,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -222,8 +222,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -292,8 +292,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -362,8 +362,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -429,8 +429,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -496,8 +496,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -596,8 +596,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -675,8 +675,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -751,8 +751,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -818,8 +818,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -894,8 +894,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -961,8 +961,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1037,8 +1037,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1107,8 +1107,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1174,8 +1174,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1241,8 +1241,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1314,8 +1314,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1387,8 +1387,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1460,8 +1460,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1530,8 +1530,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1597,8 +1597,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@uiw/codemirror-extensions-langs':
         specifier: ^4.21.12
         version: 4.21.13(@codemirror/autocomplete@6.9.0)(@codemirror/language-data@6.3.1)(@codemirror/language@6.9.0)(@codemirror/legacy-modes@6.3.3)(@codemirror/state@6.2.1)(@codemirror/view@6.18.0)(@lezer/common@1.0.4)(@lezer/highlight@1.1.6)(@lezer/javascript@1.4.7)(@lezer/lr@1.3.10)
@@ -1685,8 +1685,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1752,8 +1752,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1822,8 +1822,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -1907,8 +1907,8 @@ importers:
         specifier: ^3.0.0-beta.91
         version: 3.0.0-beta.91(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
       '@frontify/fondue':
-        specifier: 12.0.0-beta.321
-        version: 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: 12.0.0-beta.323
+        version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.6
         version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
@@ -4199,6 +4199,110 @@ packages:
 
   /@frontify/fondue@12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2):
     resolution: {integrity: sha512-FgbF7cJv23y5QrGrFUCy8hpGmytPyVLo0As0hD0Bn7GjIfUpMPUrFsjYazWqCD2UQ+4c73jlMCC/sVSKVo0JhA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      react: ^17 || ^18
+      react-dom: ^17 || ^18
+    dependencies:
+      '@ctrl/tinycolor': 4.0.2
+      '@dnd-kit/core': 6.0.8(react-dom@18.2.0)(react@18.2.0)
+      '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.0.8)(react@18.2.0)
+      '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.0.8)(react@18.2.0)
+      '@dnd-kit/utilities': 3.2.1(react@18.2.0)
+      '@frontify/fondue-tokens': 3.3.0-next.5(ts-node@10.9.1)
+      '@popperjs/core': 2.11.8
+      '@react-aria/accordion': 3.0.0-alpha.17(react@18.2.0)
+      '@react-aria/aria-modal-polyfill': 3.7.1(react@18.2.0)
+      '@react-aria/breadcrumbs': 3.5.2(react@18.2.0)
+      '@react-aria/button': 3.6.3(react@18.2.0)
+      '@react-aria/checkbox': 3.7.0(react@18.2.0)
+      '@react-aria/combobox': 3.4.3(react-dom@18.2.0)(react@18.2.0)
+      '@react-aria/dialog': 3.4.1(react-dom@18.2.0)(react@18.2.0)
+      '@react-aria/focus': 3.12.0(react@18.2.0)
+      '@react-aria/interactions': 3.13.0(react@18.2.0)
+      '@react-aria/link': 3.3.5(react@18.2.0)
+      '@react-aria/listbox': 3.7.1(react@18.2.0)
+      '@react-aria/menu': 3.7.0(react-dom@18.2.0)(react@18.2.0)
+      '@react-aria/overlays': 3.12.0(react-dom@18.2.0)(react@18.2.0)
+      '@react-aria/radio': 3.4.1(react@18.2.0)
+      '@react-aria/select': 3.8.3(react-dom@18.2.0)(react@18.2.0)
+      '@react-aria/selection': 3.12.0(react@18.2.0)
+      '@react-aria/table': 3.6.0(react-dom@18.2.0)(react@18.2.0)
+      '@react-aria/tooltip': 3.3.3(react@18.2.0)
+      '@react-aria/utils': 3.14.1(react@18.2.0)
+      '@react-aria/visually-hidden': 3.6.0(react@18.2.0)
+      '@react-stately/checkbox': 3.3.2(react@18.2.0)
+      '@react-stately/collections': 3.4.4(react@18.2.0)
+      '@react-stately/combobox': 3.2.2(react@18.2.0)
+      '@react-stately/list': 3.5.4(react@18.2.0)
+      '@react-stately/menu': 3.4.4(react@18.2.0)
+      '@react-stately/overlays': 3.4.2(react@18.2.0)
+      '@react-stately/radio': 3.6.0(react@18.2.0)
+      '@react-stately/select': 3.3.2(react@18.2.0)
+      '@react-stately/table': 3.5.0(react@18.2.0)
+      '@react-stately/toggle': 3.4.2(react@18.2.0)
+      '@react-stately/tooltip': 3.2.2(react@18.2.0)
+      '@react-stately/tree': 3.3.4(react@18.2.0)
+      '@react-types/dialog': 3.4.5(react@18.2.0)
+      '@react-types/shared': 3.16.0(react@18.2.0)
+      '@tailwindcss/forms': 0.5.6(tailwindcss@3.3.3)
+      '@udecode/plate': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
+      '@udecode/zustood': 1.1.3(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(zustand@3.7.2)
+      '@xstate/immer': 0.3.1(immer@9.0.12)(xstate@4.28.1)
+      '@xstate/react': 1.6.3(@types/react@18.2.21)(react@18.2.0)(xstate@4.28.1)
+      date-fns: 2.30.0
+      escape-html: 1.0.3
+      framer-motion: 10.16.4(react-dom@18.2.0)(react@18.2.0)
+      immer: 9.0.12
+      is-hotkey: 0.2.0
+      react: 18.2.0
+      react-colorful: 5.6.1(react-dom@18.2.0)(react@18.2.0)
+      react-datepicker: 4.17.0(react-dom@18.2.0)(react@18.2.0)
+      react-dnd: 16.0.1(@types/node@20.6.0)(@types/react@18.2.21)(react@18.2.0)
+      react-dnd-html5-backend: 15.1.3
+      react-dom: 18.2.0(react@18.2.0)
+      react-fast-compare: 3.2.2
+      react-is: 18.2.0
+      react-popper: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0)(react@18.2.0)
+      react-textarea-autosize: 8.5.3(@types/react@18.2.21)(react@18.2.0)
+      remark-gfm: 3.0.1
+      remark-parse: 10.0.2
+      scheduler: 0.23.0
+      slate: 0.94.1
+      slate-react: 0.98.3(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+      unified: 10.1.2
+      unist-util-visit: 4.1.2
+      xstate: 4.28.1
+      yaml: 2.3.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/hoist-non-react-statics'
+      - '@types/node'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@xstate/fsm'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-native
+      - slate-history
+      - slate-hyperscript
+      - styled-components
+      - supports-color
+      - tailwindcss
+      - ts-node
+      - zustand
+    dev: false
+
+  /@frontify/fondue@12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2):
+    resolution: {integrity: sha512-RqGgh5F0YTOsIryX8+wAk3vjqvRXHsVPDPXafFDZ3Gq6sjd2yEEtf9Fg+e88wBo4eRi7km5pJ80F6GRYS2P5Aw==}
     engines: {node: '>=16'}
     peerDependencies:
       react: ^17 || ^18

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -158,8 +158,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -225,8 +225,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -295,8 +295,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -365,8 +365,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -432,8 +432,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -499,8 +499,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -599,8 +599,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -678,8 +678,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -754,8 +754,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -821,8 +821,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -897,8 +897,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -964,8 +964,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1040,8 +1040,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1110,8 +1110,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1177,8 +1177,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1244,8 +1244,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1317,8 +1317,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1390,8 +1390,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1463,8 +1463,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1533,8 +1533,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1688,8 +1688,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1755,8 +1755,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1825,8 +1825,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1910,8 +1910,8 @@ importers:
         specifier: 12.0.0-beta.323
         version: 12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.6
-        version: 0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+        specifier: ^0.29.7
+        version: 0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -4126,6 +4126,23 @@ packages:
       type-fest: 4.3.1
     dev: false
 
+  /@frontify/app-bridge@3.0.0-beta.94(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0):
+    resolution: {integrity: sha512-XwQkTs78wZk18XIVg8pw/oBOBSw1FRuoFfKKHQ4T2n1bcNqlTE/NH5Koa+g+jCDHJqMxjKE1MwuQPfZNuoSYgg==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      react: ^18
+      react-dom: ^18
+      sinon: ^15
+    dependencies:
+      immer: 10.0.2
+      lodash-es: 4.17.21
+      mitt: 3.0.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      sinon: 15.2.0
+      type-fest: 4.3.1
+    dev: false
+
   /@frontify/eslint-config-basic@0.18.0(eslint@8.49.0)(prettier@3.0.3):
     resolution: {integrity: sha512-HQQXvkksqbQL8arLqWzYwoWFDYLhILrzaHgzvJWqqCK0NxeFuo9vjo0AthcD9wd/nNwFIFDKErzkuhmHVHKQvw==}
     peerDependencies:
@@ -4197,8 +4214,8 @@ packages:
       - ts-node
     dev: false
 
-  /@frontify/fondue@12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2):
-    resolution: {integrity: sha512-FgbF7cJv23y5QrGrFUCy8hpGmytPyVLo0As0hD0Bn7GjIfUpMPUrFsjYazWqCD2UQ+4c73jlMCC/sVSKVo0JhA==}
+  /@frontify/fondue@12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2):
+    resolution: {integrity: sha512-RqGgh5F0YTOsIryX8+wAk3vjqvRXHsVPDPXafFDZ3Gq6sjd2yEEtf9Fg+e88wBo4eRi7km5pJ80F6GRYS2P5Aw==}
     engines: {node: '>=16'}
     peerDependencies:
       react: ^17 || ^18
@@ -4301,8 +4318,8 @@ packages:
       - zustand
     dev: false
 
-  /@frontify/fondue@12.0.0-beta.323(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2):
-    resolution: {integrity: sha512-RqGgh5F0YTOsIryX8+wAk3vjqvRXHsVPDPXafFDZ3Gq6sjd2yEEtf9Fg+e88wBo4eRi7km5pJ80F6GRYS2P5Aw==}
+  /@frontify/fondue@12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2):
+    resolution: {integrity: sha512-reGsCfc74I2okitC1Ca09Yi0iLaRtLN4cv6UD+L7EMsmske+G6g944TJJKGo/m1ni87/rS+hdu5Ar9CDpQJiag==}
     engines: {node: '>=16'}
     peerDependencies:
       react: ^17 || ^18
@@ -4435,8 +4452,8 @@ packages:
       - terser
     dev: true
 
-  /@frontify/guideline-blocks-settings@0.29.6(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2):
-    resolution: {integrity: sha512-hZK7dB+0BltZa9MIEpKmKE7seqqpFEgZWjwP/MPCIvdBvdVJngdDT231ZFbQ44dEZdsOpSQ/E9r2+PYgWlLoAw==}
+  /@frontify/guideline-blocks-settings@0.29.7(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2):
+    resolution: {integrity: sha512-wEFcEs1D+GnXXrYqpbLj0Q3BkYvcxUhpP9+k5/0O6GNMmR6yXDpcWiDOTBbhPtwOlFx/f+cxQ+AdOt3eqJQJww==}
     peerDependencies:
       react: ^18
       react-dom: ^18
@@ -4445,9 +4462,9 @@ packages:
       '@dnd-kit/core': 6.0.8(react-dom@18.2.0)(react@18.2.0)
       '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.0.8)(react@18.2.0)
       '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.0.8)(react@18.2.0)
-      '@frontify/app-bridge': 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
-      '@frontify/fondue': 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
-      '@frontify/sidebar-settings': 0.6.9(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+      '@frontify/app-bridge': 3.0.0-beta.94(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
+      '@frontify/fondue': 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+      '@frontify/sidebar-settings': 0.6.10(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       '@react-aria/focus': 3.14.1(react@18.2.0)
       '@react-stately/overlays': 3.6.2(react@18.2.0)
       '@udecode/plate': 21.5.0(@babel/core@7.22.17)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(slate-react@0.98.3)(slate@0.94.1)(styled-components@6.0.7)
@@ -4487,14 +4504,14 @@ packages:
       - zustand
     dev: false
 
-  /@frontify/sidebar-settings@0.6.9(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2):
-    resolution: {integrity: sha512-aUKgnD8eYrHC0TINnFv5RLbsUKw+/moSUe0GswtEy5pJmO6O3dF0Qpcsz3yTstrKQTqU3KEled9E0PlFNftqhw==}
+  /@frontify/sidebar-settings@0.6.10(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2):
+    resolution: {integrity: sha512-W0b4g9w1FlBR2bqP3fgLAl6E4CvRRDgpzgks0gTxJCPe3Kuc57nD+bfpL1WGQlj9KN5knLdU3tsxCQoqB65/1w==}
     peerDependencies:
       react: ^18
       react-dom: ^18
     dependencies:
-      '@frontify/app-bridge': 3.0.0-beta.93(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
-      '@frontify/fondue': 12.0.0-beta.321(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
+      '@frontify/app-bridge': 3.0.0-beta.94(react-dom@18.2.0)(react@18.2.0)(sinon@15.2.0)
+      '@frontify/fondue': 12.0.0-beta.324(@babel/core@7.22.17)(@types/node@20.6.0)(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.93.0)(slate-hyperscript@0.77.0)(styled-components@6.0.7)(tailwindcss@3.3.3)(ts-node@10.9.1)(zustand@3.7.2)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:


### PR DESCRIPTION
In order to get rid of `react-dnd` in fondue `OrderableList` component has been renamed to `LegacyOrderableList` and deprecated. 
The only component using this component here is `CheckList` so it has been updated accordingly.
