### PR TITLE
fix(PostCss): add modal like elements to css bundle

### DIFF
--- a/postcss/scope.js
+++ b/postcss/scope.js
@@ -26,7 +26,7 @@ module.exports = (opts = {}) => {
                         .map((individualSelector) =>
                             individualSelector === opts.selector
                                 ? individualSelector
-                                : `${opts.scope} ${individualSelector}`,
+                                : `${opts.scope} ${individualSelector}, body > * ${individualSelector}`,
                         )
                         .join(", "),
                 );


### PR DESCRIPTION
Portaled element classnames were not generated, e.g. anything inside Modals or RTE Toolbar classnames.