### PR TITLE
feat(*): add css scoping to each block

### DIFF
--- a/examples/asset-upload/postcss.config.js
+++ b/examples/asset-upload/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.example-asset-upload' }),
+    ],
 };

--- a/examples/asset-upload/tailwind.config.js
+++ b/examples/asset-upload/tailwind.config.js
@@ -1,8 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    presets: [require('@frontify/fondue/tailwind'), require('../shared/tailwind.config')],
-    content: ['src/**/*.{ts,tsx}', '../shared/src/**/*.{ts,tsx}'],
+    presets: [require('@frontify/fondue/tailwind'), require('../../packages/shared/tailwind.config')],
+    content: ['src/**/*.{ts,tsx}', '../../packages/shared/src/**/*.{ts,tsx}'],
     corePlugins: {
         preflight: false,
     },

--- a/examples/asset-upload/tailwind.config.js
+++ b/examples/asset-upload/tailwind.config.js
@@ -1,10 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    presets: [require('@frontify/fondue/tailwind'), require('../../packages/shared/tailwind.config')],
-    content: ['src/**/*.{ts,tsx}', '../../packages/shared/src/**/*.{ts,tsx}'],
+    presets: [require('@frontify/fondue/tailwind'), require('../shared/tailwind.config')],
+    content: ['src/**/*.{ts,tsx}', '../shared/src/**/*.{ts,tsx}'],
     corePlugins: {
         preflight: false,
     },
-    important: '.example-asset-upload',
 };

--- a/packages/animation-curve-block/postcss.config.js
+++ b/packages/animation-curve-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.animation-curve-block' }),
+    ],
 };

--- a/packages/animation-curve-block/tailwind.config.js
+++ b/packages/animation-curve-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.animation-curve-block',
 };

--- a/packages/asset-kit-block/postcss.config.js
+++ b/packages/asset-kit-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.asset-kit-block' }),
+    ],
 };

--- a/packages/asset-kit-block/tailwind.config.js
+++ b/packages/asset-kit-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.asset-kit-block',
 };

--- a/packages/audio-block/postcss.config.js
+++ b/packages/audio-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.audio-block' }),
+    ],
 };

--- a/packages/audio-block/tailwind.config.js
+++ b/packages/audio-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.audio-block',
 };

--- a/packages/callout-block/postcss.config.js
+++ b/packages/callout-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.callout-block' }),
+    ],
 };

--- a/packages/callout-block/tailwind.config.js
+++ b/packages/callout-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.callout-block',
 };

--- a/packages/checklist-block/postcss.config.js
+++ b/packages/checklist-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.checklist-block' }),
+    ],
 };

--- a/packages/checklist-block/tailwind.config.js
+++ b/packages/checklist-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.checklist-block',
 };

--- a/packages/code-snippet-block/postcss.config.js
+++ b/packages/code-snippet-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.code-snippet-block' }),
+    ],
 };

--- a/packages/code-snippet-block/tailwind.config.js
+++ b/packages/code-snippet-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.code-snippet-block',
 };

--- a/packages/color-block/postcss.config.js
+++ b/packages/color-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.color-block' }),
+    ],
 };

--- a/packages/color-block/tailwind.config.js
+++ b/packages/color-block/tailwind.config.js
@@ -17,5 +17,4 @@ module.exports = {
             },
         },
     },
-    important: '.color-block',
 };

--- a/packages/color-kit-block/postcss.config.js
+++ b/packages/color-kit-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.color-kit-block' }),
+    ],
 };

--- a/packages/color-kit-block/tailwind.config.js
+++ b/packages/color-kit-block/tailwind.config.js
@@ -20,5 +20,4 @@ module.exports = {
             },
         },
     },
-    important: '.color-kit-block',
 };

--- a/packages/color-scale-block/postcss.config.js
+++ b/packages/color-scale-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.color-scale-block' }),
+    ],
 };

--- a/packages/color-scale-block/tailwind.config.js
+++ b/packages/color-scale-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.color-scale-block',
 };

--- a/packages/compare-slider-block/postcss.config.js
+++ b/packages/compare-slider-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.compare-slider-block' }),
+    ],
 };

--- a/packages/compare-slider-block/tailwind.config.js
+++ b/packages/compare-slider-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.compare-slider-block',
 };

--- a/packages/divider-block/postcss.config.js
+++ b/packages/divider-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.divider-block' }),
+    ],
 };

--- a/packages/divider-block/tailwind.config.js
+++ b/packages/divider-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.divider-block',
 };

--- a/packages/dos-donts-block/postcss.config.js
+++ b/packages/dos-donts-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.dos-donts-block' }),
+    ],
 };

--- a/packages/dos-donts-block/tailwind.config.js
+++ b/packages/dos-donts-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.dos-donts-block',
 };

--- a/packages/example/postcss.config.js
+++ b/packages/example/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.example-block' }),
+    ],
 };

--- a/packages/example/tailwind.config.js
+++ b/packages/example/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.example-block',
 };

--- a/packages/figma-block/postcss.config.js
+++ b/packages/figma-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.figma-block' }),
+    ],
 };

--- a/packages/figma-block/tailwind.config.js
+++ b/packages/figma-block/tailwind.config.js
@@ -23,5 +23,4 @@ module.exports = {
             },
         },
     },
-    important: '.figma-block',
 };

--- a/packages/glyphs-block/postcss.config.js
+++ b/packages/glyphs-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.glyphs-block' }),
+    ],
 };

--- a/packages/glyphs-block/tailwind.config.js
+++ b/packages/glyphs-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.glyphs-block',
 };

