### PR TITLE
fix (dosdonts-block): add fondue styles 

### DIFF
--- a/packages/dos-donts-block/src/DosDontsBlock.tsx
+++ b/packages/dos-donts-block/src/DosDontsBlock.tsx
@@ -23,8 +23,6 @@ import {
     useDndSensors,
 } from '@frontify/guideline-blocks-settings';
 import { FC, useEffect, useRef, useState } from 'react';
-import 'tailwindcss/tailwind.css';
-import '@frontify/guideline-blocks-settings/styles';
 import { DoDontItem, SortableDoDontItem } from './DoDontItem';
 import { BlockMode, ChangeType, DoDontType, GUTTER_VALUES, Item, Settings, ValueType } from './types';
 import {
@@ -39,6 +37,10 @@ import {
     PatternTheme,
     generateRandomId,
 } from '@frontify/fondue';
+
+import 'tailwindcss/tailwind.css';
+import '@frontify/guideline-blocks-settings/styles';
+import '@frontify/fondue/style';
 
 export const DO_COLOR_DEFAULT_VALUE = { red: 0, green: 200, blue: 165, alpha: 1 };
 export const DONT_COLOR_DEFAULT_VALUE = { red: 255, green: 55, blue: 90, alpha: 1 };

--- a/packages/dos-donts-block/src/DosDontsBlock.tsx
+++ b/packages/dos-donts-block/src/DosDontsBlock.tsx
@@ -38,10 +38,6 @@ import {
     generateRandomId,
 } from '@frontify/fondue';
 
-import 'tailwindcss/tailwind.css';
-import '@frontify/guideline-blocks-settings/styles';
-import '@frontify/fondue/style';
-
 export const DO_COLOR_DEFAULT_VALUE = { red: 0, green: 200, blue: 165, alpha: 1 };
 export const DONT_COLOR_DEFAULT_VALUE = { red: 255, green: 55, blue: 90, alpha: 1 };
 

--- a/packages/dos-donts-block/src/index.ts
+++ b/packages/dos-donts-block/src/index.ts
@@ -4,6 +4,10 @@ import { defineBlock } from '@frontify/guideline-blocks-settings';
 import { DosDontsBlock } from './DosDontsBlock';
 import { settings } from './settings';
 
+import 'tailwindcss/tailwind.css';
+import '@frontify/guideline-blocks-settings/styles';
+import '@frontify/fondue/style';
+
 export default defineBlock({
     block: DosDontsBlock,
     settings,


### PR DESCRIPTION
Include Fondue styles in bundle to fix tooltip arrow incorrect styling