### PR TITLE
chore: bump guideline-block-settings 0.29.16

### DIFF
--- a/examples/asset-upload/package.json
+++ b/examples/asset-upload/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     }

--- a/packages/animation-curve-block/package.json
+++ b/packages/animation-curve-block/package.json
@@ -36,7 +36,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/asset-kit-block/package.json
+++ b/packages/asset-kit-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/audio-block/package.json
+++ b/packages/audio-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/brand-positioning-block/package.json
+++ b/packages/brand-positioning-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/callout-block/package.json
+++ b/packages/callout-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/checklist-block/package.json
+++ b/packages/checklist-block/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/checkbox": "^3.10.0",
         "@react-aria/focus": "^3.14.0",

--- a/packages/code-snippet-block/package.json
+++ b/packages/code-snippet-block/package.json
@@ -37,7 +37,7 @@
         "@codemirror/view": "^6.17.0",
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@uiw/codemirror-extensions-langs": "^4.21.12",
         "@uiw/codemirror-themes-all": "^4.21.12",

--- a/packages/color-block/package.json
+++ b/packages/color-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dnd": "^16.0.1",

--- a/packages/color-kit-block/package.json
+++ b/packages/color-kit-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/color-scale-block/package.json
+++ b/packages/color-scale-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dnd": "^16.0.1",

--- a/packages/compare-slider-block/package.json
+++ b/packages/compare-slider-block/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-compare-slider": "^2.2.0",

--- a/packages/divider-block/package.json
+++ b/packages/divider-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/dos-donts-block/package.json
+++ b/packages/dos-donts-block/package.json
@@ -36,7 +36,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "autosize": "^6.0.0",
         "react": "^18.2.0",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/figma-block/package.json
+++ b/packages/figma-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/glyphs-block/package.json
+++ b/packages/glyphs-block/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/gradient-block/package.json
+++ b/packages/gradient-block/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/image-block/package.json
+++ b/packages/image-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/focus": "^3.14.0",
         "react": "^18.2.0",

--- a/packages/personal-note-block/package.json
+++ b/packages/personal-note-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "dayjs": "^1.11.6",
         "react": "^18.2.0",

--- a/packages/quote-block/package.json
+++ b/packages/quote-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/sketchfab-block/package.json
+++ b/packages/sketchfab-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/storybook-block/package.json
+++ b/packages/storybook-block/package.json
@@ -32,7 +32,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/interactions": "^3.17.0",
         "react": "^18.2.0",

--- a/packages/template-block/package.json
+++ b/packages/template-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/text-block/package.json
+++ b/packages/text-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "lodash-es": "^4.17.21",
         "react": "^18.2.0",

--- a/packages/thumbnail-grid-block/package.json
+++ b/packages/thumbnail-grid-block/package.json
@@ -39,7 +39,7 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "lodash-es": "^4.17.21",
         "react": "^18.2.0",

--- a/packages/ui-pattern-block/package.json
+++ b/packages/ui-pattern-block/package.json
@@ -37,7 +37,7 @@
         "@codesandbox/sandpack-themes": "^2.0.21",
         "@frontify/app-bridge": "^3.0.0",
         "@frontify/fondue": "12.0.0-beta.382",
-        "@frontify/guideline-blocks-settings": "^0.29.15",
+        "@frontify/guideline-blocks-settings": "^0.29.16",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@mantine/core": "^7.1.2",
         "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       glob:
         specifier: ^10.3.4
         version: 10.3.10
@@ -80,10 +80,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -156,10 +156,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -223,10 +223,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -293,10 +293,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -363,10 +363,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -430,10 +430,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -500,10 +500,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -600,10 +600,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -679,10 +679,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -755,10 +755,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -822,10 +822,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -898,10 +898,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -965,10 +965,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1041,10 +1041,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1111,10 +1111,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1178,10 +1178,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1245,10 +1245,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1318,10 +1318,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1391,10 +1391,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1464,10 +1464,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1534,10 +1534,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1601,7 +1601,7 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@uiw/codemirror-extensions-langs':
         specifier: ^4.21.12
         version: 4.21.21(@codemirror/autocomplete@6.11.1)(@codemirror/language-data@6.3.1)(@codemirror/language@6.9.3)(@codemirror/legacy-modes@6.3.3)(@codemirror/state@6.3.2)(@codemirror/view@6.22.1)(@lezer/common@1.1.1)(@lezer/highlight@1.2.0)(@lezer/javascript@1.4.9)(@lezer/lr@1.3.14)
@@ -1689,10 +1689,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1756,10 +1756,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1826,10 +1826,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1896,10 +1896,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1981,10 +1981,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -2063,10 +2063,10 @@ importers:
         version: 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.382
-        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        version: 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.29.15
-        version: 0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+        specifier: ^0.29.16
+        version: 0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -3542,7 +3542,7 @@ packages:
       - ts-node
     dev: false
 