--- a/packages/gradient-block/postcss.config.js
+++ b/packages/gradient-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.gradient-block' }),
+    ],
 };

--- a/packages/gradient-block/tailwind.config.js
+++ b/packages/gradient-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.gradient-block',
 };

--- a/packages/image-block/postcss.config.js
+++ b/packages/image-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.image-block' }),
+    ],
 };

--- a/packages/image-block/tailwind.config.js
+++ b/packages/image-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.image-block',
 };

--- a/packages/personal-note-block/postcss.config.js
+++ b/packages/personal-note-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.personal-note-block' }),
+    ],
 };

--- a/packages/personal-note-block/tailwind.config.js
+++ b/packages/personal-note-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.personal-note-block',
 };

--- a/packages/quote-block/postcss.config.js
+++ b/packages/quote-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.quote-block' }),
+    ],
 };

--- a/packages/quote-block/tailwind.config.js
+++ b/packages/quote-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.quote-block',
 };

--- a/packages/sketchfab-block/postcss.config.js
+++ b/packages/sketchfab-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.sketchfab-block' }),
+    ],
 };

--- a/packages/sketchfab-block/tailwind.config.js
+++ b/packages/sketchfab-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.sketchfab-block',
 };

--- a/packages/storybook-block/postcss.config.js
+++ b/packages/storybook-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.storybook-block' }),
+    ],
 };

--- a/packages/storybook-block/tailwind.config.js
+++ b/packages/storybook-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.storybook-block',
 };

--- a/packages/template-block/postcss.config.js
+++ b/packages/template-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.template-block' }),
+    ],
 };

--- a/packages/template-block/tailwind.config.js
+++ b/packages/template-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.template-block',
 };

--- a/packages/text-block/postcss.config.js
+++ b/packages/text-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.text-block' }),
+    ],
 };

--- a/packages/text-block/tailwind.config.js
+++ b/packages/text-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.text-block',
 };

--- a/packages/thumbnail-grid-block/postcss.config.js
+++ b/packages/thumbnail-grid-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.thumbnail-grid-block' }),
+    ],
 };

--- a/packages/thumbnail-grid-block/tailwind.config.js
+++ b/packages/thumbnail-grid-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.thumbnail-grid-block',
 };

--- a/packages/ui-pattern-block/postcss.config.js
+++ b/packages/ui-pattern-block/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        require('../../postcss/scope')({ scope: '.ui-pattern-block' }),
+    ],
 };

--- a/packages/ui-pattern-block/tailwind.config.js
+++ b/packages/ui-pattern-block/tailwind.config.js
@@ -6,5 +6,4 @@ module.exports = {
     corePlugins: {
         preflight: false,
     },
-    important: '.ui-pattern-block',
 };

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,9 +1,8 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: [
-        require("tailwindcss"),
-        require("autoprefixer"),
-        require("../../postcss/scope")({ scope: ".image-block" }),
-    ],
+    plugins: {
+        tailwindcss: {},
+        autoprefixer: {},
+    },
 };

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,8 +1,9 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
+    plugins: [
+        require("tailwindcss"),
+        require("autoprefixer"),
+        require("../../postcss/scope")({ scope: ".image-block" }),
+    ],
 };

--- a/postcss/scope.js
+++ b/postcss/scope.js
@@ -20,15 +20,16 @@ module.exports = (opts = {}) => {
                 ) {
                     return;
                 }
-                rule.selectors = rule.selectors.map((selectors) => {
-                    return selectors.split(/,\s* /g).map((selector) => {
-                        if (selector === opts.selector) {
-                            return selector;
-                        }
-                        const newSelector = `${opts.scope} ${selector}`;
-                        return newSelector;
-                    });
-                });
+                rule.selectors = rule.selectors.map((originalSelector) =>
+                    originalSelector
+                        .split(/,\s*/g)
+                        .map((individualSelector) =>
+                            individualSelector === opts.selector
+                                ? individualSelector
+                                : `${opts.scope} ${individualSelector}`,
+                        )
+                        .join(", "),
+                );
             });
         },
     };

--- a/postcss/scope.js
+++ b/postcss/scope.js
@@ -1,0 +1,37 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+/**
+ * This custom plugin prepends every css rule in the generated style.css
+ * with an extra selector, essentially scoping the whole css file to the specific block
+ */
+
+/**
+ * @type {import('postcss').PluginCreator}
+ */
+module.exports = (opts = {}) => {
+    return {
+        postcssPlugin: "scope",
+        Root(root) {
+            root.walkRules((rule) => {
+                if (
+                    rule.parent &&
+                    rule.parent.type === "atrule" &&
+                    rule.parent.name.includes("keyframes")
+                ) {
+                    return;
+                }
+                rule.selectors = rule.selectors.map((selectors) => {
+                    return selectors.split(/,\s* /g).map((selector) => {
+                        if (selector === opts.selector) {
+                            return selector;
+                        }
+                        const newSelector = `${opts.scope} ${selector}`;
+                        return newSelector;
+                    });
+                });
+            });
+        },
+    };
+};
+
+module.exports.postcss = true;


### PR DESCRIPTION
Created a PostCSS Plugin that prepends every css rule in the generated style.css with an extra selector, essentially scoping the whole css file to the specific block.

```
.foo .bar { ... }
```
becomes
```
.text-block .foo .bar { ... }
```

Previously we relied on Tailwind's `important` scoping approach, but that does not scope css rules that were imported to the package (e.g. @frontify/guideline-blocks-settings/dist/style.css)

To test:
1. run `pnpm run deploy --dryRun` inside any package
2. check the style.css inside the /dist folder of the package
3. all rules should be scoped