### PR TITLE
fix(AudioBlock): add title automatically if title is empty

### DIFF
--- a/packages/audio-block/src/AudioBlock.spec.ct.tsx
+++ b/packages/audio-block/src/AudioBlock.spec.ct.tsx
@@ -12,11 +12,13 @@ const AudioBlockSelector = '[data-test-id="audio-block"]';
 const AudioTagSelector = '[data-test-id="audio-block-audio-tag"]';
 const UploadPlaceholderSelector = '[data-test-id="block-inject-button"]';
 const AudioBlockTitleHtmlSelector = '[data-test-id="block-title"] [data-test-id="rte-content-html"]';
+const AudioBlockTitleRteSelector = '[data-test-id="block-title"]';
 const AudioBlockDescriptionHtmlSelector = '[data-test-id="block-description"] [data-test-id="rte-content-html"]';
 const DownloadButtonSelector = '[data-test-id="download-button"]';
 const AttachmentsTriggerSelector = '[data-test-id="attachments-flyout-button"]';
 const ViewModeAddonsSelector = '[data-test-id="view-mode-addons"]';
 const BlockWrapperSelector = '[data-test-id="block-item-wrapper"]';
+const UploadMenu = '[data-test-id="menu-item-title"]';
 
 const Title = '[{"type":"heading3","children":[{"text":"Audio Title"}]}]';
 const Description = '[{"type":"p","children":[{"text":"Audio Description"}]}]';
@@ -218,5 +220,15 @@ describe('Audio Block', () => {
         });
         mount(<AudioBlockWithStubs />);
         cy.get(ViewModeAddonsSelector).should('not.exist');
+    });
+
+    it.only('should add the file name to the title when the title is empty', () => {
+        const [AudioBlockWithStubs] = withAppBridgeBlockStubs(AudioBlock, {
+            editorState: true,
+        });
+        mount(<AudioBlockWithStubs />);
+        cy.get(UploadPlaceholderSelector).click();
+        cy.get(UploadMenu).eq(1).click();
+        cy.get(AudioBlockTitleRteSelector).contains('A title').should('exist');
     });
 });

--- a/packages/audio-block/src/AudioBlock.spec.ct.tsx
+++ b/packages/audio-block/src/AudioBlock.spec.ct.tsx
@@ -222,7 +222,7 @@ describe('Audio Block', () => {
         cy.get(ViewModeAddonsSelector).should('not.exist');
     });
 
-    it.only('should add the file name to the title when the title is empty', () => {
+    it('should add the file name to the title when the title is empty', () => {
         const [AudioBlockWithStubs] = withAppBridgeBlockStubs(AudioBlock, {
             editorState: true,
         });
@@ -230,5 +230,19 @@ describe('Audio Block', () => {
         cy.get(UploadPlaceholderSelector).click();
         cy.get(UploadMenu).eq(1).click();
         cy.get(AudioBlockTitleRteSelector).contains('A title').should('exist');
+    });
+
+    it('should not add the file name to the title when the title is not empty', () => {
+        const [AudioBlockWithStubs] = withAppBridgeBlockStubs(AudioBlock, {
+            editorState: true,
+            blockSettings: {
+                title: Title,
+            },
+        });
+        mount(<AudioBlockWithStubs />);
+        cy.get(UploadPlaceholderSelector).click();
+        cy.get(UploadMenu).eq(1).click();
+        cy.get(AudioBlockTitleRteSelector).contains('Audio Title').should('exist');
+        cy.get(AudioBlockTitleRteSelector).contains('A title').should('not.exist');
     });
 });

--- a/packages/audio-block/src/AudioBlock.tsx
+++ b/packages/audio-block/src/AudioBlock.tsx
@@ -49,6 +49,7 @@ export const AudioBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
     const [openFileDialog, { selectedFiles }] = useFileInput({ accept: 'audio/*' });
     const { assetDownloadEnabled } = usePrivacySettings(appBridge);
     const audio = blockAssets?.[AUDIO_ID]?.[0];
+    const blockId = appBridge.context('blockId').get();
 
     const [uploadFile, { results: uploadResults, doneAll }] = useAssetUpload({
         onUploadProgress: () => !isLoading && setIsLoading(true),
@@ -89,7 +90,11 @@ export const AudioBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
         }
     };
 
-    const onTitleChange = async (title: string) => title !== blockSettings.title && (await setBlockSettings({ title }));
+    const onTitleChange = async (title: string) => {
+        if (title !== blockSettings.title) {
+            await setBlockSettings({ title });
+        }
+    };
 
     const onDescriptionChange = (description: string) =>
         description !== blockSettings.description && setBlockSettings({ description });
@@ -142,7 +147,7 @@ export const AudioBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
                         <div data-test-id="block-title">
                             <RichTextEditor
                                 key={titleKey}
-                                id={`${appBridge.context('blockId').get()}-title`}
+                                id={`${blockId}-title`}
                                 plugins={titlePlugins}
                                 isEditing={isEditing}
                                 onTextChange={onTitleChange}
@@ -153,7 +158,7 @@ export const AudioBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
 
                         <div data-test-id="block-description">
                             <RichTextEditor
-                                id={`${appBridge.context('blockId').get()}-description`}
+                                id={`${blockId}-description`}
                                 plugins={getDescriptionPlugins(appBridge)}
                                 isEditing={isEditing}
                                 onTextChange={onDescriptionChange}


### PR DESCRIPTION
- fixes the issue with not adding title if title is empty and a audio asset gets added
- adds tests to avoid regression
- replaces deprecated getBlockId function

[Task](https://app.clickup.com/t/8693jjk0q)