### PR TITLE
fix(Audio Block):  remove empty text items

### DIFF
--- a/packages/audio-block/src/AudioBlock.tsx
+++ b/packages/audio-block/src/AudioBlock.tsx
@@ -173,7 +173,7 @@ export const AudioBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
                         </div>
                     </div>
                     {audio && !isEditing && (
-                        <div className="tw-flex tw-gap-2" data-test-id="view-mode-addons">
+                        <div className="tw-flex tw-gap-2 tw-leading-normal" data-test-id="view-mode-addons">
                             {isDownloadable(
                                 blockSettings.security,
                                 blockSettings.downloadable,

--- a/packages/audio-block/src/AudioBlock.tsx
+++ b/packages/audio-block/src/AudioBlock.tsx
@@ -114,6 +114,9 @@ export const AudioBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [doneAll, uploadResults]);
 
+    const titleValue = blockSettings.title ?? DEFAULT_CONTENT_TITLE;
+    const descriptionValue = blockSettings.description ?? DEFAULT_CONTENT_DESCRIPTION;
+
     return (
         <div className="audio-block">
             <div
@@ -151,8 +154,9 @@ export const AudioBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
                                 plugins={titlePlugins}
                                 isEditing={isEditing}
                                 onTextChange={onTitleChange}
-                                value={blockSettings.title ?? DEFAULT_CONTENT_TITLE}
+                                value={titleValue}
                                 placeholder="Asset name"
+                                showSerializedText={hasRichTextValue(titleValue)}
                             />
                         </div>
 
@@ -162,8 +166,9 @@ export const AudioBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
                                 plugins={getDescriptionPlugins(appBridge)}
                                 isEditing={isEditing}
                                 onTextChange={onDescriptionChange}
-                                value={blockSettings.description ?? DEFAULT_CONTENT_DESCRIPTION}
+                                value={descriptionValue}
                                 placeholder="Add a description here"
+                                showSerializedText={hasRichTextValue(descriptionValue)}
                             />
                         </div>
                     </div>


### PR DESCRIPTION
Use the `showSerializedText` property to hide the rich text editor on occasions when the block title or description is empty