### PR TITLE
fix(UIPattern): settings default values

### DIFF
--- a/packages/ui-pattern-block/src/settings.ts
+++ b/packages/ui-pattern-block/src/settings.ts
@@ -166,7 +166,7 @@ export const settings = defineSettings({
                 {
                     id: 'showResetButton',
                     type: 'switch',
-                    defaultValue: true,
+                    defaultValue: false,
                     label: 'Show reset button',
                 },
             ],
@@ -198,7 +198,7 @@ export const settings = defineSettings({
                 {
                     id: 'showSandboxLink',
                     type: 'switch',
-                    defaultValue: true,
+                    defaultValue: false,
                     label: 'Show sandbox link',
                 },
             ],


### PR DESCRIPTION
Adjust the default value of `showSandboxLink` and `showResetButton` to `false`

[Task](https://app.clickup.com/t/8692ta8f9)