### PR TITLE
fix(*): css scoping regex is incorrect

### DIFF
--- a/postcss/scope.js
+++ b/postcss/scope.js
@@ -22,7 +22,7 @@ module.exports = (opts = {}) => {
                 }
                 rule.selectors = rule.selectors.map((originalSelector) =>
                     originalSelector
-                        .split(/,\s*/g)
+                        .split(/(?<!\\),\s*/g)
                         .map((individualSelector) =>
                             individualSelector === opts.selector
                                 ? individualSelector


### PR DESCRIPTION


1. The CSS scoping postCSS plugin regex was wrong. Tailwind classes like `bg-[rgb(150,150,150)]` were wrongly prepended because of the commas. Updated the regex with a negative lookahead, to not prepend with the selector if the comma is escaped. (tailwind transforms classes like that to `bg-[rgb(150\,150\,150)]`).