-  /@frontify/fondue@12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7):
+  /@frontify/fondue@12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7):
     resolution: {integrity: sha512-0ffu0jmh46VTj99biHpJQSEfs44bph9xizpiYArWVQz5Jk+7MLSD4+wdfog9Ii3Czk43fUMKCeeu4yRcO9GFxw==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -3612,6 +3612,7 @@ packages:
       react-textarea-autosize: 8.5.3(@types/react@18.2.39)(react@18.2.0)
       remark-gfm: 3.0.1
       remark-parse: 10.0.2
+      scheduler: 0.23.0
       slate: 0.94.1
       slate-react: 0.98.4(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       unified: 10.1.2
@@ -3636,7 +3637,6 @@ packages:
       - jotai-xstate
       - jotai-zustand
       - react-native
-      - scheduler
       - slate-history
       - slate-hyperscript
       - styled-components
@@ -3676,8 +3676,8 @@ packages:
       - terser
     dev: true
 
-  /@frontify/guideline-blocks-settings@0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7):
-    resolution: {integrity: sha512-L2HYQFYQR+VMcqlijrswvYQKdGLrnCLycPAw2Vn4E83PXrWdJoFjIFyukGPYwur2NGL8D1c297MlCIE7Ib4Dyg==}
+  /@frontify/guideline-blocks-settings@0.29.16(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7):
+    resolution: {integrity: sha512-PsNw9Gc8BkCPs0r7ySVRsZX39DMipT/TiEImU1J9pHLzFQ+I2+54r1mfYY10gpIW4tXixDaadUZUQewDgTeevA==}
     peerDependencies:
       react: ^18
       react-dom: ^18
@@ -3687,60 +3687,8 @@ packages:
       '@dnd-kit/modifiers': 7.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
       '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
       '@frontify/app-bridge': 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
-      '@frontify/fondue': 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
-      '@frontify/sidebar-settings': 0.8.1(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
-      '@react-aria/focus': 3.15.0(react@18.2.0)
-      '@react-stately/overlays': 3.6.4(react@18.2.0)
-      '@udecode/plate': 21.5.0(@babel/core@7.23.5)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.1)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-react: 0.98.4(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/hoist-non-react-statics'
-      - '@types/node'
-      - '@types/react'
-      - '@types/react-dom'
-      - '@xstate/fsm'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-dnd
-      - react-dnd-html5-backend
-      - react-is
-      - react-native
-      - scheduler
-      - sinon
-      - slate-history
-      - slate-hyperscript
-      - styled-components
-      - supports-color
-      - tailwindcss
-      - ts-node
-      - zustand
-    dev: false
-
-  /@frontify/guideline-blocks-settings@0.29.15(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7):
-    resolution: {integrity: sha512-L2HYQFYQR+VMcqlijrswvYQKdGLrnCLycPAw2Vn4E83PXrWdJoFjIFyukGPYwur2NGL8D1c297MlCIE7Ib4Dyg==}
-    peerDependencies:
-      react: ^18
-      react-dom: ^18
-    dependencies:
-      '@ctrl/tinycolor': 4.0.2
-      '@dnd-kit/core': 6.1.0(react-dom@18.2.0)(react@18.2.0)
-      '@dnd-kit/modifiers': 7.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
-      '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
-      '@frontify/app-bridge': 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
-      '@frontify/fondue': 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
-      '@frontify/sidebar-settings': 0.8.1(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+      '@frontify/fondue': 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+      '@frontify/sidebar-settings': 0.8.1(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       '@react-aria/focus': 3.15.0(react@18.2.0)
       '@react-stately/overlays': 3.6.4(react@18.2.0)
       '@udecode/plate': 21.5.0(@babel/core@7.23.5)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.1)
@@ -3780,14 +3728,14 @@ packages:
       - zustand
     dev: false
 
-  /@frontify/sidebar-settings@0.8.1(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7):
+  /@frontify/sidebar-settings@0.8.1(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7):
     resolution: {integrity: sha512-F4oPR4meAcPenPoRN/ck62V4Z9VF2LowTuvQk7m5L/Asaj4GBGgKr+MDCxmVFuw7p3TPGZKEBfSnr1h/NZcF7Q==}
     peerDependencies:
       react: ^18
       react-dom: ^18
     dependencies:
       '@frontify/app-bridge': 3.0.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
-      '@frontify/fondue': 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
+      '@frontify/fondue': 12.0.0-beta.382(@babel/core@7.23.5)(@types/node@20.10.1)(@types/react-dom@18.2.17)(@types/react@18.2.39)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.1)(tailwindcss@3.3.5)(ts-node@10.9.1)(zustand@4.4.7)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -3808,7 +3756,6 @@ packages:
       - jotai-xstate
       - jotai-zustand
       - react-native
-      - scheduler
       - sinon
       - slate-history
       - slate-hyperscript
@@ -14135,7 +14082,6 @@ packages:
       nanoid: 3.3.7
       picocolors: 1.0.0
       source-map-js: 1.0.2
-    dev: true
 
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -15380,7 +15326,7 @@ packages:
       '@types/stylis': 4.2.4
       css-to-react-native: 3.2.0
       csstype: 3.1.2
-      postcss: 8.4.31
+      postcss: 8.4.32
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       shallowequal: 1.1.0


### PR DESCRIPTION
Bumping it in a single PR, so we can keep that noise out of this PR: https://github.com/Frontify/guideline-blocks/pull/699