### PR TITLE
fix: change default audio positioning

### DIFF
--- a/packages/audio-block/src/settings.ts
+++ b/packages/audio-block/src/settings.ts
@@ -32,7 +32,7 @@ export const settings = defineSettings({
             id: 'positioning',
             label: 'Positioning',
             type: 'segmentedControls',
-            defaultValue: TextPosition.Below,
+            defaultValue: TextPosition.Above,
             choices: [
                 { value: TextPosition.Below, icon: IconEnum.MediaObjectTextBottom },
                 { value: TextPosition.Above, icon: IconEnum.MediaObjectTextTop },


### PR DESCRIPTION
Default positioning has been updated to reflect the positioning of the old audio block.
The title and description should be by default above the audio block, until the user changes this value.