### PR TITLE
chore: Show Asset setting fields in translated view

### DIFF
--- a/packages/audio-block/src/settings.ts
+++ b/packages/audio-block/src/settings.ts
@@ -24,6 +24,7 @@ export const settings = defineSettings({
             size: 'small',
             extensions: FileExtensionSets.Audio,
             objectTypes: [AssetChooserObjectType.File],
+            showForTranslations: true,
         },
     ],
     layout: [

--- a/packages/callout-block/src/settings.ts
+++ b/packages/callout-block/src/settings.ts
@@ -112,6 +112,7 @@ export const settings = defineSettings({
                     ],
                 },
             ],
+            showForTranslations: true,
         },
     ],
     layout: [

--- a/packages/compare-slider-block/src/settings.ts
+++ b/packages/compare-slider-block/src/settings.ts
@@ -66,6 +66,7 @@ export const settings = defineSettings({
                     defaultValue: false,
                 },
             ],
+            showForTranslations: true,
         },
         {
             id: 'secondAssetSection',
@@ -86,6 +87,7 @@ export const settings = defineSettings({
                     defaultValue: false,
                 },
             ],
+            showForTranslations: true,
         },
     ],
     layout: [

--- a/packages/image-block/src/settings.ts
+++ b/packages/image-block/src/settings.ts
@@ -54,6 +54,7 @@ export const settings = defineSettings({
                     ],
                 },
             ],
+            showForTranslations: true,
         },
         {
             id: 'imageResolutionInfo',
@@ -177,11 +178,15 @@ export const settings = defineSettings({
                 },
             ],
         },
-        getBorderSettings(),
-        getBorderRadiusSettings({
-            id: 'cornerRadius',
-            radiusStyleMap: radiusValues,
-        }),
+        {
+            ...getBorderSettings(),
+        },
+        {
+            ...getBorderRadiusSettings({
+                id: 'cornerRadius',
+                radiusStyleMap: radiusValues,
+            }),
+        },
     ],
     security: [...getSecurityGlobalControlSetting(), getSecurityDownloadableSetting()],
 });

--- a/packages/image-block/src/settings.ts
+++ b/packages/image-block/src/settings.ts
@@ -178,15 +178,11 @@ export const settings = defineSettings({
                 },
             ],
         },
-        {
-            ...getBorderSettings(),
-        },
-        {
-            ...getBorderRadiusSettings({
-                id: 'cornerRadius',
-                radiusStyleMap: radiusValues,
-            }),
-        },
+        getBorderSettings(),
+        getBorderRadiusSettings({
+            id: 'cornerRadius',
+            radiusStyleMap: radiusValues,
+        }),
     ],
     security: [...getSecurityGlobalControlSetting(), getSecurityDownloadableSetting()],
 });

--- a/packages/quote-block/src/settings.tsx
+++ b/packages/quote-block/src/settings.tsx
@@ -171,6 +171,7 @@ export const settings = defineSettings({
                     ],
                 },
             ],
+            showForTranslations: true,
         },
     ],
     layout: [

--- a/packages/template-block/src/settings.ts
+++ b/packages/template-block/src/settings.ts
@@ -332,7 +332,7 @@ export const settings = defineSettings({
                     onChange: (bundle) =>
                         bundle.setBlockValue(
                             'radiusValue_blockCard',
-                            radiusStyleMap[bundle.getBlock('radiusChoice_blockCard')?.value as Radius]
+                            radiusStyleMap[bundle.getBlock('radiusChoice_blockCard')?.value as Radius],
                         ),
                 },
             ],
@@ -363,7 +363,7 @@ export const settings = defineSettings({
                     onChange: (bundle) =>
                         bundle.setBlockValue(
                             'radiusValue_templatePreview',
-                            radiusStyleMap[bundle.getBlock('radiusChoice_templatePreview')?.value as Radius]
+                            radiusStyleMap[bundle.getBlock('radiusChoice_templatePreview')?.value as Radius],
                         ),
                 },
             ],

--- a/packages/template-block/src/settings.ts
+++ b/packages/template-block/src/settings.ts
@@ -34,6 +34,7 @@ export const settings = defineSettings({
             id: TEMPLATE_BLOCK_SETTING_ID,
             type: 'templateInput',
             label: 'Template',
+            showForTranslations: true,
         },
         {
             id: 'preview',
@@ -54,6 +55,7 @@ export const settings = defineSettings({
                 },
             ],
             defaultValue: PreviewType.Template,
+            showForTranslations: true,
         },
         {
             id: 'previewCustom',
@@ -62,6 +64,7 @@ export const settings = defineSettings({
             extensions: FileExtensionSets.Images,
             label: 'Custom Preview',
             show: (bundle: Bundle) => bundle.getBlock('preview')?.value === PreviewType.Custom,
+            showForTranslations: true,
         },
     ],
     layout: [
@@ -329,7 +332,7 @@ export const settings = defineSettings({
                     onChange: (bundle) =>
                         bundle.setBlockValue(
                             'radiusValue_blockCard',
-                            radiusStyleMap[bundle.getBlock('radiusChoice_blockCard')?.value as Radius],
+                            radiusStyleMap[bundle.getBlock('radiusChoice_blockCard')?.value as Radius]
                         ),
                 },
             ],
@@ -360,7 +363,7 @@ export const settings = defineSettings({
                     onChange: (bundle) =>
                         bundle.setBlockValue(
                             'radiusValue_templatePreview',
-                            radiusStyleMap[bundle.getBlock('radiusChoice_templatePreview')?.value as Radius],
+                            radiusStyleMap[bundle.getBlock('radiusChoice_templatePreview')?.value as Radius]
                         ),
                 },
             ],


### PR DESCRIPTION
- The PR enables `showForTranslation` fields for all the blocks having Asset settings visible in the sidebar
- Settings enabled::

Block name | Enabled Setting 1 | Enabled Setting 2 | Enabled Setting 3
-- | -- | -- | --
Template | Template Input | Template Preview | Custom Preview
Image | Image (from asset input) | - | -
Callout | Icon Switch | - | -
Audio | Audio (from asset input) | - | -
Compare Slider | First Asset | Second Asset | -
Quote | Quotation Marks | - | -

