### PR TITLE
chore: bump app-bridge in asset-kit block

### DIFF
--- a/examples/asset-upload/package.json
+++ b/examples/asset-upload/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "react": "^18.2.0",

--- a/packages/animation-curve-block/package.json
+++ b/packages/animation-curve-block/package.json
@@ -34,7 +34,7 @@
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/asset-kit-block/package.json
+++ b/packages/asset-kit-block/package.json
@@ -32,7 +32,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/asset-kit-block/package.json
+++ b/packages/asset-kit-block/package.json
@@ -32,7 +32,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "3.0.0-beta.103",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -53,7 +53,7 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
         if (downloadUrlBlock && downloadExpiration && downloadExpiration > Math.floor(Date.now() / 1000)) {
             return downloadAssets(downloadUrlBlock);
         }
-        generateBulkDownload([ASSET_SETTINGS_ID]);
+        generateBulkDownload(blockAssets);
     };
 
     const downloadAssets = (downloadUrl: string) => {

--- a/packages/audio-block/package.json
+++ b/packages/audio-block/package.json
@@ -32,7 +32,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/brand-positioning-block/package.json
+++ b/packages/brand-positioning-block/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/callout-block/package.json
+++ b/packages/callout-block/package.json
@@ -32,7 +32,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/checklist-block/package.json
+++ b/packages/checklist-block/package.json
@@ -33,7 +33,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/code-snippet-block/package.json
+++ b/packages/code-snippet-block/package.json
@@ -35,7 +35,7 @@
         "@codemirror/language": "^6.9.0",
         "@codemirror/state": "^6.2.1",
         "@codemirror/view": "^6.17.0",
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-block/package.json
+++ b/packages/color-block/package.json
@@ -32,7 +32,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-kit-block/package.json
+++ b/packages/color-kit-block/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/color-scale-block/package.json
+++ b/packages/color-scale-block/package.json
@@ -32,7 +32,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/compare-slider-block/package.json
+++ b/packages/compare-slider-block/package.json
@@ -28,7 +28,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/divider-block/package.json
+++ b/packages/divider-block/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/dos-donts-block/package.json
+++ b/packages/dos-donts-block/package.json
@@ -34,7 +34,7 @@
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/figma-block/package.json
+++ b/packages/figma-block/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/glyphs-block/package.json
+++ b/packages/glyphs-block/package.json
@@ -33,7 +33,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/gradient-block/package.json
+++ b/packages/gradient-block/package.json
@@ -33,7 +33,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/image-block/package.json
+++ b/packages/image-block/package.json
@@ -32,7 +32,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/personal-note-block/package.json
+++ b/packages/personal-note-block/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/quote-block/package.json
+++ b/packages/quote-block/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -41,7 +41,7 @@
         "vitest": "^0.34.4"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@uiw/codemirror-extensions-langs": "^4.21.12",
         "@uiw/react-codemirror": "^4.21.12"

--- a/packages/sketchfab-block/package.json
+++ b/packages/sketchfab-block/package.json
@@ -31,7 +31,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/storybook-block/package.json
+++ b/packages/storybook-block/package.json
@@ -30,7 +30,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/template-block/package.json
+++ b/packages/template-block/package.json
@@ -32,7 +32,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/text-block/package.json
+++ b/packages/text-block/package.json
@@ -32,7 +32,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/thumbnail-grid-block/package.json
+++ b/packages/thumbnail-grid-block/package.json
@@ -37,7 +37,7 @@
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/packages/ui-pattern-block/package.json
+++ b/packages/ui-pattern-block/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@codesandbox/sandpack-react": "^2.9.0",
         "@codesandbox/sandpack-themes": "^2.0.21",
-        "@frontify/app-bridge": "^3.0.0-beta.100",
+        "@frontify/app-bridge": "^3.0.0-beta.103",
         "@frontify/fondue": "12.0.0-beta.341",
         "@frontify/guideline-blocks-settings": "^0.29.12",
         "@frontify/guideline-blocks-shared": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       glob:
         specifier: ^10.3.4
         version: 10.3.10
@@ -80,10 +80,10 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
-        version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -156,7 +156,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -219,11 +219,11 @@ importers:
   packages/asset-kit-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: 3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -293,7 +293,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -363,7 +363,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -430,7 +430,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -500,7 +500,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -600,7 +600,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -679,7 +679,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -755,7 +755,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -822,7 +822,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -898,7 +898,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -965,7 +965,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1041,7 +1041,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1111,7 +1111,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1178,7 +1178,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1245,7 +1245,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1318,7 +1318,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1391,7 +1391,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1464,7 +1464,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1534,7 +1534,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1598,10 +1598,10 @@ importers:
     dependencies:
       '@frontify/app-bridge':
         specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@uiw/codemirror-extensions-langs':
         specifier: ^4.21.12
         version: 4.21.21(@codemirror/autocomplete@6.11.1)(@codemirror/language-data@6.3.1)(@codemirror/language@6.9.3)(@codemirror/legacy-modes@6.3.3)(@codemirror/state@6.3.2)(@codemirror/view@6.22.1)(@lezer/common@1.1.1)(@lezer/highlight@1.2.0)(@lezer/javascript@1.4.9)(@lezer/lr@1.3.14)
@@ -1689,7 +1689,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1756,7 +1756,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1826,7 +1826,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1896,7 +1896,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1981,7 +1981,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -2063,7 +2063,7 @@ importers:
         version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
-        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
         specifier: ^0.29.12
         version: 0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -3249,6 +3249,23 @@ packages:
       type-fest: 4.8.2
     dev: false
 
+  /@frontify/app-bridge@3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1):
+    resolution: {integrity: sha512-tVPd8sH1WcxIaPoBkuMaV68OQDwri4Q/k8Q3edGMv6qihqW0n+eEUmceTuYgBvngOHgtHQfC73dEaA8C6RsoOA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      react: ^18
+      react-dom: ^18
+      sinon: ^15 || ^16 || ^17
+    dependencies:
+      immer: 10.0.3
+      lodash-es: 4.17.21
+      mitt: 3.0.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      sinon: 17.0.1
+      type-fest: 4.8.2
+    dev: false
+
   /@frontify/eslint-config-basic@0.18.0(eslint@8.54.0)(prettier@3.1.0):
     resolution: {integrity: sha512-HQQXvkksqbQL8arLqWzYwoWFDYLhILrzaHgzvJWqqCK0NxeFuo9vjo0AthcD9wd/nNwFIFDKErzkuhmHVHKQvw==}
     peerDependencies:
@@ -3314,12 +3331,13 @@ packages:
   /@frontify/fondue-tokens@3.3.0-next.5(ts-node@10.9.1):
     resolution: {integrity: sha512-6M919jnfqZnSW1GFSJ3jDiUx3Ml4L6FjA+IJR19LSVWK7de/xiXOiNDa4Rh1UAzZmA1NgzPAJKyu2FI3RZza/Q==}
     dependencies:
+      postcss: 8.4.31
       tailwindcss: 3.3.5(ts-node@10.9.1)
     transitivePeerDependencies:
       - ts-node
     dev: false
 
-  /@frontify/fondue@12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7):
+  /@frontify/fondue@12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7):
     resolution: {integrity: sha512-/V2Q/1aNL6i/Bw52YJDXpxZnRLZ8PZuGZWAso35o78i/bC/3Q95QWxzQmFuupyIyflyWPfkemwCM7S38EL4nBA==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -3389,6 +3407,7 @@ packages:
       react-textarea-autosize: 8.5.3(@types/react@18.2.39)(react@18.2.0)
       remark-gfm: 3.0.1
       remark-parse: 10.0.2
+      scheduler: 0.23.0
       slate: 0.94.1
       slate-react: 0.98.4(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       unified: 10.1.2
@@ -3413,7 +3432,6 @@ packages:
       - jotai-xstate
       - jotai-zustand
       - react-native
-      - scheduler
       - slate-history
       - slate-hyperscript
       - styled-components
@@ -3453,58 +3471,6 @@ packages:
       - terser
     dev: true
 
-  /@frontify/guideline-blocks-settings@0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7):
-    resolution: {integrity: sha512-PiacqsjeZdlnuILQOPFYWZJRggwoJUkFDyOyvn57TeUVKnsutBJlX5gFqBBqIXVwl6D3pAJBg1K+gKFMEhw38Q==}
-    peerDependencies:
-      react: ^18
-      react-dom: ^18
-    dependencies:
-      '@ctrl/tinycolor': 4.0.2
-      '@dnd-kit/core': 6.1.0(react-dom@18.2.0)(react@18.2.0)
-      '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.1.0)(react@18.2.0)
-      '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.1.0)(react@18.2.0)
-      '@frontify/app-bridge': 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
-      '@frontify/fondue': 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
-      '@frontify/sidebar-settings': 0.8.0(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
-      '@react-aria/focus': 3.15.0(react@18.2.0)
-      '@react-stately/overlays': 3.6.4(react@18.2.0)
-      '@udecode/plate': 21.5.0(@babel/core@7.23.5)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-react: 0.98.4(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/hoist-non-react-statics'
-      - '@types/node'
-      - '@types/react'
-      - '@types/react-dom'
-      - '@xstate/fsm'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-dnd
-      - react-dnd-html5-backend
-      - react-is
-      - react-native
-      - scheduler
-      - sinon
-      - slate-history
-      - slate-hyperscript
-      - styled-components
-      - supports-color
-      - tailwindcss
-      - ts-node
-      - zustand
-    dev: false
-
   /@frontify/guideline-blocks-settings@0.29.14(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7):
     resolution: {integrity: sha512-PiacqsjeZdlnuILQOPFYWZJRggwoJUkFDyOyvn57TeUVKnsutBJlX5gFqBBqIXVwl6D3pAJBg1K+gKFMEhw38Q==}
     peerDependencies:
@@ -3516,8 +3482,8 @@ packages:
       '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.1.0)(react@18.2.0)
       '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.1.0)(react@18.2.0)
       '@frontify/app-bridge': 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
-      '@frontify/fondue': 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
-      '@frontify/sidebar-settings': 0.8.0(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+      '@frontify/fondue': 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+      '@frontify/sidebar-settings': 0.8.0(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@react-aria/focus': 3.15.0(react@18.2.0)
       '@react-stately/overlays': 3.6.4(react@18.2.0)
       '@udecode/plate': 21.5.0(@babel/core@7.23.5)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.1)
@@ -3557,14 +3523,14 @@ packages:
       - zustand
     dev: false
 
-  /@frontify/sidebar-settings@0.8.0(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7):
+  /@frontify/sidebar-settings@0.8.0(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7):
     resolution: {integrity: sha512-8GSyF/AGACw94DdJnjYH1oYJt4hvu5fF2fLUhG1mZVE38qvB7eCeOySwxUuUWuPMUr/QN079/BzVv7eVznwPkw==}
     peerDependencies:
       react: ^18
       react-dom: ^18
     dependencies:
-      '@frontify/app-bridge': 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
-      '@frontify/fondue': 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+      '@frontify/app-bridge': 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+      '@frontify/fondue': 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -3585,7 +3551,6 @@ packages:
       - jotai-xstate
       - jotai-zustand
       - react-native
-      - scheduler
       - sinon
       - slate-history
       - slate-hyperscript

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
   examples/asset-upload:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -152,8 +152,8 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2(@dnd-kit/core@6.1.0)(react@18.2.0)
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -219,7 +219,7 @@ importers:
   packages/asset-kit-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: 3.0.0-beta.103
+        specifier: ^3.0.0-beta.103
         version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
@@ -289,8 +289,8 @@ importers:
   packages/audio-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -359,8 +359,8 @@ importers:
   packages/brand-positioning-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -426,8 +426,8 @@ importers:
   packages/callout-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -496,8 +496,8 @@ importers:
   packages/checklist-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -596,8 +596,8 @@ importers:
         specifier: ^6.17.0
         version: 6.22.1
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -675,8 +675,8 @@ importers:
   packages/color-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -751,8 +751,8 @@ importers:
   packages/color-kit-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -818,8 +818,8 @@ importers:
   packages/color-scale-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -894,8 +894,8 @@ importers:
   packages/compare-slider-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -961,8 +961,8 @@ importers:
   packages/divider-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1037,8 +1037,8 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2(@dnd-kit/core@6.1.0)(react@18.2.0)
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1107,8 +1107,8 @@ importers:
   packages/example:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1174,8 +1174,8 @@ importers:
   packages/figma-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1241,8 +1241,8 @@ importers:
   packages/glyphs-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1314,8 +1314,8 @@ importers:
   packages/gradient-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1387,8 +1387,8 @@ importers:
   packages/image-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1460,8 +1460,8 @@ importers:
   packages/personal-note-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1530,8 +1530,8 @@ importers:
   packages/quote-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1597,7 +1597,7 @@ importers:
   packages/shared:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
+        specifier: ^3.0.0-beta.103
         version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
@@ -1685,8 +1685,8 @@ importers:
   packages/sketchfab-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1752,8 +1752,8 @@ importers:
   packages/storybook-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1822,8 +1822,8 @@ importers:
   packages/template-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1892,8 +1892,8 @@ importers:
   packages/text-block:
     dependencies:
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -1977,8 +1977,8 @@ importers:
         specifier: ^3.2.1
         version: 3.2.2(react@18.2.0)
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -2059,8 +2059,8 @@ importers:
         specifier: ^2.0.21
         version: 2.0.21
       '@frontify/app-bridge':
-        specifier: ^3.0.0-beta.100
-        version: 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+        specifier: ^3.0.0-beta.103
+        version: 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.341
         version: 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
@@ -3232,23 +3232,6 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@frontify/app-bridge@3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1):
-    resolution: {integrity: sha512-iRtPh3MW9MFtzZkNMug6zndvvDdQNYGkjZ41AKC07nyTZaEpMwY5kLslfHRyANsOkEUN4trgaoReZigy8jKfAA==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      react: ^18
-      react-dom: ^18
-      sinon: ^15 || ^16 || ^17
-    dependencies:
-      immer: 10.0.3
-      lodash-es: 4.17.21
-      mitt: 3.0.1
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      sinon: 17.0.1
-      type-fest: 4.8.2
-    dev: false
-
   /@frontify/app-bridge@3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1):
     resolution: {integrity: sha512-tVPd8sH1WcxIaPoBkuMaV68OQDwri4Q/k8Q3edGMv6qihqW0n+eEUmceTuYgBvngOHgtHQfC73dEaA8C6RsoOA==}
     engines: {node: '>=16'}
@@ -3481,7 +3464,7 @@ packages:
       '@dnd-kit/core': 6.1.0(react-dom@18.2.0)(react@18.2.0)
       '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.1.0)(react@18.2.0)
       '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.1.0)(react@18.2.0)
-      '@frontify/app-bridge': 3.0.0-beta.102(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+      '@frontify/app-bridge': 3.0.0-beta.103(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue': 12.0.0-beta.341(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/sidebar-settings': 0.8.0(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@react-aria/focus': 3.15.0(react@18.2.0)


### PR DESCRIPTION
Update `app-bridge` in Asset kit block to use the new `api` signature for `generateBulkDownload` from `useAssetBulkDownload` hook