### PR TITLE
Template Block: Hide page count by default

### DIFF
--- a/packages/template-block/src/settings.ts
+++ b/packages/template-block/src/settings.ts
@@ -40,7 +40,7 @@ export const settings = defineSettings({
         {
             id: 'hasPageCount',
             type: 'switch',
-            defaultValue: true,
+            defaultValue: false,
             label: 'Show page count',
             info: 'Show or hide the page count indicator',
         },


### PR DESCRIPTION
Since most templates use 1 page only, and when first creating block it says "0 pages", we'll disable the page-count by default.