### PR TITLE
feat(TemplateBlock): Use `getCurrentLoggedUser` to check if user is logged in [CU-8693qphk1]

### DIFF
--- a/packages/template-block/src/TemplateBlock.spec.ct.tsx
+++ b/packages/template-block/src/TemplateBlock.spec.ct.tsx
@@ -79,6 +79,20 @@ describe('Template Block', () => {
         cy.get(CTA_BUTTON_SELECTOR).should('exist');
     });
 
+    it('should not render a block if use is not authenticated', () => {
+        const [TemplateBlockWithStubs] = withAppBridgeBlockStubs(TemplateBlock, {
+            blockTemplates: {
+                template: [getTemplateDummyWithPages()],
+            },
+            user: undefined,
+        });
+
+        mount(<TemplateBlockWithStubs />);
+        cy.get(BLOCK_CONTAINER_SELECTOR).should('exist');
+        cy.wait(100);
+        cy.get(CARD_SELECTOR).should('not.exist');
+    });
+
     it('should render a block if template provided and block is in edit mode', () => {
         const [TemplateBlockWithStubs] = withAppBridgeBlockStubs(TemplateBlock, {
             editorState: true,

--- a/packages/template-block/src/TemplateBlock.spec.ct.tsx
+++ b/packages/template-block/src/TemplateBlock.spec.ct.tsx
@@ -1,7 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { mount } from 'cypress/react18';
-import { AssetDummy, TemplateDummy, withAppBridgeBlockStubs } from '@frontify/app-bridge';
+import { AssetDummy, TemplateDummy, UserDummy, withAppBridgeBlockStubs } from '@frontify/app-bridge';
 import { TemplateBlock } from './TemplateBlock';
 import { BorderStyle, Padding, Radius, toRgbaString } from '@frontify/guideline-blocks-settings';
 import {
@@ -84,7 +84,7 @@ describe('Template Block', () => {
             blockTemplates: {
                 template: [getTemplateDummyWithPages()],
             },
-            user: undefined,
+            user: UserDummy.with(0),
         });
 
         mount(<TemplateBlockWithStubs />);

--- a/packages/template-block/src/TemplateBlock.tsx
+++ b/packages/template-block/src/TemplateBlock.tsx
@@ -21,6 +21,7 @@ export const TemplateBlock = ({ appBridge }: BlockProps): ReactElement => {
         description,
         hasPreview,
         hasTitleOnly,
+        hasLoggedInUser,
         isEditing,
         lastErrorMessage,
         preview,
@@ -54,7 +55,7 @@ export const TemplateBlock = ({ appBridge }: BlockProps): ReactElement => {
 
     const handleOpenTemplateChooser = () => appBridge.dispatch(openTemplateChooser());
 
-    if (!selectedTemplate && !isEditing) {
+    if (!isEditing && (!selectedTemplate || !hasLoggedInUser)) {
         return <div data-test-id="container" className="template-block"></div>;
     }
 

--- a/packages/template-block/src/hooks/useTemplateBlockData.ts
+++ b/packages/template-block/src/hooks/useTemplateBlockData.ts
@@ -44,6 +44,7 @@ export const useTemplateBlockData = (appBridge: BlockProps['appBridge']) => {
     const [selectedTemplate, setSelectedTemplate] = useState<Template | null>(null);
     const [lastErrorMessage, setLastErrorMessage] = useState('');
     const [templateTextKey, setTemplateTextKey] = useState(0);
+    const [hasLoggedInUser, setHasLoggedInUser] = useState(false);
     const isEditing = useEditorState(appBridge);
 
     const {
@@ -123,6 +124,12 @@ export const useTemplateBlockData = (appBridge: BlockProps['appBridge']) => {
     const hasPreview = preview !== PreviewType.None;
     const hasTitleOnly = !hasPreview && !hasPageCount && !hasRichTextValue(description);
 
+    useEffect(() => {
+        appBridge.getCurrentLoggedUser().then((user) => {
+            setHasLoggedInUser(!!user.id);
+        });
+    }, [appBridge]);
+
     return {
         blockSettings,
         cardStyles: getCardStyles(
@@ -144,6 +151,7 @@ export const useTemplateBlockData = (appBridge: BlockProps['appBridge']) => {
         description,
         hasPreview,
         hasTitleOnly,
+        hasLoggedInUser,
         isEditing,
         lastErrorMessage,
         preview,

--- a/packages/template-block/src/hooks/useTemplateBlockData.ts
+++ b/packages/template-block/src/hooks/useTemplateBlockData.ts
@@ -126,8 +126,12 @@ export const useTemplateBlockData = (appBridge: BlockProps['appBridge']) => {
 
     useEffect(() => {
         const getCurrentLoggedUser = async () => {
-            const currentLoggedUser = await appBridge.getCurrentLoggedUser();
-            setHasLoggedInUser(!!currentLoggedUser.id);
+            try {
+                const currentLoggedUser = await appBridge.getCurrentLoggedUser();
+                setHasLoggedInUser(!!currentLoggedUser.id);
+            } catch (userFetchError) {
+                setHasLoggedInUser(false);
+            }
         };
         getCurrentLoggedUser();
     }, [appBridge]);

--- a/packages/template-block/src/hooks/useTemplateBlockData.ts
+++ b/packages/template-block/src/hooks/useTemplateBlockData.ts
@@ -125,9 +125,11 @@ export const useTemplateBlockData = (appBridge: BlockProps['appBridge']) => {
     const hasTitleOnly = !hasPreview && !hasPageCount && !hasRichTextValue(description);
 
     useEffect(() => {
-        appBridge.getCurrentLoggedUser().then((user) => {
-            setHasLoggedInUser(!!user.id);
-        });
+        const getCurrentLoggedUser = async () => {
+            const currentLoggedUser = await appBridge.getCurrentLoggedUser();
+            setHasLoggedInUser(!!currentLoggedUser.id);
+        };
+        getCurrentLoggedUser();
     }, [appBridge]);
 
     return {


### PR DESCRIPTION
Fixes https://app.clickup.com/t/8693qphk1

👁️  Template Block should be hidden for users that are not logged in, because they can't create publications anyway.

⚠️  Notice regarding tests: I decided to mock a user with ID `0`, which evaluates to `false` in my code. I know this is not ideal, but at least we can test the actual behavior this way. As soon as a better solution is in place we should be able to easily switch it out.

🧪  How to test:
- Create a guideline with this version of template block (local block development)
- In the powerbar, go to the "Share" menu and get the "Public Link" (e.g. `https://dev.frontify.test/d/G9HPcwB3gvuk`)
- Open the public link e.g. in an Inkognito tab (w/o authenticated user) - the guidelines should be shown, but not the template block

![image](https://github.com/Frontify/guideline-blocks/assets/9266535/1e77b2a1-8bbd-4b96-b589-f9058c13b6b0)


Issue:
- [ ] I get a JSON.parse error from the HTTP library. In production mode, however, it works (aka the block is actually hidden). Not very elegant, though. -> Could be band-aided a bit by https://github.com/Frontify/web-app/pull/2791, but it's under consideration by Rafi & Alev (Shoutout to you! 🙏 )