### PR TITLE
chore(shared): remove eslint-config-typescript package

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,7 +16,7 @@
     "author": "Frontify Developers <developers@frontify.com>",
     "devDependencies": {
         "@babel/core": "^7.22.17",
-        "@frontify/eslint-config-typescript": "0.16.1",
+        "@frontify/eslint-config-react": "0.16.1",
         "@testing-library/react": "^14.0.0",
         "@types/node": "^20.5.9",
         "@types/react": "^18.2.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1609,9 +1609,9 @@ importers:
       '@babel/core':
         specifier: ^7.22.17
         version: 7.22.17
-      '@frontify/eslint-config-typescript':
+      '@frontify/eslint-config-react':
         specifier: 0.16.1
-        version: 0.16.1(eslint@8.49.0)(prettier@3.0.3)(typescript@5.2.2)
+        version: 0.16.1(eslint@8.49.0)(prettier@3.0.3)(react@18.2.0)(typescript@5.2.2)
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.0.0(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
Just noticed that for the shared the `eslint-config-typescript` was installed but within the `.eslintrc` the `eslint-config-react` was used so this should fix that