### PR TITLE
fix: remove border radius when border is switched off

### DIFF
--- a/packages/ui-pattern-block/src/UIPatternBlock.tsx
+++ b/packages/ui-pattern-block/src/UIPatternBlock.tsx
@@ -161,7 +161,7 @@ export const UIPatternBlock = ({ appBridge }: BlockProps): ReactElement => {
         [npmDependencies]
     );
 
-    const borderRadius = getRadiusValue(hasRadius, radiusValue, radiusChoice);
+    const borderRadius = hasBorder ? getRadiusValue(hasRadius, radiusValue, radiusChoice) : 0;
 
     return (
         <div key={sandpackTemplate} data-test-id="ui-pattern-block" className="ui-pattern-block">

--- a/packages/ui-pattern-block/src/settings.ts
+++ b/packages/ui-pattern-block/src/settings.ts
@@ -26,6 +26,8 @@ import { BACKGROUND_COLOR_DEFAULT_VALUE, BORDER_COLOR_DEFAULT_VALUE } from './he
 const PADDING_CHOICE_ID = 'paddingChoice';
 const PADDING_CUSTOM_ID = 'paddingCustom';
 
+const BORDER_SETTING = getBorderSettings({ defaultColor: BORDER_COLOR_DEFAULT_VALUE, defaultValue: true });
+
 export const settings = defineSettings({
     main: [
         {
@@ -348,8 +350,8 @@ export const settings = defineSettings({
                     ],
                 },
                 getBackgroundSettings({ defaultColor: BACKGROUND_COLOR_DEFAULT_VALUE, label: 'Pattern background' }),
-                getBorderSettings({ defaultColor: BORDER_COLOR_DEFAULT_VALUE, defaultValue: true }),
-                getBorderRadiusSettings({ defaultRadius: Radius.Medium }),
+                BORDER_SETTING,
+                getBorderRadiusSettings({ defaultRadius: Radius.Medium, dependentSettingId: BORDER_SETTING.id }),
             ],
         },
     ],


### PR DESCRIPTION
Removes the border radius setting from the sidebar when the border is switched off, as well as removing border radius styles in this same instance