### PR TITLE
fix: Template Block Image Align

### DIFF
--- a/packages/template-block/src/components/TemplatePreview.tsx
+++ b/packages/template-block/src/components/TemplatePreview.tsx
@@ -54,7 +54,7 @@ export const TemplatePreview = ({
         <div className={previewClasses} data-test-id="preview">
             {template !== null || previewCustom ? (
                 <button
-                    className="tw-relative tw-overflow-hidden"
+                    className="tw-relative tw-overflow-hidden tw-w-full tw-h-full"
                     data-test-id="preview-wrapper"
                     style={{
                         ...(hasBackgroundTemplatePreview && {

--- a/packages/template-block/src/settings.ts
+++ b/packages/template-block/src/settings.ts
@@ -293,17 +293,14 @@ export const settings = defineSettings({
                         {
                             value: AnchoringType.Start,
                             icon: IconEnum.ArrowAlignLeft,
-                            label: 'Left',
                         },
                         {
                             value: AnchoringType.Center,
                             icon: IconEnum.ArrowAlignVerticalCentre,
-                            label: 'Center',
                         },
                         {
                             value: AnchoringType.End,
                             icon: IconEnum.ArrowAlignRight,
-                            label: 'Right',
                         },
                     ],
                 },


### PR DESCRIPTION
This PR fixes the settings regarding the image-align, see screenshot. When converting the `div` into a `button` in #728 / 79855f3bff540748b73083d064c3bc3458e82d2c, the button didn't automatically take up the full height & width, like the div.

How to test:

- Create a new template block
- Enable the preview
- Play around with the layouts, sizes, and alignment of the preview
- The image should be able to align within the image frame, and it should correctly be centered etc.

![image](https://github.com/Frontify/guideline-blocks/assets/9266535/f4f7d3a5-e283-4b3f-b29e-837a400b0bea)

----

I also removed the "Left", "Center" & "Right" labels in the image anchor settings, as they were cut off (see screenshot above). They are now aligned with the same settings further up, so no label is shown (see screenshot below).

<img width="323" alt="image" src="https://github.com/Frontify/guideline-blocks/assets/9266535/93ba5b58-7c31-4d75-b75f-afd0d6e3fca4">
