### PR TITLE
chore: update @frontify/guideline-blocks-settings@0.33.1

### DIFF
--- a/examples/asset-upload/package.json
+++ b/examples/asset-upload/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     }

--- a/examples/asset-upload/package.json
+++ b/examples/asset-upload/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     }

--- a/packages/animation-curve-block/package.json
+++ b/packages/animation-curve-block/package.json
@@ -36,7 +36,7 @@
         "@dnd-kit/sortable": "^8.0.0",
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/animation-curve-block/package.json
+++ b/packages/animation-curve-block/package.json
@@ -36,7 +36,7 @@
         "@dnd-kit/sortable": "^8.0.0",
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/animation-curve-block/src/components/Card.tsx
+++ b/packages/animation-curve-block/src/components/Card.tsx
@@ -87,24 +87,21 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(
                     shouldHideWrapper={replaceWithPlaceholder || !isEditing}
                     shouldHideComponent={replaceWithPlaceholder}
                     toolbarItems={[
+                        { type: 'dragHandle', icon: <IconArrowMove16 />, draggableProps, setActivatorNodeRef },
                         {
-                            icon: <IconArrowMove16 />,
-                            draggableProps,
-                            setActivatorNodeRef,
-                        },
-                        {
+                            type: 'button',
                             icon: <IconTrashBin16 />,
                             tooltip: 'Delete Item',
                             onClick: () => onDelete(animationCurve.id),
                         },
                         {
+                            type: 'button',
                             icon: <IconDotsHorizontal16 />,
                             tooltip: 'Edit Item',
                             onClick: () => setIsEditFlyoutOpen(true),
                         },
                     ]}
                     shouldBeShown={isEditFlyoutOpen || isDragging}
-                    toolbarFlyoutItems={[]}
                 >
                     <div
                         data-test-id="animation-curve-card"

--- a/packages/asset-kit-block/package.json
+++ b/packages/asset-kit-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/asset-kit-block/package.json
+++ b/packages/asset-kit-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/asset-kit-block/src/components/ThumbnailItem.tsx
+++ b/packages/asset-kit-block/src/components/ThumbnailItem.tsx
@@ -53,22 +53,30 @@ export const ThumbnailItem = ({
     return (
         <BlockItemWrapper
             shouldHideWrapper={!isEditing}
-            toolbarFlyoutItems={[
-                [
-                    {
-                        title: 'Replace with upload',
-                        icon: <IconArrowCircleUp20 />,
-                        onClick: openFileDialog,
-                    },
-                    {
-                        title: 'Replace with asset',
-                        icon: <IconImageStack20 />,
-                        onClick: onOpenAssetChooser,
-                    },
-                ],
-            ]}
             toolbarItems={[
-                { icon: <IconTrashBin16 />, tooltip: 'Delete Item', onClick: () => onRemoveAsset(asset.id) },
+                {
+                    type: 'button',
+                    icon: <IconTrashBin16 />,
+                    tooltip: 'Delete Item',
+                    onClick: () => onRemoveAsset(asset.id),
+                },
+                {
+                    type: 'menu',
+                    items: [
+                        [
+                            {
+                                title: 'Replace with upload',
+                                icon: <IconArrowCircleUp20 />,
+                                onClick: openFileDialog,
+                            },
+                            {
+                                title: 'Replace with asset',
+                                icon: <IconImageStack20 />,
+                                onClick: onOpenAssetChooser,
+                            },
+                        ],
+                    ],
+                },
             ]}
         >
             <div data-test-id="block-thumbnail" className="tw-aspect-square">

--- a/packages/audio-block/package.json
+++ b/packages/audio-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/audio-block/package.json
+++ b/packages/audio-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/audio-block/src/components/AudioPlayer.tsx
+++ b/packages/audio-block/src/components/AudioPlayer.tsx
@@ -32,20 +32,25 @@ export const AudioPlayer = ({
         <BlockItemWrapper
             shouldHideWrapper={!isEditing}
             showAttachments
-            toolbarItems={[{ icon: <IconTrashBin16 />, tooltip: 'Delete item', onClick: onRemoveAsset }]}
-            toolbarFlyoutItems={[
-                [
-                    {
-                        title: 'Replace with upload',
-                        icon: <IconArrowCircleUp20 />,
-                        onClick: openFileDialog,
-                    },
-                    {
-                        title: 'Replace with asset',
-                        icon: <IconImageStack20 />,
-                        onClick: openAssetChooser,
-                    },
-                ],
+            toolbarItems={[
+                { type: 'button', icon: <IconTrashBin16 />, tooltip: 'Delete item', onClick: onRemoveAsset },
+                {
+                    type: 'menu',
+                    items: [
+                        [
+                            {
+                                title: 'Replace with upload',
+                                icon: <IconArrowCircleUp20 />,
+                                onClick: openFileDialog,
+                            },
+                            {
+                                title: 'Replace with asset',
+                                icon: <IconImageStack20 />,
+                                onClick: openAssetChooser,
+                            },
+                        ],
+                    ],
+                },
             ]}
         >
             {isLoading ? (

--- a/packages/brand-positioning-block/package.json
+++ b/packages/brand-positioning-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/brand-positioning-block/package.json
+++ b/packages/brand-positioning-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/callout-block/package.json
+++ b/packages/callout-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/callout-block/package.json
+++ b/packages/callout-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/checklist-block/package.json
+++ b/packages/checklist-block/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/checkbox": "^3.10.0",
         "@react-aria/focus": "^3.14.0",

--- a/packages/checklist-block/package.json
+++ b/packages/checklist-block/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/checkbox": "^3.10.0",
         "@react-aria/focus": "^3.14.0",

--- a/packages/code-snippet-block/package.json
+++ b/packages/code-snippet-block/package.json
@@ -37,7 +37,7 @@
         "@codemirror/view": "^6.17.0",
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@uiw/codemirror-extensions-langs": "^4.21.12",
         "@uiw/codemirror-themes-all": "^4.21.12",

--- a/packages/code-snippet-block/package.json
+++ b/packages/code-snippet-block/package.json
@@ -37,7 +37,7 @@
         "@codemirror/view": "^6.17.0",
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@uiw/codemirror-extensions-langs": "^4.21.12",
         "@uiw/codemirror-themes-all": "^4.21.12",

--- a/packages/color-block/package.json
+++ b/packages/color-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dnd": "^16.0.1",

--- a/packages/color-block/package.json
+++ b/packages/color-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dnd": "^16.0.1",

--- a/packages/color-kit-block/package.json
+++ b/packages/color-kit-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/color-kit-block/package.json
+++ b/packages/color-kit-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/color-scale-block/package.json
+++ b/packages/color-scale-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dnd": "^16.0.1",

--- a/packages/color-scale-block/package.json
+++ b/packages/color-scale-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dnd": "^16.0.1",

--- a/packages/compare-slider-block/package.json
+++ b/packages/compare-slider-block/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-compare-slider": "^2.2.0",

--- a/packages/compare-slider-block/package.json
+++ b/packages/compare-slider-block/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-compare-slider": "^2.2.0",

--- a/packages/compare-slider-block/src/components/EditorOverlay/EditorOverlay.tsx
+++ b/packages/compare-slider-block/src/components/EditorOverlay/EditorOverlay.tsx
@@ -28,24 +28,28 @@ export const EditorOverlay = ({
                     outlineOffset={1}
                     toolbarItems={[
                         {
+                            type: 'button',
                             icon: <IconTrashBin16 />,
                             onClick: () => handleAssetDelete('firstAsset', firstAsset[0].id),
                             tooltip: 'Remove asset',
                         },
-                    ]}
-                    toolbarFlyoutItems={[
-                        [
-                            {
-                                title: 'Replace with upload',
-                                icon: <IconArrowCircleUp20 />,
-                                onClick: () => startFileDialogUpload(SliderImageSlot.First),
-                            },
-                            {
-                                title: 'Replace with asset',
-                                icon: <IconImageStack20 />,
-                                onClick: () => openAssetChooser(SliderImageSlot.First),
-                            },
-                        ],
+                        {
+                            type: 'menu',
+                            items: [
+                                [
+                                    {
+                                        title: 'Replace with upload',
+                                        icon: <IconArrowCircleUp20 />,
+                                        onClick: () => startFileDialogUpload(SliderImageSlot.First),
+                                    },
+                                    {
+                                        title: 'Replace with asset',
+                                        icon: <IconImageStack20 />,
+                                        onClick: () => openAssetChooser(SliderImageSlot.First),
+                                    },
+                                ],
+                            ],
+                        },
                     ]}
                 >
                     <div className="tw-w-full tw-h-full tw-pointer-events-none" />
@@ -65,24 +69,28 @@ export const EditorOverlay = ({
                     outlineOffset={1}
                     toolbarItems={[
                         {
+                            type: 'button',
                             icon: <IconTrashBin16 />,
                             onClick: () => handleAssetDelete('secondAsset', secondAsset[0].id),
                             tooltip: 'Remove asset',
                         },
-                    ]}
-                    toolbarFlyoutItems={[
-                        [
-                            {
-                                title: 'Replace with upload',
-                                icon: <IconArrowCircleUp20 />,
-                                onClick: () => startFileDialogUpload(SliderImageSlot.Second),
-                            },
-                            {
-                                title: 'Replace with asset',
-                                icon: <IconImageStack20 />,
-                                onClick: () => openAssetChooser(SliderImageSlot.Second),
-                            },
-                        ],
+                        {
+                            type: 'menu',
+                            items: [
+                                [
+                                    {
+                                        title: 'Replace with upload',
+                                        icon: <IconArrowCircleUp20 />,
+                                        onClick: () => startFileDialogUpload(SliderImageSlot.Second),
+                                    },
+                                    {
+                                        title: 'Replace with asset',
+                                        icon: <IconImageStack20 />,
+                                        onClick: () => openAssetChooser(SliderImageSlot.Second),
+                                    },
+                                ],
+                            ],
+                        },
                     ]}
                 >
                     <div className="tw-w-full tw-h-full" />

--- a/packages/divider-block/package.json
+++ b/packages/divider-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/divider-block/package.json
+++ b/packages/divider-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/dos-donts-block/package.json
+++ b/packages/dos-donts-block/package.json
@@ -36,7 +36,7 @@
         "@dnd-kit/sortable": "^8.0.0",
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "autosize": "^6.0.0",
         "react": "^18.2.0",

--- a/packages/dos-donts-block/package.json
+++ b/packages/dos-donts-block/package.json
@@ -36,7 +36,7 @@
         "@dnd-kit/sortable": "^8.0.0",
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "autosize": "^6.0.0",
         "react": "^18.2.0",

--- a/packages/dos-donts-block/src/DoDontItem.tsx
+++ b/packages/dos-donts-block/src/DoDontItem.tsx
@@ -184,43 +184,46 @@ export const DoDontItem = React.forwardRef<HTMLDivElement, DoDontItemProps>(
                     shouldHideComponent={replaceWithPlaceholder}
                     shouldBeShown={isDragging}
                     toolbarItems={[
+                        { type: 'dragHandle', icon: <IconArrowMove16 />, draggableProps, setActivatorNodeRef },
+                        { type: 'button', icon: <IconTrashBin16 />, tooltip: 'Delete Item', onClick: onRemoveSelf },
                         {
-                            icon: <IconArrowMove16 />,
-                            draggableProps,
-                            setActivatorNodeRef,
+                            type: 'menu',
+                            items: [
+                                [
+                                    ...(!!linkedImage
+                                        ? [
+                                              {
+                                                  title: 'Replace with upload',
+                                                  icon: <IconArrowCircleUp20 />,
+                                                  onClick: onUploadClick,
+                                              },
+                                              {
+                                                  title: 'Replace with asset',
+                                                  icon: <IconImageStack20 />,
+                                                  onClick: onOpenAssetChooser,
+                                              },
+                                          ]
+                                        : []),
+                                    {
+                                        title: type === DoDontType.Do ? 'Change to "don\'t"' : 'Change to "do"',
+                                        icon: <IconArrowSwap20 />,
+                                        onClick: () =>
+                                            onChangeItem(
+                                                id,
+                                                type === DoDontType.Do ? DoDontType.Dont : DoDontType.Do,
+                                                'type'
+                                            ),
+                                    },
+                                ],
+                                [
+                                    {
+                                        title: 'Delete',
+                                        icon: <IconTrashBin20 />,
+                                        onClick: onRemoveSelf,
+                                    },
+                                ],
+                            ],
                         },
-                        { icon: <IconTrashBin16 />, tooltip: 'Delete Item', onClick: onRemoveSelf },
-                    ]}
-                    toolbarFlyoutItems={[
-                        [
-                            ...(!!linkedImage
-                                ? [
-                                      {
-                                          title: 'Replace with upload',
-                                          icon: <IconArrowCircleUp20 />,
-                                          onClick: onUploadClick,
-                                      },
-                                      {
-                                          title: 'Replace with asset',
-                                          icon: <IconImageStack20 />,
-                                          onClick: onOpenAssetChooser,
-                                      },
-                                  ]
-                                : []),
-                            {
-                                title: type === DoDontType.Do ? 'Change to "don\'t"' : 'Change to "do"',
-                                icon: <IconArrowSwap20 />,
-                                onClick: () =>
-                                    onChangeItem(id, type === DoDontType.Do ? DoDontType.Dont : DoDontType.Do, 'type'),
-                            },
-                        ],
-                        [
-                            {
-                                title: 'Delete',
-                                icon: <IconTrashBin20 />,
-                                onClick: onRemoveSelf,
-                            },
-                        ],
                     ]}
                 >
                     {mode === BlockMode.TEXT_AND_IMAGE && (

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/figma-block/package.json
+++ b/packages/figma-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/figma-block/package.json
+++ b/packages/figma-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/glyphs-block/package.json
+++ b/packages/glyphs-block/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/glyphs-block/package.json
+++ b/packages/glyphs-block/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/gradient-block/package.json
+++ b/packages/gradient-block/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/gradient-block/package.json
+++ b/packages/gradient-block/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/image-block/package.json
+++ b/packages/image-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/focus": "^3.14.0",
         "react": "^18.2.0",

--- a/packages/image-block/package.json
+++ b/packages/image-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/focus": "^3.14.0",
         "react": "^18.2.0",

--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -124,38 +124,42 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
                             shouldHideWrapper={!isEditing}
                             shouldBeShown={showAltTextMenu}
                             showAttachments
-                            toolbarFlyoutItems={[
-                                image
-                                    ? [
-                                          {
-                                              title: 'Set alt text',
-                                              onClick: () => setShowAltTextMenu(true),
-                                              icon: <IconSpeechBubbleQuote20 />,
-                                          },
-                                      ]
-                                    : [],
-                                [
-                                    {
-                                        title: 'Replace with upload',
-                                        icon: <IconArrowCircleUp20 />,
-                                        onClick: openFileDialog,
-                                    },
-                                    {
-                                        title: 'Replace with asset',
-                                        icon: <IconImageStack20 />,
-                                        onClick: onOpenAssetChooser,
-                                    },
-                                ],
-                                [
-                                    {
-                                        title: 'Delete',
-                                        icon: <IconTrashBin20 />,
-                                        style: MenuItemStyle.Danger,
-                                        onClick: onRemoveAsset,
-                                    },
-                                ],
+                            toolbarItems={[
+                                {
+                                    type: 'menu',
+                                    items: [
+                                        image
+                                            ? [
+                                                  {
+                                                      title: 'Set alt text',
+                                                      onClick: () => setShowAltTextMenu(true),
+                                                      icon: <IconSpeechBubbleQuote20 />,
+                                                  },
+                                              ]
+                                            : [],
+                                        [
+                                            {
+                                                title: 'Replace with upload',
+                                                icon: <IconArrowCircleUp20 />,
+                                                onClick: openFileDialog,
+                                            },
+                                            {
+                                                title: 'Replace with asset',
+                                                icon: <IconImageStack20 />,
+                                                onClick: onOpenAssetChooser,
+                                            },
+                                        ],
+                                        [
+                                            {
+                                                title: 'Delete',
+                                                icon: <IconTrashBin20 />,
+                                                style: MenuItemStyle.Danger,
+                                                onClick: onRemoveAsset,
+                                            },
+                                        ],
+                                    ],
+                                },
                             ]}
-                            toolbarItems={[]}
                         >
                             {isLoading ? (
                                 <div className="tw-flex tw-items-center tw-justify-center tw-h-64">

--- a/packages/personal-note-block/package.json
+++ b/packages/personal-note-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "dayjs": "^1.11.6",
         "react": "^18.2.0",

--- a/packages/personal-note-block/package.json
+++ b/packages/personal-note-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "dayjs": "^1.11.6",
         "react": "^18.2.0",

--- a/packages/quote-block/package.json
+++ b/packages/quote-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/quote-block/package.json
+++ b/packages/quote-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -44,6 +44,7 @@
         "@codemirror/lang-css": "^6.2.1",
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
+        "@frontify/guideline-blocks-settings": "0.33.0",
         "@uiw/react-codemirror": "^4.21.12"
     },
     "peerDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -44,7 +44,7 @@
         "@codemirror/lang-css": "^6.2.1",
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "0.33.0",
+        "@frontify/guideline-blocks-settings": "0.33.1",
         "@uiw/react-codemirror": "^4.21.12"
     },
     "peerDependencies": {

--- a/packages/sketchfab-block/package.json
+++ b/packages/sketchfab-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/sketchfab-block/package.json
+++ b/packages/sketchfab-block/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/storybook-block/package.json
+++ b/packages/storybook-block/package.json
@@ -32,7 +32,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/interactions": "^3.17.0",
         "react": "^18.2.0",

--- a/packages/storybook-block/package.json
+++ b/packages/storybook-block/package.json
@@ -32,7 +32,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@react-aria/interactions": "^3.17.0",
         "react": "^18.2.0",

--- a/packages/template-block/package.json
+++ b/packages/template-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/template-block/package.json
+++ b/packages/template-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/packages/template-block/src/components/PreviewImage.tsx
+++ b/packages/template-block/src/components/PreviewImage.tsx
@@ -3,7 +3,7 @@
 import { useBlockAssets, useEditorState } from '@frontify/app-bridge';
 import { PreviewType, previewDisplayValues, previewImageAnchoringValues } from '../types';
 import { IconArrowSync, IconSpeechBubbleQuote20, IconTrashBin, MenuItemStyle, merge } from '@frontify/fondue';
-import { BlockItemWrapper, FlyoutToolbarItem } from '@frontify/guideline-blocks-settings';
+import { BlockItemWrapper, MenuToolbarItem } from '@frontify/guideline-blocks-settings';
 import { EditAltTextFlyout } from '@frontify/guideline-blocks-shared';
 import { useEffect, useMemo, useState } from 'react';
 import { PreviewImageProps } from './types';
@@ -47,7 +47,7 @@ export const PreviewImage = ({
     };
 
     const getItemWrapperMenu = () => {
-        const menuItems: FlyoutToolbarItem[] = [
+        const menuItems: MenuToolbarItem['items'][0] = [
             {
                 title: 'Set alt text',
                 onClick: () => setShowAltTextMenu(true),
@@ -101,8 +101,7 @@ export const PreviewImage = ({
                 <div className="tw-absolute tw-top-5 tw-right-0 tw-flex tw-justify-end tw-pt-3 tw-mx-3">
                     <BlockItemWrapper
                         shouldBeShown={isHovered || showAltTextMenu}
-                        toolbarItems={[]}
-                        toolbarFlyoutItems={getItemWrapperMenu()}
+                        toolbarItems={[{ type: 'menu', items: getItemWrapperMenu() }]}
                     >
                         <EditAltTextFlyout
                             setShowAltTextMenu={setShowAltTextMenu}

--- a/packages/template-block/src/components/PreviewImage.tsx
+++ b/packages/template-block/src/components/PreviewImage.tsx
@@ -3,7 +3,7 @@
 import { useBlockAssets, useEditorState } from '@frontify/app-bridge';
 import { PreviewType, previewDisplayValues, previewImageAnchoringValues } from '../types';
 import { IconArrowSync, IconSpeechBubbleQuote20, IconTrashBin, MenuItemStyle, merge } from '@frontify/fondue';
-import { BlockItemWrapper, MenuToolbarItem } from '@frontify/guideline-blocks-settings';
+import { BlockItemWrapper, ToolbarFlyoutMenuItem } from '@frontify/guideline-blocks-settings';
 import { EditAltTextFlyout } from '@frontify/guideline-blocks-shared';
 import { useEffect, useMemo, useState } from 'react';
 import { PreviewImageProps } from './types';
@@ -47,7 +47,7 @@ export const PreviewImage = ({
     };
 
     const getItemWrapperMenu = () => {
-        const menuItems: MenuToolbarItem['items'][0] = [
+        const menuItems: ToolbarFlyoutMenuItem[] = [
             {
                 title: 'Set alt text',
                 onClick: () => setShowAltTextMenu(true),

--- a/packages/text-block/package.json
+++ b/packages/text-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "lodash-es": "^4.17.21",
         "react": "^18.2.0",

--- a/packages/text-block/package.json
+++ b/packages/text-block/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "lodash-es": "^4.17.21",
         "react": "^18.2.0",

--- a/packages/thumbnail-grid-block/package.json
+++ b/packages/thumbnail-grid-block/package.json
@@ -39,7 +39,7 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "lodash-es": "^4.17.21",
         "react": "^18.2.0",

--- a/packages/thumbnail-grid-block/package.json
+++ b/packages/thumbnail-grid-block/package.json
@@ -39,7 +39,7 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "lodash-es": "^4.17.21",
         "react": "^18.2.0",

--- a/packages/thumbnail-grid-block/src/components/Thumbnail/Item.tsx
+++ b/packages/thumbnail-grid-block/src/components/Thumbnail/Item.tsx
@@ -98,32 +98,10 @@ export const Item = forwardRef<HTMLDivElement, ThumbnailItemProps>(
                     shouldHideWrapper={replaceWithPlaceholder || !isEditing}
                     shouldHideComponent={replaceWithPlaceholder}
                     shouldBeShown={showAltTextMenu || isDragging}
-                    toolbarFlyoutItems={[
-                        image
-                            ? [
-                                  {
-                                      title: 'Set alt text',
-                                      onClick: () => setShowAltTextMenu(true),
-                                      icon: <IconSpeechBubbleQuote20 />,
-                                  },
-                              ]
-                            : [],
-                        [
-                            {
-                                title: image ? 'Replace with upload' : 'Upload asset',
-                                icon: <IconArrowCircleUp20 />,
-                                onClick: openFileDialog,
-                            },
-                            {
-                                title: image ? 'Replace with asset' : 'Browse asset',
-                                icon: <IconImageStack20 />,
-                                onClick: onOpenAssetChooser,
-                            },
-                        ],
-                    ].filter((item) => item.length > 0)}
                     toolbarItems={[
                         showGrabHandle
                             ? {
+                                  type: 'dragHandle',
                                   icon: <IconArrowMove16 />,
                                   draggableProps,
                                   setActivatorNodeRef,
@@ -131,11 +109,38 @@ export const Item = forwardRef<HTMLDivElement, ThumbnailItemProps>(
                             : undefined,
                         showDeleteButton
                             ? {
+                                  type: 'button',
                                   icon: <IconTrashBin16 />,
                                   tooltip: 'Delete Item',
                                   onClick: () => onRemoveItem(id),
                               }
                             : undefined,
+                        {
+                            type: 'menu',
+                            items: [
+                                image
+                                    ? [
+                                          {
+                                              title: 'Set alt text',
+                                              onClick: () => setShowAltTextMenu(true),
+                                              icon: <IconSpeechBubbleQuote20 />,
+                                          },
+                                      ]
+                                    : [],
+                                [
+                                    {
+                                        title: image ? 'Replace with upload' : 'Upload asset',
+                                        icon: <IconArrowCircleUp20 />,
+                                        onClick: openFileDialog,
+                                    },
+                                    {
+                                        title: image ? 'Replace with asset' : 'Browse asset',
+                                        icon: <IconImageStack20 />,
+                                        onClick: onOpenAssetChooser,
+                                    },
+                                ],
+                            ].filter((item) => item.length > 0),
+                        },
                     ]}
                 >
                     <div className={thumbnailStyles.captionPositionClassNames} data-test-id="thumbnail-item">

--- a/packages/ui-pattern-block/package.json
+++ b/packages/ui-pattern-block/package.json
@@ -37,7 +37,7 @@
         "@codesandbox/sandpack-themes": "^2.0.21",
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.32.1",
+        "@frontify/guideline-blocks-settings": "^0.33.0",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@mantine/core": "^7.1.2",
         "lodash": "^4.17.21",

--- a/packages/ui-pattern-block/package.json
+++ b/packages/ui-pattern-block/package.json
@@ -37,7 +37,7 @@
         "@codesandbox/sandpack-themes": "^2.0.21",
         "@frontify/app-bridge": "^3.3.0",
         "@frontify/fondue": "12.0.0-beta.396",
-        "@frontify/guideline-blocks-settings": "^0.33.0",
+        "@frontify/guideline-blocks-settings": "^0.33.1",
         "@frontify/guideline-blocks-shared": "workspace:*",
         "@mantine/core": "^7.1.2",
         "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       glob:
         specifier: ^10.3.4
         version: 10.3.10
@@ -80,10 +80,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -156,10 +156,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -223,10 +223,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -293,10 +293,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -363,10 +363,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -430,10 +430,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -500,10 +500,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -600,10 +600,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -679,10 +679,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -755,10 +755,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -822,10 +822,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -898,10 +898,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -965,10 +965,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1041,10 +1041,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1111,10 +1111,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1178,10 +1178,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1245,10 +1245,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1318,10 +1318,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1391,10 +1391,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1464,10 +1464,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1534,10 +1534,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1604,7 +1604,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+      '@frontify/guideline-blocks-settings':
+        specifier: 0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@uiw/react-codemirror':
         specifier: ^4.21.12
         version: 4.21.22(@babel/runtime@7.23.9)(@codemirror/autocomplete@6.12.0)(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.6)(@codemirror/state@6.4.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.24.0)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0)
@@ -1689,10 +1692,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1756,10 +1759,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1826,10 +1829,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1896,10 +1899,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1981,10 +1984,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -2063,10 +2066,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.2
-        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -3563,12 +3566,13 @@ packages:
   /@frontify/fondue-tokens@3.3.0-next.8(ts-node@10.9.2):
     resolution: {integrity: sha512-jVSWvrO2KQ0+enLksjLrvQ512j5LUgycLVzbDiwgIEhEkfne5RuJBjLOa1cWiGpzIj1458Br7cVzCykYFLeJ4g==}
     dependencies:
+      postcss: 8.4.35
       tailwindcss: 3.4.1(ts-node@10.9.2)
     transitivePeerDependencies:
       - ts-node
     dev: false
 
-  /@frontify/fondue@12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1):
+  /@frontify/fondue@12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1):
     resolution: {integrity: sha512-GoPFZPY8L9xRCYes92fFUX2knD/cxviD2AD56H3ykQfr+lsmuYgyPQ+1TEkem2PmnvwXk+GdytSU0r/7v1FX3Q==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -3638,6 +3642,7 @@ packages:
       react-textarea-autosize: 8.5.3(@types/react@18.2.56)(react@18.2.0)
       remark-gfm: 3.0.1
       remark-parse: 10.0.2
+      scheduler: 0.23.0
       slate: 0.94.1
       slate-react: 0.98.4(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       unified: 10.1.2
@@ -3662,7 +3667,6 @@ packages:
       - jotai-xstate
       - jotai-zustand
       - react-native
-      - scheduler
       - slate-history
       - slate-hyperscript
       - styled-components
@@ -3703,8 +3707,8 @@ packages:
       - terser
     dev: true
 
-  /@frontify/guideline-blocks-settings@0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1):
-    resolution: {integrity: sha512-7C1S/RWE2/77iY33S9htw0afI0HqAZhAjHqY4Gpy/Zz20zPKPmb4rDHmr0HlZlEAKuU8G//jgQbULBsZUnXSog==}
+  /@frontify/guideline-blocks-settings@0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1):
+    resolution: {integrity: sha512-Q1NZjM0RfF7Jr6fFttyjIWDY/J0IE0xQcDvPwHr2BAOijOpYo2Pqiw+FB1cNIRS9NRkso9+aWjvaSG/e5siuEA==}
     peerDependencies:
       '@frontify/app-bridge': ^3.0.0 || ^4.0.0-alpha.0
       react: ^18
@@ -3715,60 +3719,8 @@ packages:
       '@dnd-kit/modifiers': 7.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
       '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
       '@frontify/app-bridge': 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
-      '@frontify/fondue': 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
-      '@frontify/sidebar-settings': 0.9.1(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
-      '@react-aria/focus': 3.16.2(react@18.2.0)
-      '@react-stately/overlays': 3.6.5(react@18.2.0)
-      '@udecode/plate': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      slate: 0.94.1
-      slate-react: 0.98.4(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/template'
-      - '@types/hoist-non-react-statics'
-      - '@types/node'
-      - '@types/react'
-      - '@types/react-dom'
-      - '@xstate/fsm'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
-      - react-dnd
-      - react-dnd-html5-backend
-      - react-is
-      - react-native
-      - scheduler
-      - slate-history
-      - slate-hyperscript
-      - styled-components
-      - supports-color
-      - tailwindcss
-      - ts-node
-      - zustand
-    dev: false
-
-  /@frontify/guideline-blocks-settings@0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1):
-    resolution: {integrity: sha512-7C1S/RWE2/77iY33S9htw0afI0HqAZhAjHqY4Gpy/Zz20zPKPmb4rDHmr0HlZlEAKuU8G//jgQbULBsZUnXSog==}
-    peerDependencies:
-      '@frontify/app-bridge': ^3.0.0 || ^4.0.0-alpha.0
-      react: ^18
-      react-dom: ^18
-    dependencies:
-      '@ctrl/tinycolor': 4.0.3
-      '@dnd-kit/core': 6.1.0(react-dom@18.2.0)(react@18.2.0)
-      '@dnd-kit/modifiers': 7.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
-      '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
-      '@frontify/app-bridge': 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
-      '@frontify/fondue': 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
-      '@frontify/sidebar-settings': 0.9.1(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+      '@frontify/fondue': 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+      '@frontify/sidebar-settings': 0.9.2(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@react-aria/focus': 3.16.2(react@18.2.0)
       '@react-stately/overlays': 3.6.5(react@18.2.0)
       '@udecode/plate': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
@@ -3807,13 +3759,13 @@ packages:
       - zustand
     dev: false
 
-  /@frontify/sidebar-settings@0.9.1(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1):
-    resolution: {integrity: sha512-F874z4CdGCBSGWixDvrAp21iHaigLEYq29TSzvqw4D+fK7li6jh+tkHSmkRnq3O5Za8KK+HdewgxGeSoCTPYeg==}
+  /@frontify/sidebar-settings@0.9.2(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1):
+    resolution: {integrity: sha512-P4UmcjDtou88yiGc/wvYJkhIqkuDe73rd3tCQUCBVpnKm1b008JE7dGnp9tiul9Twwp4OaXjr2gEKzwctr3XPw==}
     peerDependencies:
       react: ^18
       react-dom: ^18
     dependencies:
-      '@frontify/fondue': 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+      '@frontify/fondue': 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -3834,7 +3786,6 @@ packages:
       - jotai-xstate
       - jotai-zustand
       - react-native
-      - scheduler
       - slate-history
       - slate-hyperscript
       - styled-components

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       glob:
         specifier: ^10.3.4
         version: 10.3.10
@@ -35,13 +35,13 @@ importers:
         version: 14.2.1(react-dom@18.2.0)(react@18.2.0)
       '@types/node':
         specifier: ^20.11.10
-        version: 20.11.16
+        version: 20.11.19
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       '@vitejs/plugin-react':
         specifier: ^4.2.1
         version: 4.2.1(vite@4.5.2)
@@ -50,28 +50,28 @@ importers:
         version: 13.6.4
       cypress-real-events:
         specifier: ^1.11.0
-        version: 1.11.0(cypress@13.6.4)
+        version: 1.12.0(cypress@13.6.4)
       msw:
         specifier: ^1.3.0
         version: 1.3.2(typescript@5.3.3)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       tailwindcss:
         specifier: ^3.4.1
         version: 3.4.1(ts-node@10.9.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.11.16)(typescript@5.3.3)
+        version: 10.9.2(@types/node@20.11.19)(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
       vite:
         specifier: ^4.5.2
-        version: 4.5.2(@types/node@20.11.16)
+        version: 4.5.2(@types/node@20.11.19)
       vitest:
         specifier: ^1.2.2
-        version: 1.2.2(@types/node@20.11.16)
+        version: 1.3.0(@types/node@20.11.19)
 
   examples/asset-upload:
     dependencies:
@@ -80,10 +80,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -99,19 +99,19 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../../packages/shared
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
@@ -126,7 +126,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -156,10 +156,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -178,22 +178,22 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
       cypress-real-events:
         specifier: ^1.11.0
-        version: 1.11.0(cypress@13.6.4)
+        version: 1.12.0(cypress@13.6.4)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -205,7 +205,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -223,10 +223,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -245,22 +245,22 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
       cypress-real-events:
         specifier: ^1.11.0
-        version: 1.11.0(cypress@13.6.4)
+        version: 1.12.0(cypress@13.6.4)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -272,7 +272,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -293,10 +293,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -315,22 +315,22 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
       cypress-real-events:
         specifier: ^1.11.0
-        version: 1.11.0(cypress@13.6.4)
+        version: 1.12.0(cypress@13.6.4)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -342,7 +342,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -363,10 +363,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -385,16 +385,16 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
@@ -409,7 +409,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -430,10 +430,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -452,16 +452,16 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
@@ -479,7 +479,7 @@ importers:
         version: 3.0.1
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -500,28 +500,28 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
       '@react-aria/checkbox':
         specifier: ^3.10.0
-        version: 3.13.0(react@18.2.0)
+        version: 3.14.1(react@18.2.0)
       '@react-aria/focus':
         specifier: ^3.14.0
-        version: 3.16.0(react@18.2.0)
+        version: 3.16.2(react@18.2.0)
       '@react-aria/interactions':
         specifier: ^3.17.0
-        version: 3.20.1(react@18.2.0)
+        version: 3.21.1(react@18.2.0)
       '@react-aria/utils':
         specifier: ^3.19.0
-        version: 3.23.0(react@18.2.0)
+        version: 3.23.2(react@18.2.0)
       '@react-stately/toggle':
         specifier: ^3.6.1
-        version: 3.7.0(react@18.2.0)
+        version: 3.7.2(react@18.2.0)
       dayjs:
         specifier: ^1.11.9
         version: 1.11.10
@@ -540,25 +540,25 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@react-types/shared':
         specifier: ^3.19.0
-        version: 3.22.0(react@18.2.0)
+        version: 3.22.1(react@18.2.0)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
       cypress-real-events:
         specifier: ^1.11.0
-        version: 1.11.0(cypress@13.6.4)
+        version: 1.12.0(cypress@13.6.4)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -570,7 +570,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -594,28 +594,28 @@ importers:
         version: 6.4.0
       '@codemirror/view':
         specifier: ^6.17.0
-        version: 6.23.1
+        version: 6.24.0
       '@frontify/app-bridge':
         specifier: ^3.3.0
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
       '@uiw/codemirror-extensions-langs':
         specifier: ^4.21.12
-        version: 4.21.21(@codemirror/autocomplete@6.12.0)(@codemirror/language-data@6.4.0)(@codemirror/language@6.10.1)(@codemirror/legacy-modes@6.3.3)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/javascript@1.4.13)(@lezer/lr@1.4.0)
+        version: 4.21.22(@codemirror/autocomplete@6.12.0)(@codemirror/language-data@6.4.1)(@codemirror/language@6.10.1)(@codemirror/legacy-modes@6.3.3)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/javascript@1.4.13)(@lezer/lr@1.4.0)
       '@uiw/codemirror-themes-all':
         specifier: ^4.21.12
-        version: 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+        version: 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
       '@uiw/react-codemirror':
         specifier: ^4.21.12
-        version: 4.21.21(@babel/runtime@7.23.9)(@codemirror/autocomplete@6.12.0)(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.5)(@codemirror/state@6.4.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.23.1)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0)
+        version: 4.21.22(@babel/runtime@7.23.9)(@codemirror/autocomplete@6.12.0)(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.6)(@codemirror/state@6.4.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.24.0)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -631,22 +631,22 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
       cypress-real-events:
         specifier: ^1.11.0
-        version: 1.11.0(cypress@13.6.4)
+        version: 1.12.0(cypress@13.6.4)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -658,7 +658,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -679,10 +679,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -691,7 +691,7 @@ importers:
         version: 18.2.0
       react-dnd:
         specifier: ^16.0.1
-        version: 16.0.1(@types/node@20.11.16)(@types/react@18.2.52)(react@18.2.0)
+        version: 16.0.1(@types/node@20.11.19)(@types/react@18.2.56)(react@18.2.0)
       react-dnd-html5-backend:
         specifier: ^16.0.1
         version: 16.0.1
@@ -707,22 +707,22 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
       cypress-real-events:
         specifier: ^1.11.0
-        version: 1.11.0(cypress@13.6.4)
+        version: 1.12.0(cypress@13.6.4)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -734,7 +734,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -755,10 +755,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -777,16 +777,16 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
@@ -801,7 +801,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -822,10 +822,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -834,7 +834,7 @@ importers:
         version: 18.2.0
       react-dnd:
         specifier: ^16.0.1
-        version: 16.0.1(@types/node@20.11.16)(@types/react@18.2.52)(react@18.2.0)
+        version: 16.0.1(@types/node@20.11.19)(@types/react@18.2.56)(react@18.2.0)
       react-dnd-html5-backend:
         specifier: ^16.0.1
         version: 16.0.1
@@ -853,16 +853,16 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
@@ -877,7 +877,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -898,10 +898,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -923,16 +923,16 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
@@ -947,7 +947,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -965,10 +965,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -987,16 +987,16 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
@@ -1011,7 +1011,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -1041,10 +1041,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1066,19 +1066,19 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/autosize':
         specifier: ^4.0.1
         version: 4.0.3
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
@@ -1090,7 +1090,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -1111,10 +1111,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1133,16 +1133,16 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
@@ -1157,7 +1157,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -1178,10 +1178,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1200,16 +1200,16 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
@@ -1224,7 +1224,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -1245,10 +1245,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1267,25 +1267,25 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@react-aria/interactions':
         specifier: ^3.17.0
-        version: 3.20.1(react@18.2.0)
+        version: 3.21.1(react@18.2.0)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
       cypress-real-events:
         specifier: ^1.11.0
-        version: 1.11.0(cypress@13.6.4)
+        version: 1.12.0(cypress@13.6.4)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -1297,7 +1297,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -1318,10 +1318,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1340,25 +1340,25 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@react-aria/interactions':
         specifier: ^3.17.0
-        version: 3.20.1(react@18.2.0)
+        version: 3.21.1(react@18.2.0)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
       cypress-real-events:
         specifier: ^1.11.0
-        version: 1.11.0(cypress@13.6.4)
+        version: 1.12.0(cypress@13.6.4)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -1370,7 +1370,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -1391,16 +1391,16 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
       '@react-aria/focus':
         specifier: ^3.14.0
-        version: 3.16.0(react@18.2.0)
+        version: 3.16.2(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -1416,19 +1416,19 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/lodash-es':
         specifier: ^4.17.9
         version: 4.17.12
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
@@ -1443,7 +1443,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -1464,10 +1464,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1489,16 +1489,16 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
@@ -1513,7 +1513,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -1534,10 +1534,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1556,16 +1556,16 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
@@ -1580,7 +1580,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -1598,19 +1598,16 @@ importers:
     dependencies:
       '@codemirror/lang-css':
         specifier: ^6.2.1
-        version: 6.2.1(@codemirror/view@6.23.1)
+        version: 6.2.1(@codemirror/view@6.24.0)
       '@frontify/app-bridge':
         specifier: ^3.3.0
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
-      '@frontify/guideline-blocks-settings':
-        specifier: 0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@uiw/react-codemirror':
         specifier: ^4.21.12
-        version: 4.21.21(@babel/runtime@7.23.9)(@codemirror/autocomplete@6.12.0)(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.5)(@codemirror/state@6.4.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.23.1)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0)
+        version: 4.21.22(@babel/runtime@7.23.9)(@codemirror/autocomplete@6.12.0)(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.6)(@codemirror/state@6.4.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.24.0)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@babel/core':
         specifier: ^7.23.9
@@ -1623,13 +1620,13 @@ importers:
         version: 14.2.1(react-dom@18.2.0)(react@18.2.0)
       '@types/node':
         specifier: ^20.11.10
-        version: 20.11.16
+        version: 20.11.19
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -1653,7 +1650,7 @@ importers:
         version: 1.3.2(typescript@5.3.3)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -1671,19 +1668,19 @@ importers:
         version: 3.4.1(ts-node@10.9.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.11.16)(typescript@5.3.3)
+        version: 10.9.2(@types/node@20.11.19)(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
       vite:
         specifier: ^4.5.2
-        version: 4.5.2(@types/node@20.11.16)
+        version: 4.5.2(@types/node@20.11.19)
       vite-plugin-dts:
         specifier: ^3.7.2
-        version: 3.7.2(@types/node@20.11.16)(typescript@5.3.3)(vite@4.5.2)
+        version: 3.7.2(@types/node@20.11.19)(typescript@5.3.3)(vite@4.5.2)
       vitest:
         specifier: ^1.2.2
-        version: 1.2.2(@types/node@20.11.16)
+        version: 1.3.0(@types/node@20.11.19)
 
   packages/sketchfab-block:
     dependencies:
@@ -1692,10 +1689,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1714,16 +1711,16 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
@@ -1738,7 +1735,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -1759,16 +1756,16 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
       '@react-aria/interactions':
         specifier: ^3.17.0
-        version: 3.20.1(react@18.2.0)
+        version: 3.21.1(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -1784,16 +1781,16 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
@@ -1808,7 +1805,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -1829,10 +1826,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1851,22 +1848,22 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
       cypress-real-events:
         specifier: ^1.11.0
-        version: 1.11.0(cypress@13.6.4)
+        version: 1.12.0(cypress@13.6.4)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -1878,7 +1875,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -1899,10 +1896,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1924,19 +1921,19 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/lodash-es':
         specifier: ^4.17.9
         version: 4.17.12
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
@@ -1951,7 +1948,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -1984,10 +1981,10 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -2009,25 +2006,25 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/lodash-es':
         specifier: ^4.17.9
         version: 4.17.12
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
       cypress-real-events:
         specifier: ^1.11.0
-        version: 1.11.0(cypress@13.6.4)
+        version: 1.12.0(cypress@13.6.4)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -2039,7 +2036,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -2057,7 +2054,7 @@ importers:
     dependencies:
       '@codesandbox/sandpack-react':
         specifier: ^2.9.0
-        version: 2.11.3(@lezer/common@1.2.1)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.12.1(@lezer/common@1.2.1)(react-dom@18.2.0)(react@18.2.0)
       '@codesandbox/sandpack-themes':
         specifier: ^2.0.21
         version: 2.0.21
@@ -2066,16 +2063,16 @@ importers:
         version: 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
-        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.32.2
+        version: 0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
       '@mantine/core':
         specifier: ^7.1.2
-        version: 7.5.1(@mantine/hooks@7.5.1)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
+        version: 7.5.3(@mantine/hooks@7.5.3)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -2097,7 +2094,7 @@ importers:
         version: 0.16.1(eslint@8.56.0)(prettier@3.2.5)(react@18.2.0)(typescript@5.3.3)
       '@frontify/frontify-cli':
         specifier: ^5.5.8
-        version: 5.6.0(@types/node@20.11.16)
+        version: 5.6.1(@types/node@20.11.19)
       '@types/lodash':
         specifier: ^4.14.199
         version: 4.14.202
@@ -2106,13 +2103,13 @@ importers:
         version: 4.17.12
       '@types/react':
         specifier: ^18.2.48
-        version: 18.2.52
+        version: 18.2.56
       '@types/react-dom':
         specifier: ^18.2.18
-        version: 18.2.18
+        version: 18.2.19
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.17(postcss@8.4.33)
+        version: 10.4.17(postcss@8.4.35)
       cypress:
         specifier: ^13.6.3
         version: 13.6.4
@@ -2127,7 +2124,7 @@ importers:
         version: 0.9.10(eslint@8.56.0)
       postcss:
         specifier: ^8.4.33
-        version: 8.4.33
+        version: 8.4.35
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
@@ -2215,7 +2212,7 @@ packages:
     dependencies:
       '@babel/compat-data': 7.23.5
       '@babel/helper-validator-option': 7.23.5
-      browserslist: 4.22.3
+      browserslist: 4.23.0
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -2368,7 +2365,7 @@ packages:
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
 
-  /@codemirror/autocomplete@6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1):
+  /@codemirror/autocomplete@6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1):
     resolution: {integrity: sha512-r4IjdYFthwbCQyvqnSlx0WBHRHi8nBvU+WjJxFUij81qsBfhNudf/XKKmmC2j3m0LaOYUQTf3qiEK1J8lO1sdg==}
     peerDependencies:
       '@codemirror/language': ^6.0.0
@@ -2378,7 +2375,7 @@ packages:
     dependencies:
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.24.0
       '@lezer/common': 1.2.1
     dev: false
 
@@ -2387,7 +2384,7 @@ packages:
     dependencies:
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.24.0
       '@lezer/common': 1.2.1
     dev: false
 
@@ -2409,10 +2406,10 @@ packages:
       '@lezer/cpp': 1.1.2
     dev: false
 
-  /@codemirror/lang-css@6.2.1(@codemirror/view@6.23.1):
+  /@codemirror/lang-css@6.2.1(@codemirror/view@6.24.0):
     resolution: {integrity: sha512-/UNWDNV5Viwi/1lpr/dIXJNWiwDxpw13I4pTUAsNxZdg6E0mI2kTQb0P2iHczg1Tu+H4EBgJR+hYhKiHKko7qg==}
     dependencies:
-      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.0
       '@lezer/common': 1.2.1
@@ -2424,12 +2421,12 @@ packages:
   /@codemirror/lang-html@6.4.8:
     resolution: {integrity: sha512-tE2YK7wDlb9ZpAH6mpTPiYm6rhfdQKVDa5r9IwIFlwwgvVaKsCfuKKZoJGWsmMZIf3FQAuJ5CHMPLymOtg1hXw==}
     dependencies:
-      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)
-      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.23.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)
+      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.24.0)
       '@codemirror/lang-javascript': 6.2.1
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.24.0
       '@lezer/common': 1.2.1
       '@lezer/css': 1.1.7
       '@lezer/html': 1.3.8
@@ -2445,11 +2442,11 @@ packages:
   /@codemirror/lang-javascript@6.2.1:
     resolution: {integrity: sha512-jlFOXTejVyiQCW3EQwvKH0m99bUYIw40oPmFjSX2VS78yzfe0HELZ+NEo9Yfo1MkGRpGlj3Gnu4rdxV1EnAs5A==}
     dependencies:
-      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.1
       '@codemirror/lint': 6.5.0
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.24.0
       '@lezer/common': 1.2.1
       '@lezer/javascript': 1.4.13
     dev: false
@@ -2461,10 +2458,10 @@ packages:
       '@lezer/json': 1.0.2
     dev: false
 
-  /@codemirror/lang-less@6.0.2(@codemirror/view@6.23.1):
+  /@codemirror/lang-less@6.0.2(@codemirror/view@6.24.0):
     resolution: {integrity: sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==}
     dependencies:
-      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.23.1)
+      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.24.0)
       '@codemirror/language': 6.10.1
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0
@@ -2485,11 +2482,11 @@ packages:
   /@codemirror/lang-liquid@6.2.1:
     resolution: {integrity: sha512-J1Mratcm6JLNEiX+U2OlCDTysGuwbHD76XwuL5o5bo9soJtSbz2g6RU3vGHFyS5DC8rgVmFSzi7i6oBftm7tnA==}
     dependencies:
-      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)
       '@codemirror/lang-html': 6.4.8
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.24.0
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0
       '@lezer/lr': 1.4.0
@@ -2498,11 +2495,11 @@ packages:
   /@codemirror/lang-markdown@6.2.4:
     resolution: {integrity: sha512-UghkA1vSMs8bT7RSZM6vsIocigyah2bV00eRQuZy76401UmFZdsTsbQNBGdyxRQDOLeEvF5iFwap0BM8LKyd+g==}
     dependencies:
-      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)
       '@codemirror/lang-html': 6.4.8
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.24.0
       '@lezer/common': 1.2.1
       '@lezer/markdown': 1.2.0
     dev: false
@@ -2517,10 +2514,10 @@ packages:
       '@lezer/php': 1.0.2
     dev: false
 
-  /@codemirror/lang-python@6.1.4(@codemirror/view@6.23.1):
+  /@codemirror/lang-python@6.1.4(@codemirror/view@6.24.0):
     resolution: {integrity: sha512-b6d1TDqrkCjFNvMO01SWldFiDoZ39yl3tDMC1Y5f8glA2eZpynPxJhwYVTlGFr0stizcJgrp6ojLEGH2myoZAw==}
     dependencies:
-      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.0
       '@lezer/common': 1.2.1
@@ -2536,10 +2533,10 @@ packages:
       '@lezer/rust': 1.0.2
     dev: false
 
-  /@codemirror/lang-sass@6.0.2(@codemirror/view@6.23.1):
+  /@codemirror/lang-sass@6.0.2(@codemirror/view@6.24.0):
     resolution: {integrity: sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==}
     dependencies:
-      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.23.1)
+      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.24.0)
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.0
       '@lezer/common': 1.2.1
@@ -2548,10 +2545,10 @@ packages:
       - '@codemirror/view'
     dev: false
 
-  /@codemirror/lang-sql@6.5.5(@codemirror/view@6.23.1):
+  /@codemirror/lang-sql@6.5.5(@codemirror/view@6.24.0):
     resolution: {integrity: sha512-DvOaP2RXLb2xlxJxxydTFfwyYw5YDqEFea6aAfgh9UH0kUD6J1KFZ0xPgPpw1eo/5s2w3L6uh5PVR7GM23GxkQ==}
     dependencies:
-      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.0
       '@lezer/common': 1.2.1
@@ -2581,10 +2578,10 @@ packages:
       '@lezer/lr': 1.4.0
     dev: false
 
-  /@codemirror/lang-xml@6.0.2(@codemirror/view@6.23.1):
+  /@codemirror/lang-xml@6.0.2(@codemirror/view@6.24.0):
     resolution: {integrity: sha512-JQYZjHL2LAfpiZI2/qZ/qzDuSqmGKMwyApYmEUUCTxLM4MWS7sATUEfIguZQr9Zjx/7gcdnewb039smF6nC2zw==}
     dependencies:
-      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.0
       '@lezer/common': 1.2.1
@@ -2593,10 +2590,10 @@ packages:
       - '@codemirror/view'
     dev: false
 
-  /@codemirror/lang-yaml@6.0.0(@codemirror/view@6.23.1):
+  /@codemirror/lang-yaml@6.0.0(@codemirror/view@6.24.0):
     resolution: {integrity: sha512-fVPapdX1oYr5HMC5bou1MHscGnNCvOHuhUW6C+V2gfIeIRcughvVfznV0OuUyHy0AdXoBCjOehjzFcmLRumu2Q==}
     dependencies:
-      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.0
       '@lezer/common': 1.2.1
@@ -2605,28 +2602,28 @@ packages:
       - '@codemirror/view'
     dev: false
 
-  /@codemirror/language-data@6.4.0(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-Wvup3FunHdkL782SUaA35e/cBKa/KEHKxRsrZtvcqTWDgULhrq5K44SnC5r4xYhBLuuxk9NLCAJU3desf+/2qQ==}
+  /@codemirror/language-data@6.4.1(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-NYhC3NvEMwUxSWS1sB5AePUtr5g2ASSYOZ37YixicDG8PWHslDV9mmXIX0KvmtEm50V8FT4F5i4HAsk/7i78LA==}
     dependencies:
       '@codemirror/lang-angular': 0.1.3
       '@codemirror/lang-cpp': 6.0.2
-      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.23.1)
+      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.24.0)
       '@codemirror/lang-html': 6.4.8
       '@codemirror/lang-java': 6.0.1
       '@codemirror/lang-javascript': 6.2.1
       '@codemirror/lang-json': 6.0.1
-      '@codemirror/lang-less': 6.0.2(@codemirror/view@6.23.1)
+      '@codemirror/lang-less': 6.0.2(@codemirror/view@6.24.0)
       '@codemirror/lang-liquid': 6.2.1
       '@codemirror/lang-markdown': 6.2.4
       '@codemirror/lang-php': 6.0.1
-      '@codemirror/lang-python': 6.1.4(@codemirror/view@6.23.1)
+      '@codemirror/lang-python': 6.1.4(@codemirror/view@6.24.0)
       '@codemirror/lang-rust': 6.0.1
-      '@codemirror/lang-sass': 6.0.2(@codemirror/view@6.23.1)
-      '@codemirror/lang-sql': 6.5.5(@codemirror/view@6.23.1)
+      '@codemirror/lang-sass': 6.0.2(@codemirror/view@6.24.0)
+      '@codemirror/lang-sql': 6.5.5(@codemirror/view@6.24.0)
       '@codemirror/lang-vue': 0.1.3
       '@codemirror/lang-wast': 6.0.2
-      '@codemirror/lang-xml': 6.0.2(@codemirror/view@6.23.1)
-      '@codemirror/lang-yaml': 6.0.0(@codemirror/view@6.23.1)
+      '@codemirror/lang-xml': 6.0.2(@codemirror/view@6.24.0)
+      '@codemirror/lang-yaml': 6.0.0(@codemirror/view@6.24.0)
       '@codemirror/language': 6.10.1
       '@codemirror/legacy-modes': 6.3.3
     transitivePeerDependencies:
@@ -2637,7 +2634,7 @@ packages:
     resolution: {integrity: sha512-5GrXzrhq6k+gL5fjkAwt90nYDmjlzTIJV8THnxNFtNKWotMIlzzN+CpqxqwXOECnUdOndmSeWntVrVcv5axWRQ==}
     dependencies:
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.24.0
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0
       '@lezer/lr': 1.4.0
@@ -2654,15 +2651,15 @@ packages:
     resolution: {integrity: sha512-+5YyicIaaAZKU8K43IQi8TBy6mF6giGeWAH7N96Z5LC30Wm5JMjqxOYIE9mxwMG1NbhT2mA3l9hA4uuKUM3E5g==}
     dependencies:
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.24.0
       crelt: 1.0.6
     dev: false
 
-  /@codemirror/search@6.5.5:
-    resolution: {integrity: sha512-PIEN3Ke1buPod2EHbJsoQwlbpkz30qGZKcnmH1eihq9+bPQx8gelauUwLYaY4vBOuBAuEhmpDLii4rj/uO0yMA==}
+  /@codemirror/search@6.5.6:
+    resolution: {integrity: sha512-rpMgcsh7o0GuCDUXKPvww+muLA1pDJaFrpq/CCHtpQJYz8xopu4D1hPcKRoDD0YlF8gZaqTNIRa4VRBWyhyy7Q==}
     dependencies:
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.24.0
       crelt: 1.0.6
     dev: false
 
@@ -2675,12 +2672,12 @@ packages:
     dependencies:
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.24.0
       '@lezer/highlight': 1.2.0
     dev: false
 
-  /@codemirror/view@6.23.1:
-    resolution: {integrity: sha512-J2Xnn5lFYT1ZN/5ewEoMBCmLlL71lZ3mBdb7cUEuHhX2ESoSrNEucpsDXpX22EuTGm9LOgC9v4Z0wx+Ez8QmGA==}
+  /@codemirror/view@6.24.0:
+    resolution: {integrity: sha512-zK6m5pNkdhdJl8idPP1gA4N8JKTiSsOz8U/Iw+C1ChMwyLG7+MLiNXnH/wFuAk6KeGEe33/adOiAh5jMqee03w==}
     dependencies:
       '@codemirror/state': 6.4.0
       style-mod: 4.1.0
@@ -2694,8 +2691,8 @@ packages:
       strict-event-emitter: 0.4.6
     dev: false
 
-  /@codesandbox/sandpack-client@2.11.2:
-    resolution: {integrity: sha512-TdKmmsPpTbW7NLm2PuiHM+rltDKoF09Y6kRWhkH6IrQFqp3jWaqTlY5r66KfJisRUxeqiUF6o2yL/kZR2oFcig==}
+  /@codesandbox/sandpack-client@2.12.0:
+    resolution: {integrity: sha512-p0+yGdiJx8klwGzy+6mJCs1gKJG5mrYgXQ2HIHWKhWTBtiNI+DipGvxsR+yXXVHFm4NmnJbQtrTFtZDDpf4sIA==}
     dependencies:
       '@codesandbox/nodebox': 0.1.8
       buffer: 6.0.3
@@ -2704,27 +2701,26 @@ packages:
       static-browser-server: 1.0.3
     dev: false
 
-  /@codesandbox/sandpack-react@2.11.3(@lezer/common@1.2.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-Syr/nb8bJYvlx6CoaXHlWDapVOp0ZJkXCZDWBCzKCR7Q1y7Bsx15LEuqSPzGQqJa/J8qyy/dRYlpKvPkZtOoFw==}
+  /@codesandbox/sandpack-react@2.12.1(@lezer/common@1.2.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-/xCbeO25+SHli2+VhgHw4b3QQS4bc4KQL38OBvqoRqSb5JjVsnOs+nrKG6SFNTWz8mBhbzE20K4UxhLFRXY9rw==}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18
       react-dom: ^16.8.0 || ^17 || ^18
     dependencies:
-      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)
       '@codemirror/commands': 6.3.3
-      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.23.1)
+      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.24.0)
       '@codemirror/lang-html': 6.4.8
       '@codemirror/lang-javascript': 6.2.1
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
-      '@codesandbox/sandpack-client': 2.11.2
+      '@codemirror/view': 6.24.0
+      '@codesandbox/sandpack-client': 2.12.0
       '@lezer/highlight': 1.2.0
       '@react-hook/intersection-observer': 3.1.1(react@18.2.0)
       '@stitches/core': 1.2.8
       anser: 2.1.1
       clean-set: 1.1.2
-      codesandbox-import-util-types: 2.2.3
       dequal: 2.0.3
       escape-carriage: 1.3.1
       lz-string: 1.5.0
@@ -2788,7 +2784,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       find-up: 6.3.0
       node-html-parser: 5.3.3
-      semver: 7.5.4
+      semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3370,10 +3366,6 @@ packages:
       mnemonist: 0.39.6
     dev: true
 
-  /@fastify/deepmerge@1.3.0:
-    resolution: {integrity: sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==}
-    dev: true
-
   /@fastify/error@3.4.1:
     resolution: {integrity: sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ==}
     dev: true
@@ -3381,7 +3373,13 @@ packages:
   /@fastify/fast-json-stringify-compiler@4.3.0:
     resolution: {integrity: sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==}
     dependencies:
-      fast-json-stringify: 5.11.1
+      fast-json-stringify: 5.12.0
+    dev: true
+
+  /@fastify/merge-json-schemas@0.1.1:
+    resolution: {integrity: sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==}
+    dependencies:
+      fast-deep-equal: 3.1.3
     dev: true
 
   /@floating-ui/core@1.6.0:
@@ -3390,8 +3388,8 @@ packages:
       '@floating-ui/utils': 0.2.1
     dev: false
 
-  /@floating-ui/dom@1.6.1:
-    resolution: {integrity: sha512-iA8qE43/H5iGozC3W0YSnVSW42Vh522yyM1gj+BqRwVsTNOyr231PsXDaV04yT39PsO0QL2QpbI/M0ZaLUQgRQ==}
+  /@floating-ui/dom@1.6.3:
+    resolution: {integrity: sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==}
     dependencies:
       '@floating-ui/core': 1.6.0
       '@floating-ui/utils': 0.2.1
@@ -3403,7 +3401,7 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@floating-ui/dom': 1.6.1
+      '@floating-ui/dom': 1.6.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -3414,7 +3412,7 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@floating-ui/dom': 1.6.1
+      '@floating-ui/dom': 1.6.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -3552,8 +3550,8 @@ packages:
       typescript: '>=5.0.0'
     dependencies:
       '@frontify/eslint-config-basic': 0.18.0(eslint@8.56.0)(prettier@3.2.5)
-      '@typescript-eslint/eslint-plugin': 6.20.0(@typescript-eslint/parser@6.20.0)(eslint@8.56.0)(typescript@5.3.3)
-      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.56.0)(typescript@5.3.3)
       eslint: 8.56.0
       prettier: 3.2.5
       typescript: 5.3.3
@@ -3565,13 +3563,12 @@ packages:
   /@frontify/fondue-tokens@3.3.0-next.8(ts-node@10.9.2):
     resolution: {integrity: sha512-jVSWvrO2KQ0+enLksjLrvQ512j5LUgycLVzbDiwgIEhEkfne5RuJBjLOa1cWiGpzIj1458Br7cVzCykYFLeJ4g==}
     dependencies:
-      postcss: 8.4.33
       tailwindcss: 3.4.1(ts-node@10.9.2)
     transitivePeerDependencies:
       - ts-node
     dev: false
 
-  /@frontify/fondue@12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0):
+  /@frontify/fondue@12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1):
     resolution: {integrity: sha512-GoPFZPY8L9xRCYes92fFUX2knD/cxviD2AD56H3ykQfr+lsmuYgyPQ+1TEkem2PmnvwXk+GdytSU0r/7v1FX3Q==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -3620,10 +3617,10 @@ packages:
       '@react-types/dialog': 3.4.5(react@18.2.0)
       '@react-types/shared': 3.16.0(react@18.2.0)
       '@tailwindcss/forms': 0.5.7(tailwindcss@3.4.1)
-      '@udecode/plate': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/zustood': 1.1.3(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(zustand@4.5.0)
+      '@udecode/plate': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/zustood': 1.1.3(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(zustand@4.5.1)
       '@xstate/immer': 0.3.1(immer@9.0.12)(xstate@4.28.1)
-      '@xstate/react': 1.6.3(@types/react@18.2.52)(react@18.2.0)(xstate@4.28.1)
+      '@xstate/react': 1.6.3(@types/react@18.2.56)(react@18.2.0)(xstate@4.28.1)
       date-fns: 2.30.0
       escape-html: 1.0.3
       framer-motion: 10.18.0(react-dom@18.2.0)(react@18.2.0)
@@ -3632,16 +3629,15 @@ packages:
       react: 18.2.0
       react-colorful: 5.6.1(react-dom@18.2.0)(react@18.2.0)
       react-datepicker: 4.25.0(react-dom@18.2.0)(react@18.2.0)
-      react-dnd: 16.0.1(@types/node@20.11.16)(@types/react@18.2.52)(react@18.2.0)
+      react-dnd: 16.0.1(@types/node@20.11.19)(@types/react@18.2.56)(react@18.2.0)
       react-dnd-html5-backend: 15.1.3
       react-dom: 18.2.0(react@18.2.0)
       react-fast-compare: 3.2.2
       react-is: 18.2.0
       react-popper: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0)(react@18.2.0)
-      react-textarea-autosize: 8.5.3(@types/react@18.2.52)(react@18.2.0)
+      react-textarea-autosize: 8.5.3(@types/react@18.2.56)(react@18.2.0)
       remark-gfm: 3.0.1
       remark-parse: 10.0.2
-      scheduler: 0.23.0
       slate: 0.94.1
       slate-react: 0.98.4(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       unified: 10.1.2
@@ -3666,6 +3662,7 @@ packages:
       - jotai-xstate
       - jotai-zustand
       - react-native
+      - scheduler
       - slate-history
       - slate-hyperscript
       - styled-components
@@ -3675,8 +3672,8 @@ packages:
       - zustand
     dev: false
 
-  /@frontify/frontify-cli@5.6.0(@types/node@20.11.16):
-    resolution: {integrity: sha512-PJTxpMU3g2dls6L0JK7q6HZbAgWJsL+8UQ/2WwxtyqowUC7KZ5jOTTsxVusitwJCqpnfSxUNRCgX4YpEl8M7fw==}
+  /@frontify/frontify-cli@5.6.1(@types/node@20.11.19):
+    resolution: {integrity: sha512-Q6PZDrfKJGtIOE1oreZ4nwkuh4VIy2+SNDv+wCUBLGYpRwoS1sG9qS4V4dEpmB/bxNGy205IkHPcNeF2MdUBlQ==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
@@ -3686,13 +3683,13 @@ packages:
       cac: 6.7.14
       conf: 12.0.0
       fast-glob: 3.3.2
-      fastify: 4.26.0
+      fastify: 4.26.1
       glob-to-regexp: 0.4.1
       node-fetch: 3.3.2
       open: 9.1.0
       picocolors: 1.0.0
       prompts: 2.4.2
-      vite: 4.5.2(@types/node@20.11.16)
+      vite: 4.5.2(@types/node@20.11.19)
       vite-plugin-externals: 0.6.2(vite@4.5.2)
       zod: 3.22.4
     transitivePeerDependencies:
@@ -3706,8 +3703,8 @@ packages:
       - terser
     dev: true
 
-  /@frontify/guideline-blocks-settings@0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0):
-    resolution: {integrity: sha512-Q1NZjM0RfF7Jr6fFttyjIWDY/J0IE0xQcDvPwHr2BAOijOpYo2Pqiw+FB1cNIRS9NRkso9+aWjvaSG/e5siuEA==}
+  /@frontify/guideline-blocks-settings@0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1):
+    resolution: {integrity: sha512-7C1S/RWE2/77iY33S9htw0afI0HqAZhAjHqY4Gpy/Zz20zPKPmb4rDHmr0HlZlEAKuU8G//jgQbULBsZUnXSog==}
     peerDependencies:
       '@frontify/app-bridge': ^3.0.0 || ^4.0.0-alpha.0
       react: ^18
@@ -3718,11 +3715,11 @@ packages:
       '@dnd-kit/modifiers': 7.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
       '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
       '@frontify/app-bridge': 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
-      '@frontify/fondue': 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
-      '@frontify/sidebar-settings': 0.9.2(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
-      '@react-aria/focus': 3.16.0(react@18.2.0)
-      '@react-stately/overlays': 3.6.4(react@18.2.0)
-      '@udecode/plate': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@frontify/fondue': 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+      '@frontify/sidebar-settings': 0.9.1(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+      '@react-aria/focus': 3.16.2(react@18.2.0)
+      '@react-stately/overlays': 3.6.5(react@18.2.0)
+      '@udecode/plate': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -3758,8 +3755,8 @@ packages:
       - zustand
     dev: false
 
-  /@frontify/guideline-blocks-settings@0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0):
-    resolution: {integrity: sha512-Q1NZjM0RfF7Jr6fFttyjIWDY/J0IE0xQcDvPwHr2BAOijOpYo2Pqiw+FB1cNIRS9NRkso9+aWjvaSG/e5siuEA==}
+  /@frontify/guideline-blocks-settings@0.32.2(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1):
+    resolution: {integrity: sha512-7C1S/RWE2/77iY33S9htw0afI0HqAZhAjHqY4Gpy/Zz20zPKPmb4rDHmr0HlZlEAKuU8G//jgQbULBsZUnXSog==}
     peerDependencies:
       '@frontify/app-bridge': ^3.0.0 || ^4.0.0-alpha.0
       react: ^18
@@ -3770,11 +3767,11 @@ packages:
       '@dnd-kit/modifiers': 7.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
       '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
       '@frontify/app-bridge': 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
-      '@frontify/fondue': 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
-      '@frontify/sidebar-settings': 0.9.2(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
-      '@react-aria/focus': 3.16.0(react@18.2.0)
-      '@react-stately/overlays': 3.6.4(react@18.2.0)
-      '@udecode/plate': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@frontify/fondue': 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+      '@frontify/sidebar-settings': 0.9.1(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+      '@react-aria/focus': 3.16.2(react@18.2.0)
+      '@react-stately/overlays': 3.6.5(react@18.2.0)
+      '@udecode/plate': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -3810,13 +3807,13 @@ packages:
       - zustand
     dev: false
 
-  /@frontify/sidebar-settings@0.9.2(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0):
-    resolution: {integrity: sha512-P4UmcjDtou88yiGc/wvYJkhIqkuDe73rd3tCQUCBVpnKm1b008JE7dGnp9tiul9Twwp4OaXjr2gEKzwctr3XPw==}
+  /@frontify/sidebar-settings@0.9.1(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1):
+    resolution: {integrity: sha512-F874z4CdGCBSGWixDvrAp21iHaigLEYq29TSzvqw4D+fK7li6jh+tkHSmkRnq3O5Za8KK+HdewgxGeSoCTPYeg==}
     peerDependencies:
       react: ^18
       react-dom: ^18
     dependencies:
-      '@frontify/fondue': 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+      '@frontify/fondue': 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -3837,6 +3834,7 @@ packages:
       - jotai-xstate
       - jotai-zustand
       - react-native
+      - scheduler
       - slate-history
       - slate-hyperscript
       - styled-components
@@ -3866,29 +3864,29 @@ packages:
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
     dev: true
 
-  /@internationalized/date@3.5.1:
-    resolution: {integrity: sha512-LUQIfwU9e+Fmutc/DpRTGXSdgYZLBegi4wygCWDSVmUdLTaMHsQyASDiJtREwanwKuQLq0hY76fCJ9J/9I2xOQ==}
+  /@internationalized/date@3.5.2:
+    resolution: {integrity: sha512-vo1yOMUt2hzp63IutEaTUxROdvQg1qlMRsbCvbay2AK2Gai7wIgCyK5weEX3nHkiLgo4qCXHijFNC/ILhlRpOQ==}
     dependencies:
-      '@swc/helpers': 0.5.3
+      '@swc/helpers': 0.5.6
     dev: false
 
-  /@internationalized/message@3.1.1:
-    resolution: {integrity: sha512-ZgHxf5HAPIaR0th+w0RUD62yF6vxitjlprSxmLJ1tam7FOekqRSDELMg4Cr/DdszG5YLsp5BG3FgHgqquQZbqw==}
+  /@internationalized/message@3.1.2:
+    resolution: {integrity: sha512-MHAWsZWz8jf6jFPZqpTudcCM361YMtPIRu9CXkYmKjJ/0R3pQRScV5C0zS+Qi50O5UAm8ecKhkXx6mWDDcF6/g==}
     dependencies:
-      '@swc/helpers': 0.5.3
+      '@swc/helpers': 0.5.6
       intl-messageformat: 10.5.11
     dev: false
 
-  /@internationalized/number@3.5.0:
-    resolution: {integrity: sha512-ZY1BW8HT9WKYvaubbuqXbbDdHhOUMfE2zHHFJeTppid0S+pc8HtdIxFxaYMsGjCb4UsF+MEJ4n2TfU7iHnUK8w==}
+  /@internationalized/number@3.5.1:
+    resolution: {integrity: sha512-N0fPU/nz15SwR9IbfJ5xaS9Ss/O5h1sVXMZf43vc9mxEG48ovglvvzBjF53aHlq20uoR6c+88CrIXipU/LSzwg==}
     dependencies:
-      '@swc/helpers': 0.5.3
+      '@swc/helpers': 0.5.6
     dev: false
 
-  /@internationalized/string@3.2.0:
-    resolution: {integrity: sha512-Xx3Sy3f2c9ctT+vh8c7euEaEHQZltp0euZ3Hy4UfT3E13r6lxpUS3kgKyumEjboJZSnaZv7JhqWz3D75v+IxQg==}
+  /@internationalized/string@3.2.1:
+    resolution: {integrity: sha512-vWQOvRIauvFMzOO+h7QrdsJmtN1AXAFVcaLWP9AseRN2o7iHceZ6bIXhBD4teZl8i91A3gxKnWBlGgjCwU6MFQ==}
     dependencies:
-      '@swc/helpers': 0.5.3
+      '@swc/helpers': 0.5.6
     dev: false
 
   /@isaacs/cliui@8.0.2:
@@ -3917,8 +3915,8 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.22
 
-  /@jridgewell/resolve-uri@3.1.1:
-    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
+  /@jridgewell/resolve-uri@3.1.2:
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
   /@jridgewell/set-array@1.1.2:
@@ -3931,13 +3929,13 @@ packages:
   /@jridgewell/trace-mapping@0.3.22:
     resolution: {integrity: sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==}
     dependencies:
-      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
   /@jridgewell/trace-mapping@0.3.9:
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
     dependencies:
-      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
   /@juggle/resize-observer@3.4.0:
@@ -4070,52 +4068,52 @@ packages:
       '@lezer/lr': 1.4.0
     dev: false
 
-  /@mantine/core@7.5.1(@mantine/hooks@7.5.1)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-V7apuQuRubqxTRXb1uxOM43K7tkLRzpbb1ONJ/sj8QRp/26bShkdYp7EVuSKyrQ8DQ5EGYyBBGyzBOQARh41gA==}
+  /@mantine/core@7.5.3(@mantine/hooks@7.5.3)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Wvv6DJXI+GX9mmKG5HITTh/24sCZ0RoYQHdTHh0tOfGnEy+RleyhA82UjnMsp0n2NjfCISBwbiKgfya6b2iaFw==}
     peerDependencies:
-      '@mantine/hooks': 7.5.1
+      '@mantine/hooks': 7.5.3
       react: ^18.2.0
       react-dom: ^18.2.0
     dependencies:
       '@floating-ui/react': 0.24.8(react-dom@18.2.0)(react@18.2.0)
-      '@mantine/hooks': 7.5.1(react@18.2.0)
+      '@mantine/hooks': 7.5.3(react@18.2.0)
       clsx: 2.0.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-number-format: 5.3.1(react-dom@18.2.0)(react@18.2.0)
-      react-remove-scroll: 2.5.7(@types/react@18.2.52)(react@18.2.0)
-      react-textarea-autosize: 8.5.3(@types/react@18.2.52)(react@18.2.0)
+      react-remove-scroll: 2.5.7(@types/react@18.2.56)(react@18.2.0)
+      react-textarea-autosize: 8.5.3(@types/react@18.2.56)(react@18.2.0)
       type-fest: 3.13.1
     transitivePeerDependencies:
       - '@types/react'
     dev: false
 
-  /@mantine/hooks@7.5.1(react@18.2.0):
-    resolution: {integrity: sha512-LfrEOkX8U2KbkYAU5BMA7FPbMva/TSd65c45W35wHSx3iqYMsoPN9+Ll1zc/HT0XNFp73jGet9cU7VREbAl0/A==}
+  /@mantine/hooks@7.5.3(react@18.2.0):
+    resolution: {integrity: sha512-mFI448mAs12v8FrgSVhytqlhTVrEjIfd/PqPEfwJu5YcZIq4YZdqpzJIUbANnRrFSvmoQpDb1PssdKx7Ds35hw==}
     peerDependencies:
       react: ^18.2.0
     dependencies:
       react: 18.2.0
     dev: false
 
-  /@microsoft/api-extractor-model@7.28.3(@types/node@20.11.16):
+  /@microsoft/api-extractor-model@7.28.3(@types/node@20.11.19):
     resolution: {integrity: sha512-wT/kB2oDbdZXITyDh2SQLzaWwTOFbV326fP0pUwNW00WeliARs0qjmXBWmGWardEzp2U3/axkO3Lboqun6vrig==}
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 3.62.0(@types/node@20.11.16)
+      '@rushstack/node-core-library': 3.62.0(@types/node@20.11.19)
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor@7.39.0(@types/node@20.11.16):
+  /@microsoft/api-extractor@7.39.0(@types/node@20.11.19):
     resolution: {integrity: sha512-PuXxzadgnvp+wdeZFPonssRAj/EW4Gm4s75TXzPk09h3wJ8RS3x7typf95B4vwZRrPTQBGopdUl+/vHvlPdAcg==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.28.3(@types/node@20.11.16)
+      '@microsoft/api-extractor-model': 7.28.3(@types/node@20.11.19)
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 3.62.0(@types/node@20.11.16)
+      '@rushstack/node-core-library': 3.62.0(@types/node@20.11.19)
       '@rushstack/rig-package': 0.5.1
       '@rushstack/ts-command-line': 4.17.1
       colors: 1.2.5
@@ -4194,7 +4192,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.17.0
+      fastq: 1.17.1
 
   /@open-draft/deferred-promise@2.2.0:
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
@@ -4225,7 +4223,7 @@ packages:
       '@babel/runtime': 7.23.9
     dev: false
 
-  /@radix-ui/react-arrow@1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0):
+  /@radix-ui/react-arrow@1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==}
     peerDependencies:
       '@types/react': '*'
@@ -4239,14 +4237,14 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.56
+      '@types/react-dom': 18.2.19
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-collection@1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0):
+  /@radix-ui/react-collection@1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==}
     peerDependencies:
       '@types/react': '*'
@@ -4260,17 +4258,17 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.52)(react@18.2.0)
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.56)(react@18.2.0)
+      '@types/react': 18.2.56
+      '@types/react-dom': 18.2.19
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-compose-refs@1.0.1(@types/react@18.2.52)(react@18.2.0):
+  /@radix-ui/react-compose-refs@1.0.1(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==}
     peerDependencies:
       '@types/react': '*'
@@ -4280,11 +4278,11 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.9
-      '@types/react': 18.2.52
+      '@types/react': 18.2.56
       react: 18.2.0
     dev: false
 
-  /@radix-ui/react-context@1.0.1(@types/react@18.2.52)(react@18.2.0):
+  /@radix-ui/react-context@1.0.1(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==}
     peerDependencies:
       '@types/react': '*'
@@ -4294,11 +4292,11 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.9
-      '@types/react': 18.2.52
+      '@types/react': 18.2.56
       react: 18.2.0
     dev: false
 
-  /@radix-ui/react-direction@1.0.1(@types/react@18.2.52)(react@18.2.0):
+  /@radix-ui/react-direction@1.0.1(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==}
     peerDependencies:
       '@types/react': '*'
@@ -4308,11 +4306,11 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.9
-      '@types/react': 18.2.52
+      '@types/react': 18.2.56
       react: 18.2.0
     dev: false
 
-  /@radix-ui/react-dismissable-layer@1.0.5(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0):
+  /@radix-ui/react-dismissable-layer@1.0.5(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==}
     peerDependencies:
       '@types/react': '*'
@@ -4327,17 +4325,17 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@18.2.52)(react@18.2.0)
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@18.2.56)(react@18.2.0)
+      '@types/react': 18.2.56
+      '@types/react-dom': 18.2.19
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-dropdown-menu@2.0.6(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0):
+  /@radix-ui/react-dropdown-menu@2.0.6(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-i6TuFOoWmLWq+M/eCLGd/bQ2HfAX1RJgvrBQ6AQLmzfvsLdefxbWu8G9zczcPFfcSPehz9GcpF6K9QYreFV8hA==}
     peerDependencies:
       '@types/react': '*'
@@ -4352,19 +4350,19 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-menu': 2.0.6(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-menu': 2.0.6(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@types/react': 18.2.56
+      '@types/react-dom': 18.2.19
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-focus-guards@1.0.1(@types/react@18.2.52)(react@18.2.0):
+  /@radix-ui/react-focus-guards@1.0.1(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==}
     peerDependencies:
       '@types/react': '*'
@@ -4374,11 +4372,11 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.9
-      '@types/react': 18.2.52
+      '@types/react': 18.2.56
       react: 18.2.0
     dev: false
 
-  /@radix-ui/react-focus-scope@1.0.4(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0):
+  /@radix-ui/react-focus-scope@1.0.4(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==}
     peerDependencies:
       '@types/react': '*'
@@ -4392,16 +4390,16 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@types/react': 18.2.56
+      '@types/react-dom': 18.2.19
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-id@1.0.1(@types/react@18.2.52)(react@18.2.0):
+  /@radix-ui/react-id@1.0.1(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==}
     peerDependencies:
       '@types/react': '*'
@@ -4411,12 +4409,12 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@types/react': 18.2.52
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@types/react': 18.2.56
       react: 18.2.0
     dev: false
 
-  /@radix-ui/react-menu@2.0.6(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0):
+  /@radix-ui/react-menu@2.0.6(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-BVkFLS+bUC8HcImkRKPSiVumA1VPOOEC5WBMiT+QAVsPzW1FJzI9KnqgGxVDPBcql5xXrHkD3JOVoXWEXD8SYA==}
     peerDependencies:
       '@types/react': '*'
@@ -4431,30 +4429,30 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-focus-scope': 1.0.4(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-popper': 1.1.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-portal': 1.0.4(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.0.4(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-popper': 1.1.3(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-portal': 1.0.4(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@types/react': 18.2.56
+      '@types/react-dom': 18.2.19
       aria-hidden: 1.2.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-remove-scroll: 2.5.5(@types/react@18.2.52)(react@18.2.0)
+      react-remove-scroll: 2.5.5(@types/react@18.2.56)(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-popper@1.1.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0):
+  /@radix-ui/react-popper@1.1.3(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-cKpopj/5RHZWjrbF2846jBNacjQVwkP068DfmgrNJXpvVWrOvlAmE9xSiy5OqeE+Gi8D9fP+oDhUnPqNMY8/5w==}
     peerDependencies:
       '@types/react': '*'
@@ -4469,22 +4467,22 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.9
       '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-arrow': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-use-rect': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-use-size': 1.0.1(@types/react@18.2.52)(react@18.2.0)
+      '@radix-ui/react-arrow': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-use-rect': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@18.2.56)(react@18.2.0)
       '@radix-ui/rect': 1.0.1
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@types/react': 18.2.56
+      '@types/react-dom': 18.2.19
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-portal@1.0.4(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0):
+  /@radix-ui/react-portal@1.0.4(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==}
     peerDependencies:
       '@types/react': '*'
@@ -4498,14 +4496,14 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.56
+      '@types/react-dom': 18.2.19
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-presence@1.0.1(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0):
+  /@radix-ui/react-presence@1.0.1(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==}
     peerDependencies:
       '@types/react': '*'
@@ -4519,15 +4517,15 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@types/react': 18.2.56
+      '@types/react-dom': 18.2.19
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-primitive@1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0):
+  /@radix-ui/react-primitive@1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==}
     peerDependencies:
       '@types/react': '*'
@@ -4541,14 +4539,14 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.52)(react@18.2.0)
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.56)(react@18.2.0)
+      '@types/react': 18.2.56
+      '@types/react-dom': 18.2.19
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-roving-focus@1.0.4(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0):
+  /@radix-ui/react-roving-focus@1.0.4(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==}
     peerDependencies:
       '@types/react': '*'
@@ -4563,21 +4561,21 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@types/react': 18.2.56
+      '@types/react-dom': 18.2.19
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-slot@1.0.2(@types/react@18.2.52)(react@18.2.0):
+  /@radix-ui/react-slot@1.0.2(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}
     peerDependencies:
       '@types/react': '*'
@@ -4587,12 +4585,12 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@types/react': 18.2.52
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@types/react': 18.2.56
       react: 18.2.0
     dev: false
 
-  /@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.2.52)(react@18.2.0):
+  /@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==}
     peerDependencies:
       '@types/react': '*'
@@ -4602,11 +4600,11 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.9
-      '@types/react': 18.2.52
+      '@types/react': 18.2.56
       react: 18.2.0
     dev: false
 
-  /@radix-ui/react-use-controllable-state@1.0.1(@types/react@18.2.52)(react@18.2.0):
+  /@radix-ui/react-use-controllable-state@1.0.1(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==}
     peerDependencies:
       '@types/react': '*'
@@ -4616,12 +4614,12 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@types/react': 18.2.52
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@types/react': 18.2.56
       react: 18.2.0
     dev: false
 
-  /@radix-ui/react-use-escape-keydown@1.0.3(@types/react@18.2.52)(react@18.2.0):
+  /@radix-ui/react-use-escape-keydown@1.0.3(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==}
     peerDependencies:
       '@types/react': '*'
@@ -4631,12 +4629,12 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@types/react': 18.2.52
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@types/react': 18.2.56
       react: 18.2.0
     dev: false
 
-  /@radix-ui/react-use-layout-effect@1.0.1(@types/react@18.2.52)(react@18.2.0):
+  /@radix-ui/react-use-layout-effect@1.0.1(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==}
     peerDependencies:
       '@types/react': '*'
@@ -4646,11 +4644,11 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.9
-      '@types/react': 18.2.52
+      '@types/react': 18.2.56
       react: 18.2.0
     dev: false
 
-  /@radix-ui/react-use-rect@1.0.1(@types/react@18.2.52)(react@18.2.0):
+  /@radix-ui/react-use-rect@1.0.1(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-Cq5DLuSiuYVKNU8orzJMbl15TXilTnJKUCltMVQg53BQOF1/C5toAaGrowkgksdBQ9H+SRL23g0HDmg9tvmxXw==}
     peerDependencies:
       '@types/react': '*'
@@ -4661,11 +4659,11 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/rect': 1.0.1
-      '@types/react': 18.2.52
+      '@types/react': 18.2.56
       react: 18.2.0
     dev: false
 
-  /@radix-ui/react-use-size@1.0.1(@types/react@18.2.52)(react@18.2.0):
+  /@radix-ui/react-use-size@1.0.1(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-ibay+VqrgcaI6veAojjofPATwledXiSmX+C0KrBk/xgpX9rBzPV3OsfwlhQdUOFbh+LKQorLYT+xTXW9V8yd0g==}
     peerDependencies:
       '@types/react': '*'
@@ -4675,8 +4673,8 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@types/react': 18.2.52
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.56)(react@18.2.0)
+      '@types/react': 18.2.56
       react: 18.2.0
     dev: false
 
@@ -4691,14 +4689,14 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/button': 3.9.1(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/selection': 3.17.3(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-stately/tree': 3.7.5(react@18.2.0)
+      '@react-aria/button': 3.9.3(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/selection': 3.17.5(react-dom@18.2.0)(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-stately/tree': 3.7.6(react@18.2.0)
       '@react-types/accordion': 3.0.0-alpha.13(react@18.2.0)
-      '@react-types/button': 3.9.1(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/button': 3.9.2(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       '@swc/helpers': 0.4.36
       react: 18.2.0
     transitivePeerDependencies:
@@ -4710,7 +4708,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       '@swc/helpers': 0.4.36
       aria-hidden: 1.2.3
       react: 18.2.0
@@ -4721,12 +4719,12 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/i18n': 3.10.0(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/link': 3.6.3(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-types/breadcrumbs': 3.7.2(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-aria/i18n': 3.10.2(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/link': 3.6.5(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-types/breadcrumbs': 3.7.3(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       '@swc/helpers': 0.4.36
       react: 18.2.0
     dev: false
@@ -4737,45 +4735,46 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-aria/focus': 3.16.0(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-stately/toggle': 3.7.0(react@18.2.0)
-      '@react-types/button': 3.9.1(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-aria/focus': 3.16.2(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-stately/toggle': 3.7.2(react@18.2.0)
+      '@react-types/button': 3.9.2(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-aria/button@3.9.1(react@18.2.0):
-    resolution: {integrity: sha512-nAnLMUAnwIVcRkKzS1G2IU6LZSkIWPJGu9amz/g7Y02cGUwFp3lk5bEw2LdoaXiSDJNSX8g0SZFU8FROg57jfQ==}
+  /@react-aria/button@3.9.3(react@18.2.0):
+    resolution: {integrity: sha512-ZXo2VGTxfbaTEnfeIlm5ym4vYpGAy8sGrad8Scv+EyDAJWLMKokqctfaN6YSWbqUApC3FN63IvMqASflbmnYig==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.16.0(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-stately/toggle': 3.7.0(react@18.2.0)
-      '@react-types/button': 3.9.1(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-aria/focus': 3.16.2(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-stately/toggle': 3.7.2(react@18.2.0)
+      '@react-types/button': 3.9.2(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
-  /@react-aria/checkbox@3.13.0(react@18.2.0):
-    resolution: {integrity: sha512-eylJwtADIPKJ1Y5rITNJm/8JD8sXG2nhiZBIg1ko44Szxrpu+Le53NoGtg8nlrfh9vbUrXVvuFtf2jxbPXR5Jw==}
+  /@react-aria/checkbox@3.14.1(react@18.2.0):
+    resolution: {integrity: sha512-b4rtrg5SpRSa9jBOqzJMmprJ+jDi3KyVvUh+DsvISe5Ti7gVAhMBgnca1D0xBp22w2jhk/o4gyu1bYxGLum0GA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/form': 3.0.1(react@18.2.0)
-      '@react-aria/label': 3.7.4(react@18.2.0)
-      '@react-aria/toggle': 3.10.0(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-stately/checkbox': 3.6.1(react@18.2.0)
-      '@react-stately/form': 3.0.0(react@18.2.0)
-      '@react-stately/toggle': 3.7.0(react@18.2.0)
-      '@react-types/checkbox': 3.6.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-aria/form': 3.0.3(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/label': 3.7.6(react@18.2.0)
+      '@react-aria/toggle': 3.10.2(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-stately/checkbox': 3.6.3(react@18.2.0)
+      '@react-stately/form': 3.0.1(react@18.2.0)
+      '@react-stately/toggle': 3.7.2(react@18.2.0)
+      '@react-types/checkbox': 3.7.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
@@ -4785,13 +4784,13 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-aria/label': 3.7.4(react@18.2.0)
-      '@react-aria/toggle': 3.10.0(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
+      '@react-aria/label': 3.7.6(react@18.2.0)
+      '@react-aria/toggle': 3.10.2(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
       '@react-stately/checkbox': 3.3.2(react@18.2.0)
-      '@react-stately/toggle': 3.7.0(react@18.2.0)
-      '@react-types/checkbox': 3.6.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-stately/toggle': 3.7.2(react@18.2.0)
+      '@react-types/checkbox': 3.7.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
@@ -4802,21 +4801,21 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-aria/i18n': 3.10.0(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
+      '@react-aria/i18n': 3.10.2(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
       '@react-aria/listbox': 3.7.1(react@18.2.0)
-      '@react-aria/live-announcer': 3.3.1
+      '@react-aria/live-announcer': 3.3.2
       '@react-aria/menu': 3.7.0(react-dom@18.2.0)(react@18.2.0)
       '@react-aria/overlays': 3.12.0(react-dom@18.2.0)(react@18.2.0)
       '@react-aria/selection': 3.12.0(react@18.2.0)
-      '@react-aria/textfield': 3.14.1(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-stately/collections': 3.10.4(react@18.2.0)
-      '@react-stately/combobox': 3.8.1(react@18.2.0)
-      '@react-stately/layout': 3.13.5(react@18.2.0)
-      '@react-types/button': 3.9.1(react@18.2.0)
-      '@react-types/combobox': 3.10.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-aria/textfield': 3.14.3(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-stately/collections': 3.10.5(react@18.2.0)
+      '@react-stately/combobox': 3.8.2(react@18.2.0)
+      '@react-stately/layout': 3.13.7(react@18.2.0)
+      '@react-types/button': 3.9.2(react@18.2.0)
+      '@react-types/combobox': 3.10.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -4827,12 +4826,12 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-aria/focus': 3.16.0(react@18.2.0)
+      '@react-aria/focus': 3.16.2(react@18.2.0)
       '@react-aria/overlays': 3.12.0(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-stately/overlays': 3.6.4(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-stately/overlays': 3.6.5(react@18.2.0)
       '@react-types/dialog': 3.4.5(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     transitivePeerDependencies:
       - react-dom
@@ -4843,77 +4842,77 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       '@swc/helpers': 0.4.36
       clsx: 1.2.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/focus@3.16.0(react@18.2.0):
-    resolution: {integrity: sha512-GP6EYI07E8NKQQcXHjpIocEU0vh0oi0Vcsd+/71fKS0NnTR0TUOEeil0JuuQ9ymkmPDTu51Aaaa4FxVsuN/23A==}
+  /@react-aria/focus@3.16.2(react@18.2.0):
+    resolution: {integrity: sha512-Rqo9ummmgotESfypzFjI3uh58yMpL+E+lJBbQuXkBM0u0cU2YYzu0uOrFrq3zcHk997udZvq1pGK/R+2xk9B7g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       clsx: 2.1.0
       react: 18.2.0
     dev: false
 
-  /@react-aria/form@3.0.1(react@18.2.0):
-    resolution: {integrity: sha512-6586oODMDR4/ciGRwXjpvEAg7tWGSDrXE//waK0n5e5sMuzlPOo1DHc5SpPTvz0XdJsu6VDt2rHdVWVIC9LEyw==}
+  /@react-aria/form@3.0.3(react@18.2.0):
+    resolution: {integrity: sha512-5Q2BHE4TTPDzGY2npCzpRRYshwWUb3SMUA/Cbz7QfEtBk+NYuVaq3KjvqLqgUUdyKtqLZ9Far0kIAexloOC4jw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-stately/form': 3.0.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-stately/form': 3.0.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
-  /@react-aria/grid@3.8.6(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-JlQDkdm5heG1FfRyy5KnB8b6s/hRqSI6Xt2xN2AccLX5kcbfFr2/d5KVxyf6ahfa4Gfd46alN6477ju5eTWJew==}
+  /@react-aria/grid@3.8.8(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-7Bzbya4tO0oIgqexwRb8D6ZdC0GASYq9f/pnkrqocgvG9e1SCld4zOioKbYQDvAK/NnbCgXmmdqFAcLM/iazaA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.16.0(react@18.2.0)
-      '@react-aria/i18n': 3.10.0(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/live-announcer': 3.3.1
-      '@react-aria/selection': 3.17.3(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-stately/collections': 3.10.4(react@18.2.0)
-      '@react-stately/grid': 3.8.4(react@18.2.0)
-      '@react-stately/selection': 3.14.2(react@18.2.0)
-      '@react-stately/virtualizer': 3.6.6(react@18.2.0)
-      '@react-types/checkbox': 3.6.0(react@18.2.0)
-      '@react-types/grid': 3.2.3(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-aria/focus': 3.16.2(react@18.2.0)
+      '@react-aria/i18n': 3.10.2(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/live-announcer': 3.3.2
+      '@react-aria/selection': 3.17.5(react-dom@18.2.0)(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-stately/collections': 3.10.5(react@18.2.0)
+      '@react-stately/grid': 3.8.5(react@18.2.0)
+      '@react-stately/selection': 3.14.3(react@18.2.0)
+      '@react-stately/virtualizer': 3.6.8(react@18.2.0)
+      '@react-types/checkbox': 3.7.1(react@18.2.0)
+      '@react-types/grid': 3.2.4(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@react-aria/i18n@3.10.0(react@18.2.0):
-    resolution: {integrity: sha512-sviD5Y1pLPG49HHRmVjR+5nONrp0HK219+nu9Y7cDfUhXu2EjyhMS9t/n9/VZ69hHChZ2PnHYLEE2visu9CuCg==}
+  /@react-aria/i18n@3.10.2(react@18.2.0):
+    resolution: {integrity: sha512-Z1ormoIvMOI4mEdcFLYsoJy9w/EzBdBmgfLP+S/Ah+1xwQOXpgwZxiKOhYHpWa0lf6hkKJL34N9MHJvCJ5Crvw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@internationalized/date': 3.5.1
-      '@internationalized/message': 3.1.1
-      '@internationalized/number': 3.5.0
-      '@internationalized/string': 3.2.0
-      '@react-aria/ssr': 3.9.1(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@internationalized/date': 3.5.2
+      '@internationalized/message': 3.1.2
+      '@internationalized/number': 3.5.1
+      '@internationalized/string': 3.2.1
+      '@react-aria/ssr': 3.9.2(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
@@ -4923,30 +4922,30 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-aria/interactions@3.20.1(react@18.2.0):
-    resolution: {integrity: sha512-PLNBr87+SzRhe9PvvF9qvzYeP4ofTwfKSorwmO+hjr3qoczrSXf4LRQlb27wB6hF10C7ZE/XVbUI1lj4QQrZ/g==}
+  /@react-aria/interactions@3.21.1(react@18.2.0):
+    resolution: {integrity: sha512-AlHf5SOzsShkHfV8GLLk3v9lEmYqYHURKcXWue0JdYbmquMRkUsf/+Tjl1+zHVAQ8lKqRnPYbTmc4AcZbqxltw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/ssr': 3.9.1(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-aria/ssr': 3.9.2(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
 
-  /@react-aria/label@3.7.4(react@18.2.0):
-    resolution: {integrity: sha512-3Y0yyrqpLzZdzHw+TOyzwuyx5wa2ujU5DGfKuL5GFnU9Ii4DtdwBGSYS7Yu7qadU+eQmG4OGhAgFVswbIgIwJw==}
+  /@react-aria/label@3.7.6(react@18.2.0):
+    resolution: {integrity: sha512-ap9iFS+6RUOqeW/F2JoNpERqMn1PvVIo3tTMrJ1TY1tIwyJOxdCBRgx9yjnPBnr+Ywguep+fkPNNi/m74+tXVQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
@@ -4956,25 +4955,25 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-aria/focus': 3.16.0(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-types/link': 3.5.2(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-aria/focus': 3.16.2(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-types/link': 3.5.3(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-aria/link@3.6.3(react@18.2.0):
-    resolution: {integrity: sha512-8kPWc4u/lDow3Ll0LDxeMgaxt9Y3sl8UldKLGli8tzRSltYFugNh/n+i9sCnmo4Qv9Tp9kYv+yxBK50Uk9sINw==}
+  /@react-aria/link@3.6.5(react@18.2.0):
+    resolution: {integrity: sha512-kg8CxKqkciQFzODvLAfxEs8gbqNXFZCW/ISOE2LHYKbh9pA144LVo71qO3SPeYVVzIjmZeW4vEMdZwqkNozecw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.16.0(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-types/link': 3.5.2(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-aria/focus': 3.16.2(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-types/link': 3.5.3(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
@@ -4984,22 +4983,22 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-aria/focus': 3.16.0(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/label': 3.7.4(react@18.2.0)
+      '@react-aria/focus': 3.16.2(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/label': 3.7.6(react@18.2.0)
       '@react-aria/selection': 3.12.0(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-stately/collections': 3.10.4(react@18.2.0)
-      '@react-stately/list': 3.10.2(react@18.2.0)
-      '@react-types/listbox': 3.4.6(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-stately/collections': 3.10.5(react@18.2.0)
+      '@react-stately/list': 3.10.3(react@18.2.0)
+      '@react-types/listbox': 3.4.7(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-aria/live-announcer@3.3.1:
-    resolution: {integrity: sha512-hsc77U7S16trM86d+peqJCOCQ7/smO1cybgdpOuzXyiwcHQw8RQ4GrXrS37P4Ux/44E9nMZkOwATQRT2aK8+Ew==}
+  /@react-aria/live-announcer@3.3.2:
+    resolution: {integrity: sha512-aOyPcsfyY9tLCBhuUaYCruwcd1IrYLc47Ou+J7wMzjeN9v4lsaEfiN12WFl8pDqOwfy6/7It2wmlm5hOuZY8wQ==}
     dependencies:
-      '@swc/helpers': 0.5.3
+      '@swc/helpers': 0.5.6
     dev: false
 
   /@react-aria/menu@3.7.0(react-dom@18.2.0)(react@18.2.0):
@@ -5009,17 +5008,17 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-aria/i18n': 3.10.0(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
+      '@react-aria/i18n': 3.10.2(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
       '@react-aria/overlays': 3.12.0(react-dom@18.2.0)(react@18.2.0)
       '@react-aria/selection': 3.12.0(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-stately/collections': 3.10.4(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-stately/collections': 3.10.5(react@18.2.0)
       '@react-stately/menu': 3.4.4(react@18.2.0)
-      '@react-stately/tree': 3.7.5(react@18.2.0)
-      '@react-types/button': 3.9.1(react@18.2.0)
-      '@react-types/menu': 3.9.6(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-stately/tree': 3.7.6(react@18.2.0)
+      '@react-types/button': 3.9.2(react@18.2.0)
+      '@react-types/menu': 3.9.7(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -5031,16 +5030,16 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-aria/focus': 3.16.0(react@18.2.0)
-      '@react-aria/i18n': 3.10.0(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/ssr': 3.9.1(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
+      '@react-aria/focus': 3.16.2(react@18.2.0)
+      '@react-aria/i18n': 3.10.2(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/ssr': 3.9.2(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
       '@react-aria/visually-hidden': 3.6.0(react@18.2.0)
-      '@react-stately/overlays': 3.6.4(react@18.2.0)
-      '@react-types/button': 3.9.1(react@18.2.0)
-      '@react-types/overlays': 3.8.4(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-stately/overlays': 3.6.5(react@18.2.0)
+      '@react-types/button': 3.9.2(react@18.2.0)
+      '@react-types/overlays': 3.8.5(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -5051,14 +5050,14 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-aria/focus': 3.16.0(react@18.2.0)
-      '@react-aria/i18n': 3.10.0(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/label': 3.7.4(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-stately/radio': 3.10.1(react@18.2.0)
-      '@react-types/radio': 3.7.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-aria/focus': 3.16.2(react@18.2.0)
+      '@react-aria/i18n': 3.10.2(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/label': 3.7.6(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-stately/radio': 3.10.2(react@18.2.0)
+      '@react-types/radio': 3.7.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
@@ -5069,18 +5068,18 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-aria/i18n': 3.10.0(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/label': 3.7.4(react@18.2.0)
+      '@react-aria/i18n': 3.10.2(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/label': 3.7.6(react@18.2.0)
       '@react-aria/listbox': 3.7.1(react@18.2.0)
       '@react-aria/menu': 3.7.0(react-dom@18.2.0)(react@18.2.0)
       '@react-aria/selection': 3.12.0(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
       '@react-aria/visually-hidden': 3.6.0(react@18.2.0)
-      '@react-stately/select': 3.6.1(react@18.2.0)
-      '@react-types/button': 3.9.1(react@18.2.0)
-      '@react-types/select': 3.9.1(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-stately/select': 3.6.2(react@18.2.0)
+      '@react-types/button': 3.9.2(react@18.2.0)
+      '@react-types/select': 3.9.2(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -5091,40 +5090,40 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-aria/focus': 3.16.0(react@18.2.0)
-      '@react-aria/i18n': 3.10.0(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-stately/collections': 3.10.4(react@18.2.0)
-      '@react-stately/selection': 3.14.2(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-aria/focus': 3.16.2(react@18.2.0)
+      '@react-aria/i18n': 3.10.2(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-stately/collections': 3.10.5(react@18.2.0)
+      '@react-stately/selection': 3.14.3(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-aria/selection@3.17.3(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-xl2sgeGH61ngQeE05WOWWPVpGRTPMjQEFmsAWEprArFi4Z7ihSZgpGX22l1w7uSmtXM/eN/v0W8hUYUju5iXlQ==}
+  /@react-aria/selection@3.17.5(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-gO5jBUkc7WdkiFMlWt3x9pTSuj3Yeegsxfo44qU5NPlKrnGtPRZDWrlACNgkDHu645RNNPhlyoX0C+G8mUg1xA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.16.0(react@18.2.0)
-      '@react-aria/i18n': 3.10.0(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-stately/selection': 3.14.2(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-aria/focus': 3.16.2(react@18.2.0)
+      '@react-aria/i18n': 3.10.2(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-stately/selection': 3.14.3(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@react-aria/ssr@3.9.1(react@18.2.0):
-    resolution: {integrity: sha512-NqzkLFP8ZVI4GSorS0AYljC13QW2sc8bDqJOkBvkAt3M8gbcAXJWVRGtZBCRscki9RZF+rNlnPdg0G0jYkhJcg==}
+  /@react-aria/ssr@3.9.2(react@18.2.0):
+    resolution: {integrity: sha512-0gKkgDYdnq1w+ey8KzG9l+H5Z821qh9vVjztk55rUg71vTk/Eaebeir+WtzcLLwTjw3m/asIjx8Y59y1lJZhBw==}
     engines: {node: '>= 12'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@swc/helpers': 0.5.3
+      '@swc/helpers': 0.5.6
       react: 18.2.0
 
   /@react-aria/table@3.6.0(react-dom@18.2.0)(react@18.2.0):
@@ -5134,51 +5133,51 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-aria/focus': 3.16.0(react@18.2.0)
-      '@react-aria/grid': 3.8.6(react-dom@18.2.0)(react@18.2.0)
-      '@react-aria/i18n': 3.10.0(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/live-announcer': 3.3.1
+      '@react-aria/focus': 3.16.2(react@18.2.0)
+      '@react-aria/grid': 3.8.8(react-dom@18.2.0)(react@18.2.0)
+      '@react-aria/i18n': 3.10.2(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/live-announcer': 3.3.2
       '@react-aria/selection': 3.12.0(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-stately/table': 3.11.4(react@18.2.0)
-      '@react-stately/virtualizer': 3.6.6(react@18.2.0)
-      '@react-types/checkbox': 3.6.0(react@18.2.0)
-      '@react-types/grid': 3.2.3(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@react-types/table': 3.9.2(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-stately/table': 3.11.6(react@18.2.0)
+      '@react-stately/virtualizer': 3.6.8(react@18.2.0)
+      '@react-types/checkbox': 3.7.1(react@18.2.0)
+      '@react-types/grid': 3.2.4(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@react-types/table': 3.9.3(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@react-aria/textfield@3.14.1(react@18.2.0):
-    resolution: {integrity: sha512-UMepuYtDdCgrUF4dMphNxrUm23xOmR54aZD1pbp9cJyfioVkJN35BTXZVkD0D07gHLn4RhxKIZxBortQQrLB9g==}
+  /@react-aria/textfield@3.14.3(react@18.2.0):
+    resolution: {integrity: sha512-wPSjj/mTABspYQdahg+l5YMtEQ3m5iPCTtb5g6nR1U1rzJkvS4i5Pug6PUXeLeMz2H3ToflPWGlNOqBioAFaOQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.16.0(react@18.2.0)
-      '@react-aria/form': 3.0.1(react@18.2.0)
-      '@react-aria/label': 3.7.4(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-stately/form': 3.0.0(react@18.2.0)
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@react-types/textfield': 3.9.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-aria/focus': 3.16.2(react@18.2.0)
+      '@react-aria/form': 3.0.3(react@18.2.0)
+      '@react-aria/label': 3.7.6(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-stately/form': 3.0.1(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@react-types/textfield': 3.9.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
-  /@react-aria/toggle@3.10.0(react@18.2.0):
-    resolution: {integrity: sha512-6cUf4V9TuG2J7AvXUdU/GspEPFCubUOID3mrselSe563RViy+mMZk0vUEOdyoNanDcEXl58W4dE3SGWxFn71vg==}
+  /@react-aria/toggle@3.10.2(react@18.2.0):
+    resolution: {integrity: sha512-DgitscHWgI6IFgnvp2HcMpLGX/cAn+XX9kF5RJQbRQ9NqUgruU5cEEGSOLMrEJ6zXDa2xmOiQ+kINcyNhA+JLg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/focus': 3.16.0(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-stately/toggle': 3.7.0(react@18.2.0)
-      '@react-types/checkbox': 3.6.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-aria/focus': 3.16.2(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-stately/toggle': 3.7.2(react@18.2.0)
+      '@react-types/checkbox': 3.7.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
@@ -5188,12 +5187,12 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-aria/focus': 3.16.0(react@18.2.0)
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-stately/tooltip': 3.4.6(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@react-types/tooltip': 3.4.6(react@18.2.0)
+      '@react-aria/focus': 3.16.2(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-stately/tooltip': 3.4.7(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@react-types/tooltip': 3.4.7(react@18.2.0)
       react: 18.2.0
     dev: false
 
@@ -5203,22 +5202,22 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-aria/ssr': 3.9.1(react@18.2.0)
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-aria/ssr': 3.9.2(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       clsx: 1.2.1
       react: 18.2.0
     dev: false
 
-  /@react-aria/utils@3.23.0(react@18.2.0):
-    resolution: {integrity: sha512-fJA63/VU4iQNT8WUvrmll3kvToqMurD69CcgVmbQ56V7ZbvlzFi44E7BpnoaofScYLLtFWRjVdaHsohT6O/big==}
+  /@react-aria/utils@3.23.2(react@18.2.0):
+    resolution: {integrity: sha512-yznR9jJ0GG+YJvTMZxijQwVp+ahP66DY0apZf7X+dllyN+ByEDW+yaL1ewYPIpugxVzH5P8jhnBXsIyHKN411g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/ssr': 3.9.1(react@18.2.0)
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-aria/ssr': 3.9.2(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       clsx: 2.1.0
       react: 18.2.0
 
@@ -5228,9 +5227,9 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-aria/interactions': 3.20.1(react@18.2.0)
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-aria/interactions': 3.21.1(react@18.2.0)
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       clsx: 1.2.1
       react: 18.2.0
     dev: false
@@ -5278,34 +5277,34 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/toggle': 3.7.0(react@18.2.0)
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/checkbox': 3.6.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-stately/toggle': 3.7.2(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/checkbox': 3.7.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       '@swc/helpers': 0.4.36
       react: 18.2.0
     dev: false
 
-  /@react-stately/checkbox@3.6.1(react@18.2.0):
-    resolution: {integrity: sha512-rOjFeVBy32edYwhKiHj3ZLdLeO+xZ2fnBwxnOBjcygnw4Neygm8FJH/dB1J0hdYYR349yby86ED2x0wRc84zPw==}
+  /@react-stately/checkbox@3.6.3(react@18.2.0):
+    resolution: {integrity: sha512-hWp0GXVbMI4sS2NbBjWgOnHNrRqSV4jeftP8zc5JsIYRmrWBUZitxluB34QuVPzrBO29bGsF0GTArSiQZt6BWw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/form': 3.0.0(react@18.2.0)
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/checkbox': 3.6.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-stately/form': 3.0.1(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/checkbox': 3.7.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
-  /@react-stately/collections@3.10.4(react@18.2.0):
-    resolution: {integrity: sha512-OHhCrItGt4zB2bSrgObRo0H2SC7QlkH8ReGxo+NVIWchXRLRoiWBP7S+IwleewEo5gOqDVPY3hqA9n4iiI8twg==}
+  /@react-stately/collections@3.10.5(react@18.2.0):
+    resolution: {integrity: sha512-k8Q29Nnvb7iAia1QvTanZsrWP2aqVNBy/1SlE6kLL6vDqtKZC+Esd1SDLHRmIcYIp5aTdfwIGd0NuiRQA7a81Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
@@ -5315,7 +5314,7 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
@@ -5328,83 +5327,83 @@ packages:
       '@react-stately/list': 3.5.4(react@18.2.0)
       '@react-stately/menu': 3.4.4(react@18.2.0)
       '@react-stately/select': 3.3.2(react@18.2.0)
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/combobox': 3.10.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/combobox': 3.10.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-stately/combobox@3.8.1(react@18.2.0):
-    resolution: {integrity: sha512-FaWkqTXQdWg7ptaeU4iPcqF/kxbRg2ZNUcvW/hiL/enciV5tRCsddvfNqvDvy1L30z9AUwlp9MWqzm/DhBITCw==}
+  /@react-stately/combobox@3.8.2(react@18.2.0):
+    resolution: {integrity: sha512-f+IHuFW848VoMbvTfSakn2WIh2urDxO355LrKxnisXPCkpQHpq3lvT2mJtKJwkPxjAy7xPjpV8ejgga2R6p53Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.10.4(react@18.2.0)
-      '@react-stately/form': 3.0.0(react@18.2.0)
-      '@react-stately/list': 3.10.2(react@18.2.0)
-      '@react-stately/overlays': 3.6.4(react@18.2.0)
-      '@react-stately/select': 3.6.1(react@18.2.0)
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/combobox': 3.10.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-stately/collections': 3.10.5(react@18.2.0)
+      '@react-stately/form': 3.0.1(react@18.2.0)
+      '@react-stately/list': 3.10.3(react@18.2.0)
+      '@react-stately/overlays': 3.6.5(react@18.2.0)
+      '@react-stately/select': 3.6.2(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/combobox': 3.10.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
-  /@react-stately/flags@3.0.0:
-    resolution: {integrity: sha512-e3i2ItHbIa0eEwmSXAnPdD7K8syW76JjGe8ENxwFJPW/H1Pu9RJfjkCb/Mq0WSPN/TpxBb54+I9TgrGhbCoZ9w==}
+  /@react-stately/flags@3.0.1:
+    resolution: {integrity: sha512-h5PcDMj54aipQNO18ig/IMI1kzPwcvSwVq5M6Ib6XE1WIkOH0dIuW2eADdAOhcGi3KXJtXVdD29zh0Eox1TKgQ==}
     dependencies:
       '@swc/helpers': 0.4.36
     dev: false
 
-  /@react-stately/form@3.0.0(react@18.2.0):
-    resolution: {integrity: sha512-C8wkfFmtx1escizibhdka5JvTy9/Vp173CS9cakjvWTmnjYYC1nOlzwp7BsYWTgerCFbRY/BU/Cf/bJDxPiUKQ==}
+  /@react-stately/form@3.0.1(react@18.2.0):
+    resolution: {integrity: sha512-T1Ul2Ou0uE/S4ECLcGKa0OfXjffdjEHfUFZAk7OZl0Mqq/F7dl5WpoLWJ4d4IyvZzGO6anFNenP+vODWbrF3NA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
-  /@react-stately/grid@3.8.4(react@18.2.0):
-    resolution: {integrity: sha512-rwqV1K4lVhaiaqJkt4TfYqdJoVIyqvSm98rKAYfCNzrKcivVpoiCMJ2EMt6WlYCjDVBdEOQ7fMV1I60IV0pntA==}
+  /@react-stately/grid@3.8.5(react@18.2.0):
+    resolution: {integrity: sha512-KCzi0x0p1ZKK+OptonvJqMbn6Vlgo6GfOIlgcDd0dNYDP8TJ+3QFJAFre5mCr7Fubx7LcAOio4Rij0l/R8fkXQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.10.4(react@18.2.0)
-      '@react-stately/selection': 3.14.2(react@18.2.0)
-      '@react-types/grid': 3.2.3(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-stately/collections': 3.10.5(react@18.2.0)
+      '@react-stately/selection': 3.14.3(react@18.2.0)
+      '@react-types/grid': 3.2.4(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
-  /@react-stately/layout@3.13.5(react@18.2.0):
-    resolution: {integrity: sha512-JuT7nC+1tUdn2YdJAGCMV4EtGRfwdSTixcxZTuVppDU3xJ3PtIHWJQXiEKIGcAkPe9YV2k3omWcopfXvTXy11A==}
+  /@react-stately/layout@3.13.7(react@18.2.0):
+    resolution: {integrity: sha512-9HH/aSxpEHwUW1T1vGN3+iznkAXQUzoMrsoEepNzesOsUGSm/MFZmEk4+9cdPA7y3ou2eHpGNUB1YIDDVptElg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.10.4(react@18.2.0)
-      '@react-stately/table': 3.11.4(react@18.2.0)
-      '@react-stately/virtualizer': 3.6.6(react@18.2.0)
-      '@react-types/grid': 3.2.3(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@react-types/table': 3.9.2(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-stately/collections': 3.10.5(react@18.2.0)
+      '@react-stately/table': 3.11.6(react@18.2.0)
+      '@react-stately/virtualizer': 3.6.8(react@18.2.0)
+      '@react-types/grid': 3.2.4(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@react-types/table': 3.9.3(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
-  /@react-stately/list@3.10.2(react@18.2.0):
-    resolution: {integrity: sha512-INt+zofkIg2KN8B95xPi9pJG7ZFWAm30oIm/lCPBqM3K1Nm03/QaAbiQj2QeJcOsG3lb7oqI6D6iwTolwJkjIQ==}
+  /@react-stately/list@3.10.3(react@18.2.0):
+    resolution: {integrity: sha512-Ul8el0tQy2Ucl3qMQ0fiqdJ874W1ZNjURVSgSxN+pGwVLNBVRjd6Fl7YwZFCXER2YOlzkwg+Zqozf/ZlS0EdXA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.10.4(react@18.2.0)
-      '@react-stately/selection': 3.14.2(react@18.2.0)
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-stately/collections': 3.10.5(react@18.2.0)
+      '@react-stately/selection': 3.14.3(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
@@ -5415,9 +5414,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.9
       '@react-stately/collections': 3.4.4(react@18.2.0)
-      '@react-stately/selection': 3.14.2(react@18.2.0)
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-stately/selection': 3.14.3(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
@@ -5426,10 +5425,10 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/overlays': 3.6.4(react@18.2.0)
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/menu': 3.9.6(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-stately/overlays': 3.6.5(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/menu': 3.9.7(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       '@swc/helpers': 0.4.36
       react: 18.2.0
     dev: false
@@ -5440,32 +5439,32 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/overlays': 3.8.4(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/overlays': 3.8.5(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-stately/overlays@3.6.4(react@18.2.0):
-    resolution: {integrity: sha512-tHEaoAGpE9dSnsskqLPVKum59yGteoSqsniTopodM+miQozbpPlSjdiQnzGLroy5Afx5OZYClE616muNHUILXA==}
+  /@react-stately/overlays@3.6.5(react@18.2.0):
+    resolution: {integrity: sha512-U4rCFj6TPJPXLUvYXAcvh+yP/CO2W+7f0IuqP7ZZGE+Osk9qFkT+zRK5/6ayhBDFpmueNfjIEAzT9gYPQwNHFw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/overlays': 3.8.4(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/overlays': 3.8.5(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
-  /@react-stately/radio@3.10.1(react@18.2.0):
-    resolution: {integrity: sha512-MsBYbcLCvjKsqTAKe43T681F2XwKMsS7PLG0eplZgWP9210AMY78GeY1XPYZKHPAau8XkbYiuJqbqTerIJ3DBw==}
+  /@react-stately/radio@3.10.2(react@18.2.0):
+    resolution: {integrity: sha512-JW5ZWiNMKcZvMTsuPeWJQLHXD5rlqy7Qk6fwUx/ZgeibvMBW/NnW19mm2+IMinzmbtERXvR6nsiA837qI+4dew==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/form': 3.0.0(react@18.2.0)
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/radio': 3.7.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-stately/form': 3.0.1(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/radio': 3.7.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
@@ -5475,9 +5474,9 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/radio': 3.7.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/radio': 3.7.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
@@ -5490,53 +5489,53 @@ packages:
       '@react-stately/collections': 3.4.4(react@18.2.0)
       '@react-stately/list': 3.5.4(react@18.2.0)
       '@react-stately/menu': 3.4.4(react@18.2.0)
-      '@react-stately/selection': 3.14.2(react@18.2.0)
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/select': 3.9.1(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-stately/selection': 3.14.3(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/select': 3.9.2(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-stately/select@3.6.1(react@18.2.0):
-    resolution: {integrity: sha512-e5ixtLiYLlFWM8z1msDqXWhflF9esIRfroptZsltMn1lt2iImUlDRlOTZlMtPQzUrDWoiHXRX88sSKUM/jXjQQ==}
+  /@react-stately/select@3.6.2(react@18.2.0):
+    resolution: {integrity: sha512-duOxdHKol93h6Ew6fap6Amz+zngoERKZLSKVm/8I8uaBgkoBhEeTFv7mlpHTgINxymMw3mMrvy6GL/gfKFwkqg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/form': 3.0.0(react@18.2.0)
-      '@react-stately/list': 3.10.2(react@18.2.0)
-      '@react-stately/overlays': 3.6.4(react@18.2.0)
-      '@react-types/select': 3.9.1(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-stately/form': 3.0.1(react@18.2.0)
+      '@react-stately/list': 3.10.3(react@18.2.0)
+      '@react-stately/overlays': 3.6.5(react@18.2.0)
+      '@react-types/select': 3.9.2(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
-  /@react-stately/selection@3.14.2(react@18.2.0):
-    resolution: {integrity: sha512-mL7OoiUgVWaaF7ks5XSxgbXeShijYmD4G3bkBHhqkpugU600QH6BM2hloCq8KOUupk1y8oTljPtF9EmCv375DA==}
+  /@react-stately/selection@3.14.3(react@18.2.0):
+    resolution: {integrity: sha512-d/t0rIWieqQ7wjLoMoWnuHEUSMoVXxkPBFuSlJF3F16289FiQ+b8aeKFDzFTYN7fFD8rkZTnpuE4Tcxg3TmA+w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.10.4(react@18.2.0)
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-stately/collections': 3.10.5(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
-  /@react-stately/table@3.11.4(react@18.2.0):
-    resolution: {integrity: sha512-dWINJIEOKQl4qq3moq+S8xCD3m+yJqBj0dahr+rOkS+t2uqORwzsusTM35D2T/ZHZi49S2GpE7QuDa+edCynPw==}
+  /@react-stately/table@3.11.6(react@18.2.0):
+    resolution: {integrity: sha512-34YsfOILXusj3p6QNcKEaDWVORhM6WEhwPSLCZlkwAJvkxuRQFdih5rQKoIDc0uV5aZsB6bYBqiFhnjY0VERhw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.10.4(react@18.2.0)
-      '@react-stately/flags': 3.0.0
-      '@react-stately/grid': 3.8.4(react@18.2.0)
-      '@react-stately/selection': 3.14.2(react@18.2.0)
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/grid': 3.2.3(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@react-types/table': 3.9.2(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-stately/collections': 3.10.5(react@18.2.0)
+      '@react-stately/flags': 3.0.1
+      '@react-stately/grid': 3.8.5(react@18.2.0)
+      '@react-stately/selection': 3.14.3(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/grid': 3.2.4(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@react-types/table': 3.9.3(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
@@ -5547,11 +5546,11 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.9
       '@react-stately/collections': 3.4.4(react@18.2.0)
-      '@react-stately/grid': 3.8.4(react@18.2.0)
-      '@react-stately/selection': 3.14.2(react@18.2.0)
-      '@react-types/grid': 3.2.3(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@react-types/table': 3.9.2(react@18.2.0)
+      '@react-stately/grid': 3.8.5(react@18.2.0)
+      '@react-stately/selection': 3.14.3(react@18.2.0)
+      '@react-types/grid': 3.2.4(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@react-types/table': 3.9.3(react@18.2.0)
       react: 18.2.0
     dev: false
 
@@ -5561,20 +5560,20 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/checkbox': 3.6.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/checkbox': 3.7.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-stately/toggle@3.7.0(react@18.2.0):
-    resolution: {integrity: sha512-TRksHkCJk/Xogq4181g3CYgJf+EfsJCqX5UZDSw1Z1Kgpvonjmdf6FAfQfCh9QR2OuXUL6hOLUDVLte5OPI+5g==}
+  /@react-stately/toggle@3.7.2(react@18.2.0):
+    resolution: {integrity: sha512-SHCF2btcoK57c4lyhucRbyPBAFpp0Pdp0vcPdn3hUgqbu6e5gE0CwG/mgFmZRAQoc7PRc7XifL0uNw8diJJI0Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/checkbox': 3.6.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/checkbox': 3.7.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
@@ -5584,20 +5583,20 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@react-stately/overlays': 3.6.4(react@18.2.0)
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/tooltip': 3.4.6(react@18.2.0)
+      '@react-stately/overlays': 3.4.2(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/tooltip': 3.4.7(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-stately/tooltip@3.4.6(react@18.2.0):
-    resolution: {integrity: sha512-uL93bmsXf+OOgpKLPEKfpDH4z+MK2CuqlqVxx7rshN0vjWOSoezE5nzwgee90+RpDrLNNNWTNa7n+NkDRpI1jA==}
+  /@react-stately/tooltip@3.4.7(react@18.2.0):
+    resolution: {integrity: sha512-ACtRgBQ8rphBtsUaaxvEAM0HHN9PvMuyvL0vUHd7jvBDCVZJ6it1BKu9SBKjekBkoBOw9nemtkplh9R2CA6V8Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/overlays': 3.6.4(react@18.2.0)
-      '@react-types/tooltip': 3.4.6(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-stately/overlays': 3.6.5(react@18.2.0)
+      '@react-types/tooltip': 3.4.7(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
@@ -5608,41 +5607,41 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.9
       '@react-stately/collections': 3.4.4(react@18.2.0)
-      '@react-stately/selection': 3.14.2(react@18.2.0)
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-stately/selection': 3.14.3(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-stately/tree@3.7.5(react@18.2.0):
-    resolution: {integrity: sha512-xTJVwvhAeY0N5rui4N/TxN7f8hjXdqApDuGDxMZeFAWoQz8Abf7LFKBVQ3OkT6qVr7P+23dgoisUDBhD5a45Hg==}
+  /@react-stately/tree@3.7.6(react@18.2.0):
+    resolution: {integrity: sha512-y8KvEoZX6+YvqjNCVGS3zA/BKw4D3XrUtUKIDme3gu5Mn6z97u+hUXKdXVCniZR7yvV3fHAIXwE5V2K8Oit4aw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-stately/collections': 3.10.4(react@18.2.0)
-      '@react-stately/selection': 3.14.2(react@18.2.0)
-      '@react-stately/utils': 3.9.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-stately/collections': 3.10.5(react@18.2.0)
+      '@react-stately/selection': 3.14.3(react@18.2.0)
+      '@react-stately/utils': 3.9.1(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
-  /@react-stately/utils@3.9.0(react@18.2.0):
-    resolution: {integrity: sha512-yPKFY1F88HxuZ15BG2qwAYxtpE4HnIU0Ofi4CuBE0xC6I8mwo4OQjDzi+DZjxQngM9D6AeTTD6F1V8gkozA0Gw==}
+  /@react-stately/utils@3.9.1(react@18.2.0):
+    resolution: {integrity: sha512-yzw75GE0iUWiyps02BOAPTrybcsMIxEJlzXqtvllAb01O9uX5n0i3X+u2eCpj2UoDF4zS08Ps0jPgWxg8xEYtA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@swc/helpers': 0.5.3
+      '@swc/helpers': 0.5.6
       react: 18.2.0
 
-  /@react-stately/virtualizer@3.6.6(react@18.2.0):
-    resolution: {integrity: sha512-9hWvfITdE/028q4YFve6FxlmA3PdSMkUwpYA+vfaGCXI/4DFZIssBMspUeu4PTRJoV+k+m0z1wYHPmufrq6a3g==}
+  /@react-stately/virtualizer@3.6.8(react@18.2.0):
+    resolution: {integrity: sha512-Pf06ihTwExRJltGhi72tmLIo0pcjkL55nu7ifMafAAdxZK4ONxRLSuUjjpvYf/0Rs92xRZy2t/XmHREnfirdkQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-aria/utils': 3.23.0(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      '@swc/helpers': 0.5.3
+      '@react-aria/utils': 3.23.2(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      '@swc/helpers': 0.5.6
       react: 18.2.0
     dev: false
 
@@ -5651,44 +5650,44 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-types/breadcrumbs@3.7.2(react@18.2.0):
-    resolution: {integrity: sha512-esl6RucDW2CNMsApJxNYfMtDaUcfLlwKMPH/loYsOBbKxGl2HsgVLMcdpjEkTRs2HCTNCbBXWpeU8AY77t+bsw==}
+  /@react-types/breadcrumbs@3.7.3(react@18.2.0):
+    resolution: {integrity: sha512-eFto/+6J+JR58vThNcALZRA1OlqlG3GzQ/bq3q8IrrkOZcrfbEJJCWit/+53Ia98siJKuF4OJHnotxIVIz5I3w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/link': 3.5.2(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/link': 3.5.3(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-types/button@3.9.1(react@18.2.0):
-    resolution: {integrity: sha512-bf9iTar3PtqnyV9rA+wyFyrskZKhwmOuOd/ifYIjPs56YNVXWH5Wfqj6Dx3xdFBgtKx8mEVQxVhoX+WkHX+rtw==}
+  /@react-types/button@3.9.2(react@18.2.0):
+    resolution: {integrity: sha512-EnPTkGHZRtiwAoJy5q9lDjoG30bEzA/qnvKG29VVXKYAGeqY2IlFs1ypmU+z1X/CpJgPcG3I5cakM7yTVm3pSg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-types/checkbox@3.6.0(react@18.2.0):
-    resolution: {integrity: sha512-vgbuJzQpVCNT5AZWV0OozXCnihqrXxoZKfJFIw0xro47pT2sn3t5UC4RA9wfjDGMoK4frw1K/4HQLsQIOsPBkw==}
+  /@react-types/checkbox@3.7.1(react@18.2.0):
+    resolution: {integrity: sha512-kuGqjQFex0As/3gfWyk+e9njCcad/ZdnYLLiNvhlk15730xfa0MmnOdpqo9jfuFSXBjOcpxoofvEhvrRMtEdUA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-types/combobox@3.10.0(react@18.2.0):
-    resolution: {integrity: sha512-1IXSNS02TPbguyYopaW2snU6sZusbClHrEyVr4zPeexTV4kpUUBNXOzFQ+eSQRR0r2XW57Z0yRW4GJ6FGU0yCA==}
+  /@react-types/combobox@3.10.1(react@18.2.0):
+    resolution: {integrity: sha512-XMno1rgVRNta49vf5nV7VJpVSVAV20tt79t618gG1qRKH5Kt2Cy8lz2fQ5vHG6UTv/6jUOvU8g5Pc93sLaTmoA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
@@ -5697,72 +5696,72 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/overlays': 3.8.4(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/overlays': 3.8.5(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-types/grid@3.2.3(react@18.2.0):
-    resolution: {integrity: sha512-GQM4RDmYhstcYZ0Odjq+xUwh1fhLmRebG6qMM8OXHTPQ77nhl3wc1UTGRhZm6mzEionplSRx4GCpEMEHMJIU0w==}
+  /@react-types/grid@3.2.4(react@18.2.0):
+    resolution: {integrity: sha512-sDVoyQcH7MoGdx5nBi5ZOU/mVFBt9YTxhvr0PZ97dMdEHZtJC1w9SuezwWS34f50yb8YAXQRTICbZYcK4bAlDA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-types/link@3.5.2(react@18.2.0):
-    resolution: {integrity: sha512-/s51/WejmpLiyxOgP89s4txgxYoGaPe8pVDItVo1h4+BhU1Puyvgv/Jx8t9dPvo6LUXbraaN+SgKk/QDxaiirw==}
+  /@react-types/link@3.5.3(react@18.2.0):
+    resolution: {integrity: sha512-yVafjW3IejyVnK3oMBNjFABCGG6J27EUG8rvkaGaI1uB6srGUEhpJ97XLv11aj1QkXHBy3VGXqxEV3S7wn4HTw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-types/listbox@3.4.6(react@18.2.0):
-    resolution: {integrity: sha512-XOQvrTqNh5WIPDvKiWiep8T07RAsMfjAXTjDbnjxVlKACUXkcwpts9kFaLnJ9LJRFt6DwItfP+WMkzvmx63/NQ==}
+  /@react-types/listbox@3.4.7(react@18.2.0):
+    resolution: {integrity: sha512-68y5H9CVSPFiwO6MOFxTbry9JQMK/Lb1M9i3M8TDyq1AbJxBPpgAvJ9RaqIMCucsnqCzpY/zA3D/X417zByL1w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-types/menu@3.9.6(react@18.2.0):
-    resolution: {integrity: sha512-w/RbFInOf4nNayQDv5c2L8IMJbcFOkBhsT3xvvpTy+CHvJcQdjggwaV1sRiw7eF/PwB81k2CwigmidUzHJhKDg==}
+  /@react-types/menu@3.9.7(react@18.2.0):
+    resolution: {integrity: sha512-K6KhloJVoGsqwkdeez72fkNI9dfrmLI/sNrB4XuOKo2crDQ/eyZYWyJmzz8giz/tHME9w774k487rVoefoFh5w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/overlays': 3.8.4(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/overlays': 3.8.5(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-types/overlays@3.8.4(react@18.2.0):
-    resolution: {integrity: sha512-pfgNlQnbF6RB/R2oSxyqAP3Uzz0xE/k5q4n5gUeCDNLjY5qxFHGE8xniZZ503nZYw6VBa9XMN1efDOKQyeiO0w==}
+  /@react-types/overlays@3.8.5(react@18.2.0):
+    resolution: {integrity: sha512-4D7EEBQigD/m8hE68Ys8eloyyZFHHduqykSIgINJ0edmo0jygRbWlTwuhWFR9USgSP4dK54duN0Mvq0m4HEVEw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-types/radio@3.7.0(react@18.2.0):
-    resolution: {integrity: sha512-EcwGAXzSHjSqpFZha7xn3IUrhPiJLj+0yb1Ip0qPmhWz0VVw2DwrkY7q/jfaKroVvQhTo2TbfGhcsAQrt0fRqg==}
+  /@react-types/radio@3.7.1(react@18.2.0):
+    resolution: {integrity: sha512-Zut3rN1odIUBLZdijeyou+UqsLeRE76d9A+npykYGu29ndqmo3w4sLn8QeQcdj1IR71ZnG0pW2Y2BazhK5XrrQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-types/select@3.9.1(react@18.2.0):
-    resolution: {integrity: sha512-EpKSxrnh8HdZvOF9dHQkjivAcdIp1K81FaxmvosH8Lygqh0iYXxAdZGtKLMyBoPI8YFhA+rotIzTcOqgCCnqWA==}
+  /@react-types/select@3.9.2(react@18.2.0):
+    resolution: {integrity: sha512-fGFrunednY3Pq/BBwVOf87Fsuyo/SlevL0wFIE9OOl2V5NXVaTY7/7RYA8hIOHPzmvsMbndy419BEudiNGhv4A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
@@ -5774,43 +5773,43 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@react-types/shared@3.22.0(react@18.2.0):
-    resolution: {integrity: sha512-yVOekZWbtSmmiThGEIARbBpnmUIuePFlLyctjvCbgJgGhz8JnEJOipLQ/a4anaWfzAgzSceQP8j/K+VOOePleA==}
+  /@react-types/shared@3.22.1(react@18.2.0):
+    resolution: {integrity: sha512-PCpa+Vo6BKnRMuOEzy5zAZ3/H5tnQg1e80khMhK2xys0j6ZqzkgQC+fHMNZ7VDFNLqqNMj/o0eVeSBDh2POjkw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
       react: 18.2.0
 
-  /@react-types/table@3.9.2(react@18.2.0):
-    resolution: {integrity: sha512-brw5JUANOzBa2rYNpN8AIl9nDZ9RwRZC6G/wTM/JhtirjC1S42oCtf8Ap5rWJBdmMG/5KOfcGNcAl/huyqb3gg==}
+  /@react-types/table@3.9.3(react@18.2.0):
+    resolution: {integrity: sha512-Hs/pMbxJdga2zBol4H5pV1FVIiRjCuSTXst6idJjkctanTexR4xkyrtBwl+rdLNoGwQ2pGii49vgklc5bFK7zA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/grid': 3.2.3(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
-      react: 18.2.0
-    dev: false
-
-  /@react-types/textfield@3.9.0(react@18.2.0):
-    resolution: {integrity: sha512-D/DiwzsfkwlAg3uv8hoIfwju+zhB/hWDEdTvxQbPkntDr0kmN/QfI17NMSzbOBCInC4ABX87ViXLGxr940ykGA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    dependencies:
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/grid': 3.2.4(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@react-types/tooltip@3.4.6(react@18.2.0):
-    resolution: {integrity: sha512-RaZewdER7ZcsNL99RhVHs8kSLyzIBkwc0W6eFZrxST2MD9J5GzkVWRhIiqtFOd5U1aYnxdJ6woq72Ef+le6Vfw==}
+  /@react-types/textfield@3.9.1(react@18.2.0):
+    resolution: {integrity: sha512-JBHY9M2CkL6xFaGSfWmUJVu3tEK09FaeB1dU3IEh6P41xxbFnPakYHSSAdnwMXBtXPoSHIVsUBickW/pjgfe5g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     dependencies:
-      '@react-types/overlays': 3.8.4(react@18.2.0)
-      '@react-types/shared': 3.22.0(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
     dev: false
 
-  /@replit/codemirror-lang-csharp@6.2.0(@codemirror/autocomplete@6.12.0)(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/lr@1.4.0):
+  /@react-types/tooltip@3.4.7(react@18.2.0):
+    resolution: {integrity: sha512-rV4HZRQxLRNhe24yATOxnFQtGRUmsR7mqxMupXCmd1vrw8h+rdKlQv1zW2q8nALAKNmnRXZJHxYQ1SFzb98fgg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    dependencies:
+      '@react-types/overlays': 3.8.5(react@18.2.0)
+      '@react-types/shared': 3.22.1(react@18.2.0)
+      react: 18.2.0
+    dev: false
+
+  /@replit/codemirror-lang-csharp@6.2.0(@codemirror/autocomplete@6.12.0)(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/lr@1.4.0):
     resolution: {integrity: sha512-6utbaWkoymhoAXj051mkRp+VIJlpwUgCX9Toevz3YatiZsz512fw3OVCedXQx+WcR0wb6zVHjChnuxqfCLtFVQ==}
     peerDependencies:
       '@codemirror/autocomplete': ^6.0.0
@@ -5821,16 +5820,16 @@ packages:
       '@lezer/highlight': ^1.0.0
       '@lezer/lr': ^1.0.0
     dependencies:
-      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.24.0
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0
       '@lezer/lr': 1.4.0
     dev: false
 
-  /@replit/codemirror-lang-nix@6.0.1(@codemirror/autocomplete@6.12.0)(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/lr@1.4.0):
+  /@replit/codemirror-lang-nix@6.0.1(@codemirror/autocomplete@6.12.0)(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/lr@1.4.0):
     resolution: {integrity: sha512-lvzjoYn9nfJzBD5qdm3Ut6G3+Or2wEacYIDJ49h9+19WSChVnxv4ojf+rNmQ78ncuxIt/bfbMvDLMeMP0xze6g==}
     peerDependencies:
       '@codemirror/autocomplete': ^6.0.0
@@ -5841,10 +5840,10 @@ packages:
       '@lezer/highlight': ^1.0.0
       '@lezer/lr': ^1.0.0
     dependencies:
-      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.24.0
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0
       '@lezer/lr': 1.4.0
@@ -5859,7 +5858,7 @@ packages:
       '@lezer/highlight': 1.2.0
     dev: false
 
-  /@replit/codemirror-lang-svelte@6.0.0(@codemirror/autocomplete@6.12.0)(@codemirror/lang-css@6.2.1)(@codemirror/lang-html@6.4.8)(@codemirror/lang-javascript@6.2.1)(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/javascript@1.4.13)(@lezer/lr@1.4.0):
+  /@replit/codemirror-lang-svelte@6.0.0(@codemirror/autocomplete@6.12.0)(@codemirror/lang-css@6.2.1)(@codemirror/lang-html@6.4.8)(@codemirror/lang-javascript@6.2.1)(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/javascript@1.4.13)(@lezer/lr@1.4.0):
     resolution: {integrity: sha512-U2OqqgMM6jKelL0GNWbAmqlu1S078zZNoBqlJBW+retTc5M4Mha6/Y2cf4SVg6ddgloJvmcSpt4hHrVoM4ePRA==}
     peerDependencies:
       '@codemirror/autocomplete': ^6.0.0
@@ -5874,13 +5873,13 @@ packages:
       '@lezer/javascript': ^1.2.0
       '@lezer/lr': ^1.0.0
     dependencies:
-      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)
-      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.23.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)
+      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.24.0)
       '@codemirror/lang-html': 6.4.8
       '@codemirror/lang-javascript': 6.2.1
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.24.0
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0
       '@lezer/javascript': 1.4.13
@@ -5901,111 +5900,111 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@rollup/rollup-android-arm-eabi@4.9.6:
-    resolution: {integrity: sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==}
+  /@rollup/rollup-android-arm-eabi@4.12.0:
+    resolution: {integrity: sha512-+ac02NL/2TCKRrJu2wffk1kZ+RyqxVUlbjSagNgPm94frxtr+XDL12E5Ll1enWskLrtrZ2r8L3wED1orIibV/w==}
     cpu: [arm]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-android-arm64@4.9.6:
-    resolution: {integrity: sha512-T14aNLpqJ5wzKNf5jEDpv5zgyIqcpn1MlwCrUXLrwoADr2RkWA0vOWP4XxbO9aiO3dvMCQICZdKeDrFl7UMClw==}
+  /@rollup/rollup-android-arm64@4.12.0:
+    resolution: {integrity: sha512-OBqcX2BMe6nvjQ0Nyp7cC90cnumt8PXmO7Dp3gfAju/6YwG0Tj74z1vKrfRz7qAv23nBcYM8BCbhrsWqO7PzQQ==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-arm64@4.9.6:
-    resolution: {integrity: sha512-CqNNAyhRkTbo8VVZ5R85X73H3R5NX9ONnKbXuHisGWC0qRbTTxnF1U4V9NafzJbgGM0sHZpdO83pLPzq8uOZFw==}
+  /@rollup/rollup-darwin-arm64@4.12.0:
+    resolution: {integrity: sha512-X64tZd8dRE/QTrBIEs63kaOBG0b5GVEd3ccoLtyf6IdXtHdh8h+I56C2yC3PtC9Ucnv0CpNFJLqKFVgCYe0lOQ==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-x64@4.9.6:
-    resolution: {integrity: sha512-zRDtdJuRvA1dc9Mp6BWYqAsU5oeLixdfUvkTHuiYOHwqYuQ4YgSmi6+/lPvSsqc/I0Omw3DdICx4Tfacdzmhog==}
+  /@rollup/rollup-darwin-x64@4.12.0:
+    resolution: {integrity: sha512-cc71KUZoVbUJmGP2cOuiZ9HSOP14AzBAThn3OU+9LcA1+IUqswJyR1cAJj3Mg55HbjZP6OLAIscbQsQLrpgTOg==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.9.6:
-    resolution: {integrity: sha512-oNk8YXDDnNyG4qlNb6is1ojTOGL/tRhbbKeE/YuccItzerEZT68Z9gHrY3ROh7axDc974+zYAPxK5SH0j/G+QQ==}
+  /@rollup/rollup-linux-arm-gnueabihf@4.12.0:
+    resolution: {integrity: sha512-a6w/Y3hyyO6GlpKL2xJ4IOh/7d+APaqLYdMf86xnczU3nurFTaVN9s9jOXQg97BE4nYm/7Ga51rjec5nfRdrvA==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.9.6:
-    resolution: {integrity: sha512-Z3O60yxPtuCYobrtzjo0wlmvDdx2qZfeAWTyfOjEDqd08kthDKexLpV97KfAeUXPosENKd8uyJMRDfFMxcYkDQ==}
+  /@rollup/rollup-linux-arm64-gnu@4.12.0:
+    resolution: {integrity: sha512-0fZBq27b+D7Ar5CQMofVN8sggOVhEtzFUwOwPppQt0k+VR+7UHMZZY4y+64WJ06XOhBTKXtQB/Sv0NwQMXyNAA==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.9.6:
-    resolution: {integrity: sha512-gpiG0qQJNdYEVad+1iAsGAbgAnZ8j07FapmnIAQgODKcOTjLEWM9sRb+MbQyVsYCnA0Im6M6QIq6ax7liws6eQ==}
+  /@rollup/rollup-linux-arm64-musl@4.12.0:
+    resolution: {integrity: sha512-eTvzUS3hhhlgeAv6bfigekzWZjaEX9xP9HhxB0Dvrdbkk5w/b+1Sxct2ZuDxNJKzsRStSq1EaEkVSEe7A7ipgQ==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-riscv64-gnu@4.9.6:
-    resolution: {integrity: sha512-+uCOcvVmFUYvVDr27aiyun9WgZk0tXe7ThuzoUTAukZJOwS5MrGbmSlNOhx1j80GdpqbOty05XqSl5w4dQvcOA==}
+  /@rollup/rollup-linux-riscv64-gnu@4.12.0:
+    resolution: {integrity: sha512-ix+qAB9qmrCRiaO71VFfY8rkiAZJL8zQRXveS27HS+pKdjwUfEhqo2+YF2oI+H/22Xsiski+qqwIBxVewLK7sw==}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.9.6:
-    resolution: {integrity: sha512-HUNqM32dGzfBKuaDUBqFB7tP6VMN74eLZ33Q9Y1TBqRDn+qDonkAUyKWwF9BR9unV7QUzffLnz9GrnKvMqC/fw==}
+  /@rollup/rollup-linux-x64-gnu@4.12.0:
+    resolution: {integrity: sha512-TenQhZVOtw/3qKOPa7d+QgkeM6xY0LtwzR8OplmyL5LrgTWIXpTQg2Q2ycBf8jm+SFW2Wt/DTn1gf7nFp3ssVA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-musl@4.9.6:
-    resolution: {integrity: sha512-ch7M+9Tr5R4FK40FHQk8VnML0Szi2KRujUgHXd/HjuH9ifH72GUmw6lStZBo3c3GB82vHa0ZoUfjfcM7JiiMrQ==}
+  /@rollup/rollup-linux-x64-musl@4.12.0:
+    resolution: {integrity: sha512-LfFdRhNnW0zdMvdCb5FNuWlls2WbbSridJvxOvYWgSBOYZtgBfW9UGNJG//rwMqTX1xQE9BAodvMH9tAusKDUw==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.9.6:
-    resolution: {integrity: sha512-VD6qnR99dhmTQ1mJhIzXsRcTBvTjbfbGGwKAHcu+52cVl15AC/kplkhxzW/uT0Xl62Y/meBKDZvoJSJN+vTeGA==}
+  /@rollup/rollup-win32-arm64-msvc@4.12.0:
+    resolution: {integrity: sha512-JPDxovheWNp6d7AHCgsUlkuCKvtu3RB55iNEkaQcf0ttsDU/JZF+iQnYcQJSk/7PtT4mjjVG8N1kpwnI9SLYaw==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.9.6:
-    resolution: {integrity: sha512-J9AFDq/xiRI58eR2NIDfyVmTYGyIZmRcvcAoJ48oDld/NTR8wyiPUu2X/v1navJ+N/FGg68LEbX3Ejd6l8B7MQ==}
+  /@rollup/rollup-win32-ia32-msvc@4.12.0:
+    resolution: {integrity: sha512-fjtuvMWRGJn1oZacG8IPnzIV6GF2/XG+h71FKn76OYFqySXInJtseAqdprVTDTyqPxQOG9Exak5/E9Z3+EJ8ZA==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-x64-msvc@4.9.6:
-    resolution: {integrity: sha512-jqzNLhNDvIZOrt69Ce4UjGRpXJBzhUBzawMwnaDAwyHriki3XollsewxWzOzz+4yOFDkuJHtTsZFwMxhYJWmLQ==}
+  /@rollup/rollup-win32-x64-msvc@4.12.0:
+    resolution: {integrity: sha512-ZYmr5mS2wd4Dew/JjT0Fqi2NPB/ZhZ2VvPp7SmvPZb4Y1CG/LRcS6tcRo2cYU7zLK5A7cdbhWnnWmUjoI4qapg==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rushstack/node-core-library@3.62.0(@types/node@20.11.16):
+  /@rushstack/node-core-library@3.62.0(@types/node@20.11.19):
     resolution: {integrity: sha512-88aJn2h8UpSvdwuDXBv1/v1heM6GnBf3RjEy6ZPP7UnzHNCqOHA2Ut+ScYUbXcqIdfew9JlTAe3g+cnX9xQ/Aw==}
     peerDependencies:
       '@types/node': '*'
@@ -6013,7 +6012,7 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 20.11.16
+      '@types/node': 20.11.19
       colors: 1.2.5
       fs-extra: 7.0.1
       import-lazy: 4.0.0
@@ -6085,8 +6084,8 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@swc/helpers@0.5.3:
-    resolution: {integrity: sha512-FaruWX6KdudYloq1AHD/4nU+UsMTdNE8CKyrseXWEcgjDAbvkwJg2QGPAnfIJLIWsjZOSPLOAykK6fuYp4vp4A==}
+  /@swc/helpers@0.5.6:
+    resolution: {integrity: sha512-aYX01Ke9hunpoCexYAgQucEpARGQ5w/cqHFrIR+e9gdKb1QWTsVJuTJ2ozQzIAxLyRQe/m+2RqzkyOOGiMKRQA==}
     dependencies:
       tslib: 2.6.2
 
@@ -6122,7 +6121,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.9
       '@testing-library/dom': 9.3.4
-      '@types/react-dom': 18.2.18
+      '@types/react-dom': 18.2.19
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: true
@@ -6237,8 +6236,8 @@ packages:
   /@types/ms@0.7.34:
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
-  /@types/node@20.11.16:
-    resolution: {integrity: sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==}
+  /@types/node@20.11.19:
+    resolution: {integrity: sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==}
     dependencies:
       undici-types: 5.26.5
 
@@ -6249,13 +6248,13 @@ packages:
   /@types/prop-types@15.7.11:
     resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
 
-  /@types/react-dom@18.2.18:
-    resolution: {integrity: sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==}
+  /@types/react-dom@18.2.19:
+    resolution: {integrity: sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==}
     dependencies:
-      '@types/react': 18.2.52
+      '@types/react': 18.2.56
 
-  /@types/react@18.2.52:
-    resolution: {integrity: sha512-E/YjWh3tH+qsLKaUzgpZb5AY0ChVa+ZJzF7ogehVILrFpdQk6nC/WXOv0bfFEABbXbgNxLBGU7IIZByPKb6eBw==}
+  /@types/react@18.2.56:
+    resolution: {integrity: sha512-NpwHDMkS/EFZF2dONFQHgkPRwhvgq/OAvIaGQzxGSBmaeR++kTg6njr15Vatz0/2VcCEwJQFi6Jf4Q0qBu0rLA==}
     dependencies:
       '@types/prop-types': 15.7.11
       '@types/scheduler': 0.16.8
@@ -6264,14 +6263,14 @@ packages:
   /@types/scheduler@0.16.8:
     resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
 
-  /@types/semver@7.5.6:
-    resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
+  /@types/semver@7.5.7:
+    resolution: {integrity: sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==}
     dev: true
 
   /@types/set-cookie-parser@2.4.7:
     resolution: {integrity: sha512-+ge/loa0oTozxip6zmhRIk8Z/boU51wl9Q6QdLZcokIGMzY5lFXYy/x7Htj2HTC6/KZP1hUbZ1ekx8DYXICvWg==}
     dependencies:
-      '@types/node': 20.11.16
+      '@types/node': 20.11.19
     dev: true
 
   /@types/sinon@17.0.3:
@@ -6303,12 +6302,12 @@ packages:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
-      '@types/node': 20.11.16
+      '@types/node': 20.11.19
     dev: true
     optional: true
 
-  /@typescript-eslint/eslint-plugin@6.20.0(@typescript-eslint/parser@6.20.0)(eslint@8.56.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-fTwGQUnjhoYHeSF6m5pWNkzmDDdsKELYrOBxhjMrofPqCkoC2k3B2wvGHFxa1CTIqkEn88nlW1HVMztjo2K8Hg==}
+  /@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.56.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
@@ -6319,25 +6318,25 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
-      '@typescript-eslint/scope-manager': 6.20.0
-      '@typescript-eslint/type-utils': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
-      '@typescript-eslint/utils': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
-      '@typescript-eslint/visitor-keys': 6.20.0
+      '@typescript-eslint/parser': 6.21.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.56.0
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
-      semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.3.3)
+      semver: 7.6.0
+      ts-api-utils: 1.2.1(typescript@5.3.3)
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-bYerPDF/H5v6V76MdMYhjwmwgMA+jlPVqjSDq2cRqMi8bP5sR3Z+RLOiOMad3nsnmDVmn2gAFCyNgh/dIrfP/w==}
+  /@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -6346,10 +6345,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 6.20.0
-      '@typescript-eslint/types': 6.20.0
-      '@typescript-eslint/typescript-estree': 6.20.0(typescript@5.3.3)
-      '@typescript-eslint/visitor-keys': 6.20.0
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.56.0
       typescript: 5.3.3
@@ -6357,16 +6356,16 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager@6.20.0:
-    resolution: {integrity: sha512-p4rvHQRDTI1tGGMDFQm+GtxP1ZHyAh64WANVoyEcNMpaTFn3ox/3CcgtIlELnRfKzSs/DwYlDccJEtr3O6qBvA==}
+  /@typescript-eslint/scope-manager@6.21.0:
+    resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.20.0
-      '@typescript-eslint/visitor-keys': 6.20.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
     dev: true
 
-  /@typescript-eslint/type-utils@6.20.0(eslint@8.56.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-qnSobiJQb1F5JjN0YDRPHruQTrX7ICsmltXhkV536mp4idGAYrIyr47zF/JmkJtEcAVnIz4gUYJ7gOZa6SmN4g==}
+  /@typescript-eslint/type-utils@6.21.0(eslint@8.56.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -6375,23 +6374,23 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.20.0(typescript@5.3.3)
-      '@typescript-eslint/utils': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.56.0)(typescript@5.3.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.56.0
-      ts-api-utils: 1.0.3(typescript@5.3.3)
+      ts-api-utils: 1.2.1(typescript@5.3.3)
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types@6.20.0:
-    resolution: {integrity: sha512-MM9mfZMAhiN4cOEcUOEx+0HmuaW3WBfukBZPCfwSqFnQy0grXYtngKCqpQN339X3RrwtzspWJrpbrupKYUSBXQ==}
+  /@typescript-eslint/types@6.21.0:
+    resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.20.0(typescript@5.3.3):
-    resolution: {integrity: sha512-RnRya9q5m6YYSpBN7IzKu9FmLcYtErkDkc8/dKv81I9QiLLtVBHrjz+Ev/crAqgMNW2FCsoZF4g2QUylMnJz+g==}
+  /@typescript-eslint/typescript-estree@6.21.0(typescript@5.3.3):
+    resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       typescript: '*'
@@ -6399,47 +6398,47 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 6.20.0
-      '@typescript-eslint/visitor-keys': 6.20.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.3.3)
+      semver: 7.6.0
+      ts-api-utils: 1.2.1(typescript@5.3.3)
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@6.20.0(eslint@8.56.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-/EKuw+kRu2vAqCoDwDCBtDRU6CTKbUmwwI7SH7AashZ+W+7o8eiyy6V2cdOqN49KsTcASWsC5QeghYuRDTyOOg==}
+  /@typescript-eslint/utils@6.21.0(eslint@8.56.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
       '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.6
-      '@typescript-eslint/scope-manager': 6.20.0
-      '@typescript-eslint/types': 6.20.0
-      '@typescript-eslint/typescript-estree': 6.20.0(typescript@5.3.3)
+      '@types/semver': 7.5.7
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
       eslint: 8.56.0
-      semver: 7.5.4
+      semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys@6.20.0:
-    resolution: {integrity: sha512-E8Cp98kRe4gKHjJD4NExXKz/zOJ1A2hhZc+IMVD6i7w4yjIvh6VyuRI0gRtxAsXtoC35uGMaQ9rjI2zJaXDEAw==}
+  /@typescript-eslint/visitor-keys@6.21.0:
+    resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.20.0
+      '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@udecode/plate-alignment@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-alignment@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-gbcMYwxsLQryXiSvWNgW9VEOndPz9YJ0bgr641jZLQ66uMHADzb2tV585arefKqLifYnxLmXXGijCR3x42jJew==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6448,7 +6447,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -6471,7 +6470,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-autoformat@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-autoformat@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-ekwohyLREz53unJvPCwKUW8gte+QNXWu70BWCZDIbRtVMe8Fbtji2Wzuw/4Dm2/Wh5rE1K6TgA03uwGPsbro7w==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6480,7 +6479,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -6503,7 +6502,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-basic-elements@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-basic-elements@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-tB+MSDArmpKr+/EBlNpjIj5Tv9Fj3zB1ICxLVGieJ5BVXo8Qu8JYWbKI8juV1W7muf+HltC+N2hIedojA+r2Kg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6512,11 +6511,11 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-block-quote': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-code-block': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-heading': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-paragraph': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-block-quote': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-code-block': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-heading': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-paragraph': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -6539,7 +6538,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-basic-marks@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-basic-marks@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-15zTwE4+pu3duVnnb7DKCUeiKlEfdSzCMspViP3I5fPRFQFnWZVGPoN1tQskb1oxvzBGddlpz/6GCSeBW2JN6Q==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6548,7 +6547,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -6571,7 +6570,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-block-quote@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-block-quote@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-JNksR8F6yw7qgzGBZtolMWaFbseYcLKNo3z8AEBkcUCt95VSbBQP7P24/6aFoMkaAH1eD7DNRCegic9Kanru/w==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6580,7 +6579,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -6603,7 +6602,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-break@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-break@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-MotPRnMOthyHgX+sOWVhY9z/FnivkvWOhb/MM+xgK/B5PMFgz9GlHSlJIjyTOm3HzIhfo968shOYW8Z+9PAo5g==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6612,7 +6611,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -6635,7 +6634,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-button@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-button@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-lH8MjPFtWdOPUUVFUgvKIu9VR7bNo6SQhoBfAaGQPhPARqBQ+IrPlKAA2mC8IZr3ECFtuPDjg2uqGQoUTAedZQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6644,7 +6643,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -6667,7 +6666,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-code-block@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-code-block@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-ZaioZnfBmFMFZWzulMGfoDLb3l9nOIcfbfleGNDBjTRiqorbzGuz1K9MKWTjPZacS+Zt035ncC/bouMXnppP1w==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6676,7 +6675,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       prismjs: 1.29.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -6700,7 +6699,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-combobox@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-combobox@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-LLMec+quBxG7P5IKFrqRrpBsJm4FPTVzKLQnd+TAh6h8yw0wLLMw90McnpIhmp9xfyHUsZa99ymnHrkYf7+8QQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6709,8 +6708,8 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-floating': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-floating': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       downshift: 6.1.12(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -6735,7 +6734,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-comments@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-comments@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-65ciYGs+NdkRoNwXyO/gS8Zl9R1IXICrk6kXzyrukgrCGnbA3nayoV3KI5zG0rO7s5PbJhYmQxyEX8CVhZ2HgA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6744,8 +6743,8 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -6768,7 +6767,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-common@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-common@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-jEkgcbSP2Kgk0vzmKMzhxqi7bfw9oaBGX5xuds0j9l079BKIRzvj/hBnPBneC5i5B+YqU+m+xI+mfbbNcaVgAA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6778,7 +6777,7 @@ packages:
       slate-react: '>=0.94.0'
     dependencies:
       '@udecode/plate-core': 21.5.0(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-utils': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-utils': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       '@udecode/slate': 21.4.1(slate-history@0.100.0)(slate@0.94.1)
       '@udecode/slate-react': 21.4.1(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       '@udecode/slate-utils': 21.4.1(slate-history@0.100.0)(slate@0.94.1)
@@ -6846,7 +6845,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-emoji@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-emoji@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-rFL5E8QwwadpUrdhP8qT7G5fyjLTz0WVQHmaiQaUKyCw6Xlzt4R/OLmFfsX4UI2614/cGbO7tor0OSKedC46UQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6856,8 +6855,8 @@ packages:
       slate-react: '>=0.94.0'
     dependencies:
       '@emoji-mart/data': 1.1.2
-      '@udecode/plate-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -6881,7 +6880,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-find-replace@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-find-replace@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-ZMreo/MDeZG4vICdtgsWgF//ugs2bdjNwLROM/cPaEzC2LygfJCwA6dFaPh+7DjeMhIgxfIiGA+e+ZFzJzLsEQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6890,7 +6889,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -6913,7 +6912,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-floating@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-floating@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-nBEXyqsdxEDkopetcbA3+wfPDZI04VNT0TCMv/ZUgc0KgjZrLK10TIo0cp3HU7okrKwkRE0bQjOEze2fPxQWSA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6923,8 +6922,8 @@ packages:
       slate-react: '>=0.94.0'
     dependencies:
       '@floating-ui/react': 0.22.3(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-dropdown-menu': 2.0.6(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@radix-ui/react-dropdown-menu': 2.0.6(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -6948,7 +6947,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-font@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-font@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-suPdGeRCKlDep8FZCmZ0TbYNeUd7cHcnuY6YwrGfs7KUNv2WyklQH3RxPSLtio7Ei55SYHl5FcrSy8tfvpUHfA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6957,7 +6956,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -6980,7 +6979,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-heading@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-heading@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-4+6fKS5fXyiwuVxwwxM3Pu8d8zdxOGodJ8PsDSjfI4ZtrZGMnfa889tOnKw2FEtH/mgFl03Yk+ftUhDZPuNwhg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -6989,7 +6988,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7012,7 +7011,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-headless@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-headless@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-KFEEQ/NdMs3HIzidv2yz44SReVnxZmMip8JGyERe+PU5oAvhcQcp8ACvF0CQuK2xBk041/DCJbznF6WG7rBEcg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7022,46 +7021,46 @@ packages:
       slate-hyperscript: '>=0.66.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-alignment': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-autoformat': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-basic-elements': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-basic-marks': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-block-quote': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-break': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-code-block': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-comments': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-emoji': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-find-replace': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-floating': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-font': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-heading': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-highlight': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-horizontal-rule': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-indent': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-indent-list': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-kbd': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-line-height': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-link': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-list': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-media': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-mention': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-node-id': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-normalizers': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-paragraph': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-reset-node': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-select': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-serializer-csv': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-serializer-docx': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-serializer-html': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-serializer-md': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-suggestion': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-tabbable': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-table': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-trailing-block': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/resizable': 20.5.3(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-alignment': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-autoformat': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-basic-elements': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-basic-marks': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-block-quote': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-break': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-code-block': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-comments': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-emoji': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-find-replace': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-floating': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-font': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-heading': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-highlight': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-horizontal-rule': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-indent': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-indent-list': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-kbd': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-line-height': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-link': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-list': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-media': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-mention': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-node-id': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-normalizers': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-paragraph': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-reset-node': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-select': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-serializer-csv': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-serializer-docx': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-serializer-html': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-serializer-md': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-suggestion': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-tabbable': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-table': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-trailing-block': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/resizable': 20.5.3(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7087,7 +7086,7 @@ packages:
       - supports-color
     dev: false
 
-  /@udecode/plate-highlight@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-highlight@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-o11WrLmMqhM2u0/7mgLVJT+utzHJG8eP5u8swJuMAGkHE71QesUXj2ZgSxuubrF+VC/XESQXhGmeB8PkCBDIjw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7096,7 +7095,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7119,7 +7118,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-horizontal-rule@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-horizontal-rule@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-3SX2HYr3yifptfFnQ1XH1+KYN9gQUVjy9bwPpz0RJm7kZZR+SrZQ6Op8LBK17rsDIB+lsnsklkDwYQm/OaUT6g==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7128,7 +7127,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7151,7 +7150,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-indent-list@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-indent-list@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-XJvcWNxlpfay1A5h/65tR3H9YP+9rd1Ui1yF4/FIEJpBazYJF02JLR/TKCP46pqBKFEmWc9jImeUXfbgeDkLlw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7160,9 +7159,9 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-indent': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-list': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-indent': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-list': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7185,7 +7184,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-indent@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-indent@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-ETwGdPZuEesGv4DW+s9cmt0+Fo537y7sVtVJJi1juCitPgwnaqLwu+QRLDErFSIBdQebR0/gxX65R/+uH0NwnQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7194,7 +7193,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7217,7 +7216,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-kbd@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-kbd@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-KVerussGxitZox/6PJpPo/6TT+BGZ6rn3yvndSveAq1tD2HuDxw9nDbBhxiZYQBseZ97aTu4t4naCR/jJl0xwQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7226,7 +7225,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7249,7 +7248,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-line-height@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-line-height@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-JCBEjDZZw8MFulI56md3Noz1vuw6EiCmvLkX7pRcMc7dGocMo4BKOJLao1UGIfDVLkqjVlr8Av1fayQPGNuZGg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7258,7 +7257,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7281,7 +7280,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-link@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-link@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-UT2rW0HBNOYvS0iLxFC5dU7wiMAQ+L8Cgl1mIlxi+a/58B+K3ED1zwnO7MAotpKOy/GSA58+YYBQ3liSTolgRw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7290,9 +7289,9 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-normalizers': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-normalizers': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7315,7 +7314,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-list@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-list@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-PkmlSmy1/W4FMcw5pzJakb6d3MbfqCT4xCOHgjXkv4glqaRFKAwMJPhvswwveEencfQe+c5J5HFE7t2q4dWwIg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7324,8 +7323,8 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-reset-node': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-reset-node': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7348,7 +7347,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-media@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-media@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-7FY+vo0USGTZvUYKEtemfupHPjeUkK4zQZRODZCiP46t0mK1cImsSsP8OUZ2HjXKkyAMVla1ThH1+QOXb8I0cA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7357,12 +7356,12 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/resizable': 20.5.3(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/resizable': 20.5.3(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       js-video-url-parser: 0.5.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-textarea-autosize: 8.5.3(@types/react@18.2.52)(react@18.2.0)
+      react-textarea-autosize: 8.5.3(@types/react@18.2.56)(react@18.2.0)
       scriptjs: 2.5.9
       slate: 0.94.1
       slate-history: 0.100.0(slate@0.94.1)
@@ -7384,7 +7383,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-mention@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-mention@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-34iR9qk1uz0jPeWpE4mC+e/2sij0knM+nnOlcmWiEpQQP3ahaPFQups7+5Kpa23AXecpdHeRGqR1vUnWbAYnyQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7393,8 +7392,8 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7418,7 +7417,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-node-id@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-node-id@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-emPHy5KXj8R3YMsuXsZ4hhlWpPLAoVmymiUA5uEihAMoiXDTAEkVpvcw79zqLmvOn50rYwCItqv+Y19YaL29nA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7427,7 +7426,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7450,7 +7449,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-normalizers@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-normalizers@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-X6dtZvT14vGxxm9WzuoeTN8RlU5plHIagWlFdVCV2EQM1mNlo5LEnNSsSIaS9Z+VBvKagmIn8JUaaMeFB/Yixg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7459,7 +7458,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7482,7 +7481,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-paragraph@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-paragraph@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-ujQwFQ3rQRl2JaHYHSxxS5mf0NuGXu4WtfGdYD2ITCnIKP+cy6vycg7iIfcPL+w7iYFz5F9wpyIZzR9upISRBg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7491,7 +7490,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7514,7 +7513,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-reset-node@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-reset-node@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-rPCE7TzA3/GyNcOWUUuFRlbNrtm7Af4wIkrGTuoY6/T/Ypp8KeRc5HlOwzuQL+QRGMp3kyJQL3A/KDuPF1uq7A==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7523,7 +7522,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7546,7 +7545,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-select@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-select@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-trNzAIEpcf7Xtntau2XohxLmlLRoQ+9Tt0opkDyNqFW+Mp5xIL0D9OZEGZo05F/73WbxpcxH40tFkzhOhZQOmw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7555,7 +7554,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7578,7 +7577,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-serializer-csv@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-serializer-csv@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-4wMqvDmHB2SLe6MvrDKI4jTq3z/Pp2NR3ptLwOO8UavnZJYvsk/PlCBP//YSbTIi8vhPaODCCjzc8U8iZu5etA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7587,8 +7586,8 @@ packages:
       slate-hyperscript: '>=0.66.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-table': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-table': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       papaparse: 5.4.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -7613,7 +7612,7 @@ packages:
       - slate-history
     dev: false
 
-  /@udecode/plate-serializer-docx@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-serializer-docx@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-ggxpIzNSUovjZj/HQqHxdExdEVGnOh1VSR5BpuVtV2BeXOvFZK1I+GXheXfK/r/b8Kj50FZMYrNXDS0Yf1qjPg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7623,13 +7622,13 @@ packages:
       slate-hyperscript: '>=0.66.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-heading': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-indent': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-indent-list': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-media': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-paragraph': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-table': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-heading': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-indent': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-indent-list': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-media': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-paragraph': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-table': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7654,7 +7653,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-serializer-html@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-serializer-html@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-s9PqX/PcDvxhIX7ibIVXVqMPfXTTln08Zja3VX49OwXs9pDerjcQr6Sq3Ni85SIGVB8UQUvQ+VifyvfEFYjyEw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7664,7 +7663,7 @@ packages:
       slate-hyperscript: '>=0.66.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       html-entities: 2.4.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -7689,7 +7688,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-serializer-md@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-serializer-md@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-TXCzJolmmv/ROnfvEBrO4WpUJEcwwp1Jvg7MOOcdegv7824t08CycJEXZhWDKAXb2Af/MOG+1gIB55yhLwYYTg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7698,13 +7697,13 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-block-quote': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-code-block': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-heading': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-link': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-list': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-paragraph': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-block-quote': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-code-block': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-heading': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-link': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-list': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-paragraph': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       remark-parse: 9.0.0
@@ -7730,7 +7729,7 @@ packages:
       - supports-color
     dev: false
 
-  /@udecode/plate-styled-components@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-styled-components@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-+ooCADdk3O1b+yaMe09e8M/Yxf9++Lk6YVMjHxSGS0pwTKIyfdTGwcbZ9oImCYxhlv1yGDOOgPEvuoog0cX3tw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7741,7 +7740,7 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       clsx: 1.2.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -7767,7 +7766,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-suggestion@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-suggestion@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-6oeyYLMgRXn6DQiizCIWrpjNaFrS6UBHz3jHPmfLSvzJK6LxCXgAKdwzOb7/mBq2KSzRyJJK2Ua9UN12R9tP8A==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7776,7 +7775,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7799,7 +7798,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-tabbable@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-tabbable@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-RS4C2yFvSP3ZDxggg4is6ewcWCHbgGtwQcG/2dBl/PdDubnU9CkFl0MasX6A+cMajD/ZZj2XPo0wYFsUEah+Vg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7808,7 +7807,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7832,7 +7831,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-table@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-table@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-sPFvXjn0m8kCuHTCquMYnOWKyUBCBKz7lQSBgX23cayu7a0oBxcbH/cHOA77+WbpZ0ZybrLb4Kbkfcr+bdyoQA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7841,8 +7840,8 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/resizable': 20.5.3(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/resizable': 20.5.3(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7865,7 +7864,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-trailing-block@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-trailing-block@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-sGD4tLpUpl7cKlvnXA8BVg4/Wwwrj6rcXjPGvMRqOcAYYys5HIOlET/SqypPdP5QK0JZQZX3UMGKS6+fto+5Qg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7874,7 +7873,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7897,7 +7896,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-alignment@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-alignment@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-tCqLx6dxkUFesi3OfMFv4RFJFk4tIfIu07KpCzSpaX0B7u+cgV1rBWXeV+HvDquPKC4lsrVJ6lh3Yyx7LDdPBw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7907,10 +7906,10 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-alignment': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-alignment': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7936,7 +7935,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-block-quote@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-block-quote@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-5YOjAeejfJ3zp3vpYr2G+TzpveZbdv8VLUe9YpcSNlPF/r/wAzojeUwbCEkN6WuVALWCGv8ylddNUZ/DNxpg8g==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7946,9 +7945,9 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-block-quote': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-block-quote': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -7973,7 +7972,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-button@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-button@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-HVIIPshNJoDcjVs71zGCMOj5pC6OQfaiItxKggiG/EYw9eFXm4l/pCCGdny74vIQdTywWYj15yEYcMg0w1eY1Q==}
     peerDependencies:
       react: '>=16.8.0'
@@ -7983,9 +7982,9 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8010,7 +8009,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-code-block@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-code-block@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-xN62xPasT5IVzi9k/pbdoR1U3ZobbolXVWDVqjvYaiPWgVtyt4VNxwaIjfqhtb2lTtQZakwV5XjaQcIcjeZO1g==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8020,10 +8019,10 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-code-block': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-code-block': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8049,7 +8048,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-combobox@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-combobox@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-QJys2QEc+KlslbKQ1M+PxhYl7JoYr4Lr948iaPIOuYyQQAPSZIR5DFTsKgwst8vDL9TqXQIb/lL/jcUCyC8GWw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8059,10 +8058,10 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-floating': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-floating': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8088,7 +8087,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-comments@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-comments@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-+XjpARWNGt/xXWIEb+wEjD47piKSw3Fh7Y4P1fO9zl5FwIJXBankhW6V2HJQP6nw9WkTYx/DABI/C4OFAHr19w==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8098,11 +8097,11 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-comments': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-comments': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8128,7 +8127,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-cursor@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-cursor@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-/0ASgCw09m864FvtrMlTLz7OPCztos+h8t/6pnxI6lfJGzgG55wV1MOL5nVEhcEs5GO7sLEKPWYJt9hKxG54vQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8138,8 +8137,8 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8164,7 +8163,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-emoji@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-emoji@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-EzweF/YUbs6KEyGAnyBHHuduK1iW03fuPrT07YcN83RFxIu+sFPLDFbHmOVklVG1xOuo1k6WYyE37OvaNXEkeA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8174,12 +8173,12 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-emoji': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-emoji': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8205,7 +8204,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-find-replace@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-find-replace@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-b21VoIiKJbj60rMC8MPrTkayysZlGEoksJ+QpAwPi8whDtq/DCWeCY/8brGJPD/ivRKLmvlttnAkPQGCsL12JQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8215,10 +8214,10 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-find-replace': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-find-replace': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8244,7 +8243,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-font@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-font@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-wGy1TXSSF2KpWauKqpW7RBZ5EPgc16ds1r3bPNrw8utHO3WH4vuluGnWKJdIemguJeeTgiPiOp9LyVEA9PPZjQ==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8254,11 +8253,11 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-font': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-font': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8284,7 +8283,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-line-height@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-line-height@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-ddkxbNark/DbQLc2gNPfVnlA+5YUWuLeEMGl0nEAmuvq5IZCBZXz2icSccMjv+EqcioQVKBrHi+PqP0EUYMY2w==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8294,10 +8293,10 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-line-height': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-line-height': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8323,7 +8322,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-link@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-link@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-kk3gNmSqTFGfna/+fHDPl1iQ3jClOk44zrVgHanN72d4dWHzgyUSocrHrldUuQkECfFhCg4S5gIn82rKBK5rYg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8333,11 +8332,11 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-link': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-link': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8363,7 +8362,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-list@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-list@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-dtq4fMH3aJOxkq8klBC7AHLZgQDu9gD0ObFbvahqLFxyyHbRZmWWtKnOVZauCSvvU/Dsi6oK96wSBHHNezi3/w==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8373,10 +8372,10 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-list': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-list': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8402,7 +8401,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-media@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-media@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-QYByExzxchHeXflxdMz/aI5reUeTHyPILj3vaunObE1b2q2Vi5TDFW2kBl/ikA5FtcJWgqFq6SH1cKUztSlVPg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8412,13 +8411,13 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-floating': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-link': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-media': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-link': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-floating': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-link': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-media': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-link': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       js-video-url-parser: 0.5.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -8445,7 +8444,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-mention@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-mention@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-dD5QV/05oY9DJrF4Ls8rYlhZrZTqYD2oS2+eY31fo9TKsvbEArypVA9gbLAB+JtY3flWTF/XK8ZtQDK4Ky/Srw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8455,11 +8454,11 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-mention': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-mention': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8485,7 +8484,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-placeholder@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-placeholder@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-scZVD6/fWGMRYYAmlJ2OLGvYCeTD4zEOj2EPWeI5ztspqbVjqmGkOB/N54cSZkEZne2rwCfqNmJ8wkZr91T8Ig==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8495,8 +8494,8 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8521,7 +8520,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-table@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-table@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-7ZN/RMbkINTFMV5i/3KD9UnAqHRTUlJ9NA554ahoRio3+GNzXfnf2wXF98Q4NnELz245nasqkOqZ3qj18u/l3Q==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8531,12 +8530,12 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-floating': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-table': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-floating': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-table': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8562,7 +8561,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui-toolbar@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui-toolbar@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-V5Z/Y64RtAyeoeZGqz+xTKKdiKE3M0CC23kF9tQx0ciHRSM+/VdV58Xp20Oe6RKlIe91BXNQrprIezbabZA1HA==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8573,10 +8572,10 @@ packages:
       styled-components: '>=5.0.0'
     dependencies:
       '@tippyjs/react': 4.2.6(react-dom@18.2.0)(react@18.2.0)
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-floating': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-floating': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-use: 17.5.0(react-dom@18.2.0)(react@18.2.0)
@@ -8603,7 +8602,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate-ui@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-F5Llhi04azilhnq8AmuwoalDCGsK0HHQyzPsQ0G0GpZfjSf6sRN3dxfBE7AZ6WzK7hShS1CFdN+SV/2LF/K+qw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8616,28 +8615,28 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-headless': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-alignment': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-block-quote': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-code-block': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-comments': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-cursor': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-emoji': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-find-replace': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-font': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-line-height': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-link': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-list': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-media': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-mention': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-placeholder': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-table': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-headless': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-alignment': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-block-quote': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-code-block': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-comments': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-cursor': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-emoji': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-find-replace': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-font': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-line-height': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-link': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-list': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-media': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-mention': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-placeholder': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-table': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
-      react-dnd: 16.0.1(@types/node@20.11.16)(@types/react@18.2.52)(react@18.2.0)
+      react-dnd: 16.0.1(@types/node@20.11.19)(@types/react@18.2.56)(react@18.2.0)
       react-dnd-html5-backend: 15.1.3
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8666,7 +8665,7 @@ packages:
       - supports-color
     dev: false
 
-  /@udecode/plate-ui@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate-ui@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-F5Llhi04azilhnq8AmuwoalDCGsK0HHQyzPsQ0G0GpZfjSf6sRN3dxfBE7AZ6WzK7hShS1CFdN+SV/2LF/K+qw==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8679,33 +8678,33 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-headless': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-alignment': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-block-quote': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-code-block': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-comments': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-cursor': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-emoji': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-find-replace': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-font': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-line-height': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-link': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-list': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-media': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-mention': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-placeholder': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-table': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
-      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-headless': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-styled-components': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-alignment': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-block-quote': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-button': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-code-block': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-combobox': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-comments': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-cursor': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-emoji': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-find-replace': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-font': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-line-height': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-link': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-list': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-media': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-mention': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-placeholder': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-table': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-ui-toolbar': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
-      react-dnd: 16.0.1(@types/node@20.11.16)(@types/react@18.2.52)(react@18.2.0)
+      react-dnd: 16.0.1(@types/node@20.11.19)(@types/react@18.2.56)(react@18.2.0)
       react-dnd-html5-backend: 16.0.1
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
-      slate-history: 0.100.0(slate@0.101.5)
-      slate-hyperscript: 0.100.0(slate@0.101.5)
+      slate-history: 0.100.0(slate@0.102.0)
+      slate-hyperscript: 0.100.0(slate@0.102.0)
       slate-react: 0.98.4(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       styled-components: 6.1.8(react-dom@18.2.0)(react@18.2.0)
       use-context-selector: 1.4.1(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)
@@ -8729,7 +8728,7 @@ packages:
       - supports-color
     dev: false
 
-  /@udecode/plate-utils@21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/plate-utils@21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-wmUfkatfRUpKI2AUbZ55IKJDJcvKZ9okW2vP2fbEN6WeKblwjqqgIpc+LFTBUBpD9f2BJxBmcT7ECdDrodwNDg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8738,7 +8737,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.52)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.56)(react@18.2.0)
       '@udecode/plate-core': 21.5.0(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       '@udecode/slate': 21.4.1(slate-history@0.100.0)(slate@0.94.1)
       '@udecode/slate-react': 21.4.1(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
@@ -8766,7 +8765,7 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/plate@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-uKAmKHwPgzo/XzrYWrbJ0FuqJRvU394aXZMkx4bXnHzVuCvQT4HNxZM4yM+RagdRHXr6xKZxdxQG70xKF2/5Jg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8777,8 +8776,8 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-headless': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-ui': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-headless': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-ui': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8808,7 +8807,7 @@ packages:
       - supports-color
     dev: false
 
-  /@udecode/plate@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
+  /@udecode/plate@21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8):
     resolution: {integrity: sha512-uKAmKHwPgzo/XzrYWrbJ0FuqJRvU394aXZMkx4bXnHzVuCvQT4HNxZM4yM+RagdRHXr6xKZxdxQG70xKF2/5Jg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8819,13 +8818,13 @@ packages:
       slate-react: '>=0.94.0'
       styled-components: '>=5.0.0'
     dependencies:
-      '@udecode/plate-headless': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
-      '@udecode/plate-ui': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      '@udecode/plate-headless': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-ui': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
-      slate-history: 0.100.0(slate@0.101.5)
-      slate-hyperscript: 0.100.0(slate@0.101.5)
+      slate-history: 0.100.0(slate@0.102.0)
+      slate-hyperscript: 0.100.0(slate@0.102.0)
       slate-react: 0.98.4(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
       styled-components: 6.1.8(react-dom@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
@@ -8850,7 +8849,7 @@ packages:
       - supports-color
     dev: false
 
-  /@udecode/resizable@20.5.3(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
+  /@udecode/resizable@20.5.3(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1):
     resolution: {integrity: sha512-daSwKcHSE6Jq9yIxVJ7t1CmknOu75SgIRetYi2ZUeUkb5p97WnGzUKrNEan9kVCerW6e9FrCUH7Cvpw5X9+nPg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -8859,7 +8858,7 @@ packages:
       slate-history: '>=0.93.0'
       slate-react: '>=0.94.0'
     dependencies:
-      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
+      '@udecode/plate-common': 21.5.0(@babel/core@7.23.9)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-react@0.98.4)(slate@0.94.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       slate: 0.94.1
@@ -8943,14 +8942,14 @@ packages:
       - scheduler
     dev: false
 
-  /@udecode/zustood@1.1.3(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(zustand@4.5.0):
+  /@udecode/zustood@1.1.3(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)(zustand@4.5.1):
     resolution: {integrity: sha512-f3mxHDaOF+q2XvDh/mMvLhCNs0LfCLhIBl8jGmvZT/i3WWq7YujzGXgnbK8mxIkun9irfe6wlPhg9sTIB9Gnug==}
     peerDependencies:
       zustand: '>=3.5.10'
     dependencies:
       immer: 9.0.12
       react-tracked: 1.7.11(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)
-      zustand: 4.5.0(@types/react@18.2.52)(immer@9.0.12)(react@18.2.0)
+      zustand: 4.5.1(@types/react@18.2.56)(immer@9.0.12)(react@18.2.0)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -8958,8 +8957,8 @@ packages:
       - scheduler
     dev: false
 
-  /@uiw/codemirror-extensions-basic-setup@4.21.21(@codemirror/autocomplete@6.12.0)(@codemirror/commands@6.3.3)(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.5)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-+0i9dPrRSa8Mf0CvyrMvnAhajnqwsP3IMRRlaHDRgsSGL8igc4z7MhvUPn+7cWFAAqWzQRhMdMSWzo6/TEa3EA==}
+  /@uiw/codemirror-extensions-basic-setup@4.21.22(@codemirror/autocomplete@6.12.0)(@codemirror/commands@6.3.3)(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.6)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-Lxq2EitQb/MwbNrMHBmVdSIR96WmaICnYBYeZbLUxmr4kQcbrA6HXqNSNZJ0V4ZihPfKnNs9+g87QK0HsadE6A==}
     peerDependencies:
       '@codemirror/autocomplete': '>=6.0.0'
       '@codemirror/commands': '>=6.0.0'
@@ -8969,47 +8968,47 @@ packages:
       '@codemirror/state': '>=6.0.0'
       '@codemirror/view': '>=6.0.0'
     dependencies:
-      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)
       '@codemirror/commands': 6.3.3
       '@codemirror/language': 6.10.1
       '@codemirror/lint': 6.5.0
-      '@codemirror/search': 6.5.5
+      '@codemirror/search': 6.5.6
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.24.0
     dev: false
 
-  /@uiw/codemirror-extensions-langs@4.21.21(@codemirror/autocomplete@6.12.0)(@codemirror/language-data@6.4.0)(@codemirror/language@6.10.1)(@codemirror/legacy-modes@6.3.3)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/javascript@1.4.13)(@lezer/lr@1.4.0):
-    resolution: {integrity: sha512-h08pw2NeGLDgBiY8Ju5GNjfVzq1f6+wc0uPdqN5tkYBaKmByyKI10l5Gds7wBPzFH0uZlevP+Jyf9oSTcula5Q==}
+  /@uiw/codemirror-extensions-langs@4.21.22(@codemirror/autocomplete@6.12.0)(@codemirror/language-data@6.4.1)(@codemirror/language@6.10.1)(@codemirror/legacy-modes@6.3.3)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/javascript@1.4.13)(@lezer/lr@1.4.0):
+    resolution: {integrity: sha512-1yY5ruwjCShF7Qx1t22lkjxHRXE1DTsY4ecNggA4O5ZKzw/MA/rfVtnQIavs6BZ/m+yBiqyuOa8OW5h4YU5siQ==}
     peerDependencies:
       '@codemirror/language-data': '>=6.0.0'
       '@codemirror/legacy-modes': '>=6.0.0'
     dependencies:
       '@codemirror/lang-angular': 0.1.3
       '@codemirror/lang-cpp': 6.0.2
-      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.23.1)
+      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.24.0)
       '@codemirror/lang-html': 6.4.8
       '@codemirror/lang-java': 6.0.1
       '@codemirror/lang-javascript': 6.2.1
       '@codemirror/lang-json': 6.0.1
-      '@codemirror/lang-less': 6.0.2(@codemirror/view@6.23.1)
+      '@codemirror/lang-less': 6.0.2(@codemirror/view@6.24.0)
       '@codemirror/lang-lezer': 6.0.1
       '@codemirror/lang-liquid': 6.2.1
       '@codemirror/lang-markdown': 6.2.4
       '@codemirror/lang-php': 6.0.1
-      '@codemirror/lang-python': 6.1.4(@codemirror/view@6.23.1)
+      '@codemirror/lang-python': 6.1.4(@codemirror/view@6.24.0)
       '@codemirror/lang-rust': 6.0.1
-      '@codemirror/lang-sass': 6.0.2(@codemirror/view@6.23.1)
-      '@codemirror/lang-sql': 6.5.5(@codemirror/view@6.23.1)
+      '@codemirror/lang-sass': 6.0.2(@codemirror/view@6.24.0)
+      '@codemirror/lang-sql': 6.5.5(@codemirror/view@6.24.0)
       '@codemirror/lang-vue': 0.1.3
       '@codemirror/lang-wast': 6.0.2
-      '@codemirror/lang-xml': 6.0.2(@codemirror/view@6.23.1)
-      '@codemirror/language-data': 6.4.0(@codemirror/view@6.23.1)
+      '@codemirror/lang-xml': 6.0.2(@codemirror/view@6.24.0)
+      '@codemirror/language-data': 6.4.1(@codemirror/view@6.24.0)
       '@codemirror/legacy-modes': 6.3.3
       '@nextjournal/lang-clojure': 1.0.0
-      '@replit/codemirror-lang-csharp': 6.2.0(@codemirror/autocomplete@6.12.0)(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/lr@1.4.0)
-      '@replit/codemirror-lang-nix': 6.0.1(@codemirror/autocomplete@6.12.0)(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/lr@1.4.0)
+      '@replit/codemirror-lang-csharp': 6.2.0(@codemirror/autocomplete@6.12.0)(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/lr@1.4.0)
+      '@replit/codemirror-lang-nix': 6.0.1(@codemirror/autocomplete@6.12.0)(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/lr@1.4.0)
       '@replit/codemirror-lang-solidity': 6.0.2(@codemirror/language@6.10.1)
-      '@replit/codemirror-lang-svelte': 6.0.0(@codemirror/autocomplete@6.12.0)(@codemirror/lang-css@6.2.1)(@codemirror/lang-html@6.4.8)(@codemirror/lang-javascript@6.2.1)(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/javascript@1.4.13)(@lezer/lr@1.4.0)
+      '@replit/codemirror-lang-svelte': 6.0.0(@codemirror/autocomplete@6.12.0)(@codemirror/lang-css@6.2.1)(@codemirror/lang-html@6.4.8)(@codemirror/lang-javascript@6.2.1)(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/javascript@1.4.13)(@lezer/lr@1.4.0)
       codemirror-lang-mermaid: 0.5.0
     transitivePeerDependencies:
       - '@codemirror/autocomplete'
@@ -9022,392 +9021,403 @@ packages:
       - '@lezer/lr'
     dev: false
 
-  /@uiw/codemirror-theme-abcdef@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-5gHVFyrcOC6ejQeNz7eoSXq46ODYnjFHX8VIzs5Z8oqVqOKIkquI6jL3frP2jN2wdm9EEwa1w4W1zX4nyag9Tg==}
+  /@uiw/codemirror-theme-abcdef@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-8I+RPq9lUaveCtAM+fR5ANWS6y5mvIsJOrOcxrA37QSmOMC5qWfjEy8AMkDHyStx8hNe5urJ5SOIO/ZyzPOfIA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-abyss@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-/I9BI9tfhGgHv0TY0x9NQAdimR+ztipS35bxY+49GnGzKTzdY8D4CvYnk7UHQ2Mu0z4LMk0t9B4uh6R0pJ2rrA==}
+  /@uiw/codemirror-theme-abyss@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-VTZi5UDvp6Ub5GfuTzVBOfetzpWDXo0RxK+Td/QZfGaRkvwZICbGgGGJjqpitA/3dVdPOZ+C4Wdk/8I4uCRNtQ==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-androidstudio@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-ehd7ZGFO9a6WGUi0lKH0pQ7I7bSLXo4mdeDGzgI4boyOx3PGXAmtiy6TJZuNejyPiCs4WVmb2KVBQLYM0dBbkw==}
+  /@uiw/codemirror-theme-androidstudio@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-ImfX/krtnX0tOm/uf4XbTbxkZnDvM5by2pVM1IQpiy26FLUmylKjq3GyuKEMw4rerr8ndd9ezc+e+PLZPrvycg==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-andromeda@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-4iDbO6CQqVm+nK+3Fq0rsUmyOT8gqA05zMCWDAva/mJ+N3AzFCkygDyq87qSZw1kO3u6weThdNxqoukhyIT8Gg==}
+  /@uiw/codemirror-theme-andromeda@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-wHB+WE54Fy9mTE6B1B3jRA3DGRE7k3AhVfVB3KNUxy6pliklvkKnrMF2z+kbe1oHqz1mmlZxmiqc5X1j77egbA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-atomone@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-dtbbcLsw6boCxo77H7tJwBv1xgyxwMa5R50/ay5cuBV2MnruE6nCEn0NKgyF5dXf3RN1Hn5Z+rEZOMbkbnAqHA==}
+  /@uiw/codemirror-theme-atomone@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-OlrlMcEYDqRQMjXNIQklUyppNt2IvroIR/jRamNg5wq9M0KoprJyxhACY1NZbaKXEfvO/KUeFBIWxEpmnftkGA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-aura@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-Pa/tEB7+KMmWsgeJtlKkRrqWT1/oB1Vdi9xk+9zFuzuaV8XauZPloXYaHv+K7n7XUTKOECS5Yw+BCULKtnqJNQ==}
+  /@uiw/codemirror-theme-aura@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-8te279BfHYwpH+K0cLqt/aaYAwbC+k8ucRitmtoCOjbi5VSMdUKD9pb3Pr4QtrDzpkprhW5Jug3nNkdZDN4Y5Q==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-basic@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-xWDxch2Gkltsj5GTKmRoRga2fe+tw2a2mIIJARHWM5oyE3FfAF8J8Tgx4acaU6hlXRgQa4qPLaYA5kK43yj1hg==}
+  /@uiw/codemirror-theme-basic@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-HillAFFqra1i+XnHA17Y6Od4dFuqMel2uoZ9BBz5wGvpI5msk7I6qH2pKQ14/wPMNYC0JsJ1zP2DnZN5TYctKA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-bbedit@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-EH5fGyU3oepRLhVwPdqaShIgypPUG3FbwxB7cqH3TgGlDUIQtCK9u5MFo0br84kE+ZXIqqphlOb9d/5gawDVRw==}
+  /@uiw/codemirror-theme-bbedit@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-OQEZfO36pMSg2EFl2pD2HHrQXbiXqcTaLtbGQ78MHiZ6OqvGDkQ0djqf/n4/1e6P76EczHYiMdD5TKphblVbLA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-bespin@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-iQ5l4GaR9i43Nez3ZB94qwBUhLMfL5t95gKc+s0as20eprFpMO3XeHf4lcxcXZCqWV0OKYp+0OGmq0d9ugYQHg==}
+  /@uiw/codemirror-theme-bespin@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-mdWB76nvX/xqbodQzr4cVEXXlJRSokSyoFHei/tICaCyt6U6zJ0WA9Wem1ObGpgobW+nS70Ys0SrQHtKJWU2pg==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-copilot@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-1AhVILVqnczOEsn2vKU6GF7Ka+/hU0kPgwx0nkHrhjg5en0Bjz7YRglG/iVLr31A7CxvAR6csmdABqdjVxV5ng==}
+  /@uiw/codemirror-theme-console@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-5rRNWbqdchAK2Buxt5+fx7Tbiu9aIuXfngvH8xGcQNRg45idARivb748fpSiFbWTkRCwJjR0XRDsLiUBXKn9fA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-darcula@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-Dycs92ET0SZ5G9SblpYSmQDqQvD1jHgp4Sn3r1rlonkR/gcX0T7kEaNTLKI4EDG4E7WJYizHkRkKSR7gusqTFQ==}
+  /@uiw/codemirror-theme-copilot@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-Ws6l2mKyWFhELAAehTJ4eThkaI75WFTlnowUY5KcsXrJ8RTcbZRvflE1KDgey/YL40IkjVKdqd+OfpIpGYBi+Q==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-dracula@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-7NAznBZ/DgRuc8FOMmRRI7NAZv4RgARVX86b9MYxU4HcINgGrk+tnJCxOVwJbAyQQ/LjsFLzNLIK23HrjM5AtA==}
+  /@uiw/codemirror-theme-darcula@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-NMX16uOh5QAt0hXIUWWCuWNj2W1EXGieEEmbWYgz1uauEESp7GLe9u7dvNrilkaVfsoBMKm40TWQXhK1k+pT4Q==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-duotone@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-RiJDUMIR9B8/fxs5g7WqCC1Sryv845ypoeoJjTNVCtb6m6e4jX+hDZXFpvkXyy4q1nT/3KNBKYsWT/x3VIV30g==}
+  /@uiw/codemirror-theme-dracula@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-anNraklIvSvlvuAowDKlqmhdjwNXL73lMEkoart3g2vwKzw65CNSc2B+sxaA535YFUyhj0p+OMw0N/7AgbqOyg==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-eclipse@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-Dp5j4mFPH8UOoH37b2Wc45khNGcyusCDbfRw0jeBAGW258xH4UbHBlEIY+1/z4bloIfoguCyE3nPQnsa/M59Qg==}
+  /@uiw/codemirror-theme-duotone@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-xv/l5g/Ar6jrWYV2OEXUWH6U0Bje3tL/iyQYlwdElMnaz+CzQCHMkPRAoWE2w6NYZm5PZAM8DS3cwsWfZ2Kg5Q==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-github@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-msrpNrKk/CZQHk58TshI8aH7FpEyL404m/vWlGUdL2jGW7IRKm0nXn1lXXQ/snzk65h88GO6u9fiiv0pxRuZfQ==}
+  /@uiw/codemirror-theme-eclipse@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-CizcwzegkuwX6eBSP8s/7q+Yh3F13okHhKaIwQtLFLjDrrU/rCOgIx9QGamOBU5HlcuHtolotn/hqG6VsA/SUg==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-gruvbox-dark@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-Igebc4v8nmfdH+vjx16nbDsj3+zxvTGkYzfvdqJ19mNSXwOwRbjTvfdsMHR24/5rtiE98JGr40kfXilmuzSiTg==}
+  /@uiw/codemirror-theme-github@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-tCfeA2LXA1sseBccxnCoCJQfekU0J8Se/47UkqoiqIwdXwOr92s4oNTk7y9XWH06Pq+N1KETfjlw0ztNxbNmFA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-kimbie@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-dhWqIz1nsFzqoe5U3jIPeCJ9/c534YMmsGvNq3JJgRjD/KZeV8TSOJfuJNxI6jCskXh149Z5wghKE+FnNp/eUA==}
+  /@uiw/codemirror-theme-gruvbox-dark@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-jIhRYK1XMfztYtA6M9boUNTMeQUz2LYmnlqhorIuB2iI6esbJIua4CBjSWoKgDN47i96V9ZEYjO9ukNkNXImPg==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-material@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-Xdd2uI7kdKCD7xbgNhOjL7ksZsw8D+nw66QXAvyLUaBBGOFmObV7yJhCU7DGx9yAHO4eRMz6eRMuSolNnidgsg==}
+  /@uiw/codemirror-theme-kimbie@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-GkCebXPHlT3qJ8gqa4ShT/Qv3J/IbXlZ5HBsVRfj+tRBCXP+hU/SYh+1aCTFPof6pQ1lSbiys5k0BlsWuA+SLw==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-monokai-dimmed@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-+L/fJiTEgJqsukLtTOIo3x+Jk7tS1OmHrr6+6p+bA37NiTGkG1hxpOKvM0UINPFN0zyuvNHGQodW7NacvgxYWA==}
+  /@uiw/codemirror-theme-material@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-gsJRJaTMrGg4ge1RZnRMBGlvjseHvVikXyqTqUbiXD0Esn1D6tc+8F+hkn1UvbBLf4DPyr4UJnjiBMZR+Sn5og==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-monokai@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-ztPj09vlBhkAxF6Ns1iXMFnTUlvmMGs6y0empFXffKV9QnErcCjUsvaOiqzNkmn9RiRR+mAjqN4oMimtmchP8A==}
+  /@uiw/codemirror-theme-monokai-dimmed@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-DbPF9IlBgn89V8Z138hPgQ/OjH66PZiuOdqIEFyYSiEqCKz/iqmTnMTEU0DCyges230Mg77sKKQoSqsGBgchJw==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-noctis-lilac@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-k2QjlufmV6aGlkafTFqtAr2IsfZ0s8KzZfeDIFqBCjpRT+DRuVFYgu/IlPVK8uPNneLe1Hzr5IAH+X8rd7LUsw==}
+  /@uiw/codemirror-theme-monokai@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-hfuS5O0LBdpoG4sM10uyFdwdLVEp3InczSRiaK5q45EBFvsy7amAsRib47V4e466qOSilZJfaUB3969j+sVBnQ==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-nord@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-VOTWCPbkZjxPE5FZUp/WYgKXELZ0LNnfRwBz6iPAD3u4dVXfnGzHDIzVx406R0SaJ8MO42zAoee7PQiRFRsMBw==}
+  /@uiw/codemirror-theme-noctis-lilac@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-vXgcaqjQUmM0Qd2SdpEUG/xYQLP1Yw4hKRMm37ODv3nsZpTLbku54cMu7R3oMUXLW2IXLs6pbio1/fPqTr7J5A==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-okaidia@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-jZQ3YV+taTroqGmnAnFwU1uhAc+BZmuN1vjOJ9of7b6nmav1cohd8pdinZgDLag/ZrJt6TVr/KYBH8NF1Sm//g==}
+  /@uiw/codemirror-theme-nord@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-guFrL32ksumJWlU5wWqRwRTBnLJ/J85/zDqhkjNyCJbls4Sd9brK+/jaKC2BR6sSieCmD9Ea8uo6if8NYvrFDw==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-quietlight@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-s1QZXCpsT8+6NMMl3es1OWC6x50AaoXiEfwJdahpV37MqLUuMgYSf2/QLidgmQ0CL/ygsiO2wPbkSz004uKQtw==}
+  /@uiw/codemirror-theme-okaidia@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-8IBKHQX5XNNlRF72iMhjGn2Wd9gg6psCFdOzoMB3zAxY0KD9PWftLtEl11yy1jFr6wzRpxGCHY95og0Ka+F1Aw==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-red@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-IaOMm4O7pCbJ+iJe2lOq2ZzO+2tsZ5E7jSvF7t2IWyMiANswlQpcdea0yATr2xm54GyB/gNRU9D3t7jpwn8sew==}
+  /@uiw/codemirror-theme-quietlight@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-akEE2O9hTp/FMqg4IuXv5zGqX8sbl9lrkKDqbV6jwPtFk62mWBmcx+I2LejENqpOLkAIXtaGdbkcuf34tgjr0g==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-solarized@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-L+KSl9v6Lzt1Tt4A6jhGlMuDL09Iwnjyn05i17JhsuofSMcH5RVeb7YPO1iqBBRh9uLMVzvjL8vbItXjS9DeSg==}
+  /@uiw/codemirror-theme-red@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-x3wN5Vw7C+Z7Yv+4ZMPa8XiNVzJJ3dkjde+n8eULdXtAxivhzqd4yYRhvi8NkcYjBanakUtNMZxHG3vHAd2GnQ==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-sublime@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-wqr+1NFM1VjfCglB/AhgwJXmRCwo8/1rrdkIzhOTrD2AXqmOyppt9hAtvN2h+OA2OBkhqH90dco1aNJUQKcTuw==}
+  /@uiw/codemirror-theme-solarized@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-YvgVzyU8S1mNT7V7dLC8CdhZsurXTn6xDcn8t/CgFwa9g7zPJULYT3+/oB2hwid7jHFZhxn1f9QpVkVasHXjzw==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-tokyo-night-day@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-2HknKZdadg2wZ93rC0SrhR4Z4AJiKI/HGLQDF5XheMoxXeX/7bta/6Dblw3zGJmfoESNtRGBU3pHGiAgT6MjNw==}
+  /@uiw/codemirror-theme-sublime@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-IQKKX7dwJGxxkWJSJEmVJAokCah8LMWlelYPNM+rfpBRqAv0i+HvIYKTJjO6r5sqNkoR3w9fIjoyhBtXq1V1Hw==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-tokyo-night-storm@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-LJK/bR/jTt2PEJthnHu3feDwh+NYrCKE8SL4sp4iKZ12WRJh5/jmLY1EiPtPf9tWpK2SGhr9aJ3yLS5nQ0vrrw==}
+  /@uiw/codemirror-theme-tokyo-night-day@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-QMN7yak7Apvw9CXVEKNGYYLNmZUesiSMeYRCqkKTt5TOygEDT4oWW2tJX8WNyODSJZUihUqPbTvRufBUepPN6w==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-tokyo-night@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-zkQct/hRZdmcyjtwQvsqz9VsUB4V/MmlkSTbYhBsP4ZZKhkxYOdr0nDhNMXPbo8h6nWxvkUvre0NjM1GcMwBtg==}
+  /@uiw/codemirror-theme-tokyo-night-storm@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-gOSOI3Hrz8xjuUad/WPaAlb0y6b+ca2MKZ46gHa5ZA/jlqpKGTVcU3xgMr09Bjg546IbvM4XiKSgq3ojml4djg==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-tomorrow-night-blue@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-Ubg/3/+ED8uNC6RR3hCri23Re0BFYjagZbqy1/YT1p1Bx/4BooDlv4hbxw7nORnXxfQtnPq9gGc1ZJFFQXF1ww==}
+  /@uiw/codemirror-theme-tokyo-night@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-yaWelCqmOksuAbl8oYXjP/LqTj6KW2c7g9V9kL6NIb5LAnGr9DRFM3FKPpdylB4Ifx+e4QkcQBmY9/kSuPtf+g==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-vscode@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-NUD2l/PqnvzNtxscXk99hm5a5avFsE4lxG2MUtPRuOZRRNXHxNsYeXGlab6R5hUO+v/Lxy6mrMmTRyL0Gj6dIw==}
+  /@uiw/codemirror-theme-tomorrow-night-blue@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-qDnskMEfhPxBG2Bb78XyxTUthhA99XQznCYo8ktX21XQFInn5NeWPQDk/eja3v4db8l8ymp1XvP0P7HuZO86pg==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-white@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-nX4iuiZXPkR0WaNelaLpx6JAcPQ1TPoMoeYEDV8XSbMvlBZgHAgFwi2KSIexwSG5Fihywpv+mkusAPrOHNF3zw==}
+  /@uiw/codemirror-theme-vscode@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-8E7txA1IFCB+a38tovL7ZoKLC1mDfA3X83XYU+KQoaxyPzImm8aJLVDghHH8EUF0gOdJWPSW13OPVAGCayBKCA==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-theme-xcode@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-nmzqZ0v5GNWzAQSh0vgAN6XZ+OXeJpHn73fNfMiWzo4ZHzO1ZB5DAFRs8TJYdl6IXkp1RAcxIZ6OdmZ8tXF1CA==}
+  /@uiw/codemirror-theme-white@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-I+uBUBYX6wJbmu5QkU75JiUQ+qWT25XvPFvWXQE7KHLRt/3/P3/ptXWcO5vTRxRov3+8/tp5hfbSC4zvzJesEg==}
     dependencies:
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-themes-all@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-rwJB/pNBLutpQ2hPWV50FoaFv7eh8GEyK+2NIPY3SKiNAiJLWtXp3yN73Re3jY0XxOdTyi9jPnvCXJLGrxrxXw==}
+  /@uiw/codemirror-theme-xcode@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-VmLMMKrE1wInBPixuzC6RdcLnrRxPUWTVnMpmt3CR1Y8jQqur2eZZ1XAsaRgIqIqa7y0EO0nvpnMav6L8QYCfQ==}
     dependencies:
-      '@uiw/codemirror-theme-abcdef': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-abyss': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-androidstudio': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-andromeda': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-atomone': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-aura': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-basic': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-bbedit': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-bespin': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-copilot': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-darcula': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-dracula': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-duotone': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-eclipse': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-github': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-gruvbox-dark': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-kimbie': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-material': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-monokai': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-monokai-dimmed': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-noctis-lilac': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-nord': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-okaidia': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-quietlight': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-red': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-solarized': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-sublime': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-tokyo-night': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-tokyo-night-day': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-tokyo-night-storm': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-tomorrow-night-blue': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-vscode': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-white': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-theme-xcode': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
-      '@uiw/codemirror-themes': 4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
     dev: false
 
-  /@uiw/codemirror-themes@4.21.21(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1):
-    resolution: {integrity: sha512-ljVcMGdaxo75UaH+EqxJ+jLyMVVgeSfW2AKyT1VeLy+4SDpuqNQ7wq5XVxktsG6LH+OvgSFndWXgPANf4+gQcA==}
+  /@uiw/codemirror-themes-all@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-6PvBAuBc2PjTeJ+eju7DWYdNRoNc3z63+efo4fRvVsV5U42VqdYRmNGThfb+Wi2E5oGdGYb3wNt8r7efDIV3Kw==}
+    dependencies:
+      '@uiw/codemirror-theme-abcdef': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-abyss': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-androidstudio': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-andromeda': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-atomone': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-aura': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-basic': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-bbedit': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-bespin': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-console': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-copilot': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-darcula': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-dracula': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-duotone': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-eclipse': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-github': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-gruvbox-dark': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-kimbie': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-material': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-monokai': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-monokai-dimmed': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-noctis-lilac': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-nord': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-okaidia': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-quietlight': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-red': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-solarized': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-sublime': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-tokyo-night': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-tokyo-night-day': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-tokyo-night-storm': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-tomorrow-night-blue': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-vscode': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-white': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-theme-xcode': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+      '@uiw/codemirror-themes': 4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
+    dev: false
+
+  /@uiw/codemirror-themes@4.21.22(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0):
+    resolution: {integrity: sha512-oRMNtDmD6ER0EH2/NKGbrUzeRJbZ/4+GE3/9OItaAGhdsd2V33WGqVX7QwXsjLNhpNfscbVKB3PYLyRooBdlfg==}
     peerDependencies:
       '@codemirror/language': '>=6.0.0'
       '@codemirror/state': '>=6.0.0'
@@ -9415,11 +9425,11 @@ packages:
     dependencies:
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.24.0
     dev: false
 
-  /@uiw/react-codemirror@4.21.21(@babel/runtime@7.23.9)(@codemirror/autocomplete@6.12.0)(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.5)(@codemirror/state@6.4.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.23.1)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-PaxBMarufMWoR0qc5zuvBSt76rJ9POm9qoOaJbqRmnNL2viaF+d+Paf2blPSlm1JSnqn7hlRjio+40nZJ9TKzw==}
+  /@uiw/react-codemirror@4.21.22(@babel/runtime@7.23.9)(@codemirror/autocomplete@6.12.0)(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.6)(@codemirror/state@6.4.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.24.0)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-VmxU9oRXwcleG2u5Ui2xVXaLVPL8cBuRN3vA41hlu4OQ/ftJb+4p+dBd6bZ+NJKSXm3LufbPGzu8oKwNO4tG4A==}
     peerDependencies:
       '@babel/runtime': '>=7.11.0'
       '@codemirror/state': '>=6.0.0'
@@ -9433,8 +9443,8 @@ packages:
       '@codemirror/commands': 6.3.3
       '@codemirror/state': 6.4.0
       '@codemirror/theme-one-dark': 6.1.2
-      '@codemirror/view': 6.23.1
-      '@uiw/codemirror-extensions-basic-setup': 4.21.21(@codemirror/autocomplete@6.12.0)(@codemirror/commands@6.3.3)(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.5)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)
+      '@codemirror/view': 6.24.0
+      '@uiw/codemirror-extensions-basic-setup': 4.21.22(@codemirror/autocomplete@6.12.0)(@codemirror/commands@6.3.3)(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.6)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)
       codemirror: 6.0.1(@lezer/common@1.2.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -9460,43 +9470,43 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.9)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 4.5.2(@types/node@20.11.16)
+      vite: 4.5.2(@types/node@20.11.19)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@vitest/expect@1.2.2:
-    resolution: {integrity: sha512-3jpcdPAD7LwHUUiT2pZTj2U82I2Tcgg2oVPvKxhn6mDI2On6tfvPQTjAI4628GUGDZrCm4Zna9iQHm5cEexOAg==}
+  /@vitest/expect@1.3.0:
+    resolution: {integrity: sha512-7bWt0vBTZj08B+Ikv70AnLRicohYwFgzNjFqo9SxxqHHxSlUJGSXmCRORhOnRMisiUryKMdvsi1n27Bc6jL9DQ==}
     dependencies:
-      '@vitest/spy': 1.2.2
-      '@vitest/utils': 1.2.2
+      '@vitest/spy': 1.3.0
+      '@vitest/utils': 1.3.0
       chai: 4.4.1
     dev: true
 
-  /@vitest/runner@1.2.2:
-    resolution: {integrity: sha512-JctG7QZ4LSDXr5CsUweFgcpEvrcxOV1Gft7uHrvkQ+fsAVylmWQvnaAr/HDp3LAH1fztGMQZugIheTWjaGzYIg==}
+  /@vitest/runner@1.3.0:
+    resolution: {integrity: sha512-1Jb15Vo/Oy7mwZ5bXi7zbgszsdIBNjc4IqP8Jpr/8RdBC4nF1CTzIAn2dxYvpF1nGSseeL39lfLQ2uvs5u1Y9A==}
     dependencies:
-      '@vitest/utils': 1.2.2
+      '@vitest/utils': 1.3.0
       p-limit: 5.0.0
       pathe: 1.1.2
     dev: true
 
-  /@vitest/snapshot@1.2.2:
-    resolution: {integrity: sha512-SmGY4saEw1+bwE1th6S/cZmPxz/Q4JWsl7LvbQIky2tKE35US4gd0Mjzqfr84/4OD0tikGWaWdMja/nWL5NIPA==}
+  /@vitest/snapshot@1.3.0:
+    resolution: {integrity: sha512-swmktcviVVPYx9U4SEQXLV6AEY51Y6bZ14jA2yo6TgMxQ3h+ZYiO0YhAHGJNp0ohCFbPAis1R9kK0cvN6lDPQA==}
     dependencies:
-      magic-string: 0.30.6
+      magic-string: 0.30.7
       pathe: 1.1.2
       pretty-format: 29.7.0
     dev: true
 
-  /@vitest/spy@1.2.2:
-    resolution: {integrity: sha512-k9Gcahssw8d7X3pSLq3e3XEu/0L78mUkCjivUqCQeXJm9clfXR/Td8+AP+VC1O6fKPIDLcHDTAmBOINVuv6+7g==}
+  /@vitest/spy@1.3.0:
+    resolution: {integrity: sha512-AkCU0ThZunMvblDpPKgjIi025UxR8V7MZ/g/EwmAGpjIujLVV2X6rGYGmxE2D4FJbAy0/ijdROHMWa2M/6JVMw==}
     dependencies:
-      tinyspy: 2.2.0
+      tinyspy: 2.2.1
     dev: true
 
-  /@vitest/utils@1.2.2:
-    resolution: {integrity: sha512-WKITBHLsBHlpjnDQahr+XK6RE7MiAsgrIkr0pGhQ9ygoxBfUeG0lUG5iLlzqjmKSlBv3+j5EGsriBzh+C3Tq9g==}
+  /@vitest/utils@1.3.0:
+    resolution: {integrity: sha512-/LibEY/fkaXQufi4GDlQZhikQsPO2entBKtfuyIpr1jV4DpaeasqkeHjhdOhU24vSHshcSuEyVlWdzvv2XmYCw==}
     dependencies:
       diff-sequences: 29.6.3
       estree-walker: 3.0.3
@@ -9523,21 +9533,21 @@ packages:
       path-browserify: 1.0.1
     dev: true
 
-  /@vue/compiler-core@3.4.15:
-    resolution: {integrity: sha512-XcJQVOaxTKCnth1vCxEChteGuwG6wqnUHxAm1DO3gCz0+uXKaJNx8/digSz4dLALCy8n2lKq24jSUs8segoqIw==}
+  /@vue/compiler-core@3.4.19:
+    resolution: {integrity: sha512-gj81785z0JNzRcU0Mq98E56e4ltO1yf8k5PQ+tV/7YHnbZkrM0fyFyuttnN8ngJZjbpofWE/m4qjKBiLl8Ju4w==}
     dependencies:
       '@babel/parser': 7.23.9
-      '@vue/shared': 3.4.15
+      '@vue/shared': 3.4.19
       entities: 4.5.0
       estree-walker: 2.0.2
       source-map-js: 1.0.2
     dev: true
 
-  /@vue/compiler-dom@3.4.15:
-    resolution: {integrity: sha512-wox0aasVV74zoXyblarOM3AZQz/Z+OunYcIHe1OsGclCHt8RsRm04DObjefaI82u6XDzv+qGWZ24tIsRAIi5MQ==}
+  /@vue/compiler-dom@3.4.19:
+    resolution: {integrity: sha512-vm6+cogWrshjqEHTzIDCp72DKtea8Ry/QVpQRYoyTIg9k7QZDX6D8+HGURjtmatfgM8xgCFtJJaOlCaRYRK3QA==}
     dependencies:
-      '@vue/compiler-core': 3.4.15
-      '@vue/shared': 3.4.15
+      '@vue/compiler-core': 3.4.19
+      '@vue/shared': 3.4.19
     dev: true
 
   /@vue/language-core@1.8.27(typescript@5.3.3):
@@ -9550,8 +9560,8 @@ packages:
     dependencies:
       '@volar/language-core': 1.11.1
       '@volar/source-map': 1.11.1
-      '@vue/compiler-dom': 3.4.15
-      '@vue/shared': 3.4.15
+      '@vue/compiler-dom': 3.4.19
+      '@vue/shared': 3.4.19
       computeds: 0.0.1
       minimatch: 9.0.3
       muggle-string: 0.3.1
@@ -9560,8 +9570,8 @@ packages:
       vue-template-compiler: 2.7.16
     dev: true
 
-  /@vue/shared@3.4.15:
-    resolution: {integrity: sha512-KzfPTxVaWfB+eGcGdbSf4CWdaXcGDqckoeXUh7SB3fZdEtzPCK2Vq9B/lRRL3yutax/LWITz+SwvgyOxz5V75g==}
+  /@vue/shared@3.4.19:
+    resolution: {integrity: sha512-/KliRRHMF6LoiThEy+4c1Z4KB/gbPrGjWwJR+crg2otgrf/egKzRaCPvJ51S5oetgsgXLfc4Rm5ZgrKHZrtMSw==}
     dev: true
 
   /@xmldom/xmldom@0.8.10:
@@ -9583,7 +9593,7 @@ packages:
       xstate: 4.28.1
     dev: false
 
-  /@xstate/react@1.6.3(@types/react@18.2.52)(react@18.2.0)(xstate@4.28.1):
+  /@xstate/react@1.6.3(@types/react@18.2.56)(react@18.2.0)(xstate@4.28.1):
     resolution: {integrity: sha512-NCUReRHPGvvCvj2yLZUTfR0qVp6+apc8G83oXSjN4rl89ZjyujiKrTff55bze/HrsvCsP/sUJASf2n0nzMF1KQ==}
     peerDependencies:
       '@xstate/fsm': ^1.0.0
@@ -9596,7 +9606,7 @@ packages:
         optional: true
     dependencies:
       react: 18.2.0
-      use-isomorphic-layout-effect: 1.1.2(@types/react@18.2.52)(react@18.2.0)
+      use-isomorphic-layout-effect: 1.1.2(@types/react@18.2.56)(react@18.2.0)
       use-subscription: 1.8.0(react@18.2.0)
       xstate: 4.28.1
     transitivePeerDependencies:
@@ -9801,7 +9811,7 @@ packages:
     resolution: {integrity: sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       is-array-buffer: 3.0.4
     dev: true
 
@@ -9809,10 +9819,10 @@ packages:
     resolution: {integrity: sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.22.3
-      get-intrinsic: 1.2.3
+      es-abstract: 1.22.4
+      get-intrinsic: 1.2.4
       is-string: 1.0.7
     dev: true
 
@@ -9825,9 +9835,9 @@ packages:
     resolution: {integrity: sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.22.3
+      es-abstract: 1.22.4
       es-shim-unscopables: 1.0.2
     dev: true
 
@@ -9835,31 +9845,32 @@ packages:
     resolution: {integrity: sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.22.3
+      es-abstract: 1.22.4
       es-shim-unscopables: 1.0.2
     dev: true
 
-  /array.prototype.tosorted@1.1.2:
-    resolution: {integrity: sha512-HuQCHOlk1Weat5jzStICBCd83NxiIMwqDg/dHEsoefabn/hJRj5pVdWcPUSpRrwhwxZOsQassMpgN/xRYFBMIg==}
+  /array.prototype.tosorted@1.1.3:
+    resolution: {integrity: sha512-/DdH4TiTmOKzyQbp/eadcCVexiCb36xJg7HshYOYJnNZFDj33GEv0P7GxsynpShhq4OLYJzbGcBDkLsDt7MnNg==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.22.3
+      es-abstract: 1.22.4
+      es-errors: 1.3.0
       es-shim-unscopables: 1.0.2
-      get-intrinsic: 1.2.3
     dev: true
 
-  /arraybuffer.prototype.slice@1.0.2:
-    resolution: {integrity: sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==}
+  /arraybuffer.prototype.slice@1.0.3:
+    resolution: {integrity: sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==}
     engines: {node: '>= 0.4'}
     dependencies:
       array-buffer-byte-length: 1.0.1
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.22.3
-      get-intrinsic: 1.2.3
+      es-abstract: 1.22.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.2.4
       is-array-buffer: 3.0.4
       is-shared-array-buffer: 1.0.2
     dev: true
@@ -9919,19 +9930,19 @@ packages:
       when-exit: 2.1.2
     dev: true
 
-  /autoprefixer@10.4.17(postcss@8.4.33):
+  /autoprefixer@10.4.17(postcss@8.4.35):
     resolution: {integrity: sha512-/cpVNRLSfhOtcGflT13P2794gVSgmPgTR+erw5ifnMLZb0UnSlkK4tquLmkd3BhA+nLo5tX8Cu0upUsGKvKbmg==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      browserslist: 4.22.3
-      caniuse-lite: 1.0.30001583
+      browserslist: 4.23.0
+      caniuse-lite: 1.0.30001588
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.0.0
-      postcss: 8.4.33
+      postcss: 8.4.35
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -9944,12 +9955,13 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /avvio@8.2.1:
-    resolution: {integrity: sha512-TAlMYvOuwGyLK3PfBb5WKBXZmXz2fVCgv23d6zZFdle/q3gPjmxBaeuC0pY0Dzs5PWMSgfqqEZkrye19GlDTgw==}
+  /avvio@8.3.0:
+    resolution: {integrity: sha512-VBVH0jubFr9LdFASy/vNtm5giTrnbVquWBhT0fyizuNK2rQ7e7ONU2plZQWUNqtE1EmxFEb+kbSkFRkstiaS9Q==}
     dependencies:
+      '@fastify/error': 3.4.1
       archy: 1.0.0
       debug: 4.3.4(supports-color@8.1.1)
-      fastq: 1.17.0
+      fastq: 1.17.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9973,8 +9985,8 @@ packages:
       dequal: 2.0.3
     dev: true
 
-  /b4a@1.6.4:
-    resolution: {integrity: sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==}
+  /b4a@1.6.6:
+    resolution: {integrity: sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==}
     dev: true
 
   /bail@1.0.5:
@@ -9987,6 +9999,12 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  /bare-events@2.2.0:
+    resolution: {integrity: sha512-Yyyqff4PIFfSuthCZqLlPISTWHmnQxoPuAvkmgzsJEmG3CesdIv6Xweayl0JkCZJSB2yYIdJyEz97tpxNhgjbg==}
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -10051,15 +10069,15 @@ packages:
     dependencies:
       fill-range: 7.0.1
 
-  /browserslist@4.22.3:
-    resolution: {integrity: sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==}
+  /browserslist@4.23.0:
+    resolution: {integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001583
-      electron-to-chromium: 1.4.656
+      caniuse-lite: 1.0.30001588
+      electron-to-chromium: 1.4.673
       node-releases: 2.0.14
-      update-browserslist-db: 1.0.13(browserslist@4.22.3)
+      update-browserslist-db: 1.0.13(browserslist@4.23.0)
 
   /buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
@@ -10100,12 +10118,15 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /call-bind@1.0.5:
-    resolution: {integrity: sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==}
+  /call-bind@1.0.7:
+    resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
+    engines: {node: '>= 0.4'}
     dependencies:
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
       function-bind: 1.1.2
-      get-intrinsic: 1.2.3
-      set-function-length: 1.2.0
+      get-intrinsic: 1.2.4
+      set-function-length: 1.2.1
     dev: true
 
   /callsites@3.1.0:
@@ -10121,8 +10142,8 @@ packages:
     resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
     dev: false
 
-  /caniuse-lite@1.0.30001583:
-    resolution: {integrity: sha512-acWTYaha8xfhA/Du/z4sNZjHUWjkiuoAi2LM+T/aL+kemKQgPT1xBb/YKjlQ0Qo8gvbHsGNplrEJ+9G3gL7i4Q==}
+  /caniuse-lite@1.0.30001588:
+    resolution: {integrity: sha512-+hVY9jE44uKLkH0SrUTqxjxqNTOWHsbnQDIKjwkZ3lNTzUUVdBLBGXtj/q5Mp5u98r3droaZAewQuEDzjQdZlQ==}
 
   /caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
@@ -10189,8 +10210,8 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /chokidar@3.5.3:
-    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+  /chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
     dependencies:
       anymatch: 3.1.3
@@ -10301,19 +10322,15 @@ packages:
   /codemirror@6.0.1(@lezer/common@1.2.1):
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
     dependencies:
-      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.23.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.0)(@codemirror/view@6.24.0)(@lezer/common@1.2.1)
       '@codemirror/commands': 6.3.3
       '@codemirror/language': 6.10.1
       '@codemirror/lint': 6.5.0
-      '@codemirror/search': 6.5.5
+      '@codemirror/search': 6.5.6
       '@codemirror/state': 6.4.0
-      '@codemirror/view': 6.23.1
+      '@codemirror/view': 6.24.0
     transitivePeerDependencies:
       - '@lezer/common'
-    dev: false
-
-  /codesandbox-import-util-types@2.2.3:
-    resolution: {integrity: sha512-Qj00p60oNExthP2oR3vvXmUGjukij+rxJGuiaKM6tyUmSyimdZsqHI/TUvFFClAffk9s7hxGnQgWQ8KCce27qQ==}
     dev: false
 
   /color-convert@1.9.3:
@@ -10403,7 +10420,7 @@ packages:
       dot-prop: 8.0.2
       env-paths: 3.0.0
       json-schema-typed: 8.0.1
-      semver: 7.5.4
+      semver: 7.6.0
       uint8array-extras: 0.3.0
     dev: true
 
@@ -10517,8 +10534,8 @@ packages:
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
-  /cypress-real-events@1.11.0(cypress@13.6.4):
-    resolution: {integrity: sha512-4LXVRsyq+xBh5TmlEyO1ojtBXtN7xw720Pwb9rEE9rkJuXmeH3VyoR1GGayMGr+Itqf11eEjfDewtDmcx6PWPQ==}
+  /cypress-real-events@1.12.0(cypress@13.6.4):
+    resolution: {integrity: sha512-oiy+4kGKkzc2PT36k3GGQqkGxNiVypheWjMtfyi89iIk6bYmTzeqxapaLHS3pnhZOX1IEbTDUVxh8T4Nhs1tyQ==}
     peerDependencies:
       cypress: ^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x
     dependencies:
@@ -10568,7 +10585,7 @@ packages:
       process: 0.11.10
       proxy-from-env: 1.0.0
       request-progress: 3.0.0
-      semver: 7.5.4
+      semver: 7.6.0
       supports-color: 8.1.1
       tmp: 0.2.1
       untildify: 4.0.0
@@ -10661,9 +10678,9 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       array-buffer-byte-length: 1.0.1
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       es-get-iterator: 1.1.3
-      get-intrinsic: 1.2.3
+      get-intrinsic: 1.2.4
       is-arguments: 1.1.1
       is-array-buffer: 3.0.4
       is-date-object: 1.0.5
@@ -10673,8 +10690,8 @@ packages:
       object-is: 1.1.5
       object-keys: 1.1.1
       object.assign: 4.1.5
-      regexp.prototype.flags: 1.5.1
-      side-channel: 1.0.4
+      regexp.prototype.flags: 1.5.2
+      side-channel: 1.0.5
       which-boxed-primitive: 1.0.2
       which-collection: 1.0.1
       which-typed-array: 1.1.14
@@ -10708,13 +10725,13 @@ packages:
       clone: 1.0.4
     dev: true
 
-  /define-data-property@1.1.1:
-    resolution: {integrity: sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==}
+  /define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.3
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
       gopd: 1.0.1
-      has-property-descriptors: 1.0.1
     dev: true
 
   /define-lazy-prop@3.0.0:
@@ -10726,8 +10743,8 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      define-data-property: 1.1.1
-      has-property-descriptors: 1.0.1
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
       object-keys: 1.1.1
     dev: true
 
@@ -10756,8 +10773,8 @@ packages:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
 
-  /diff@5.1.0:
-    resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
+  /diff@5.2.0:
+    resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
     engines: {node: '>=0.3.1'}
 
   /dir-glob@3.0.1:
@@ -10866,8 +10883,8 @@ packages:
       type-fest: 3.13.1
     dev: true
 
-  /dotenv@16.4.1:
-    resolution: {integrity: sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==}
+  /dotenv@16.4.4:
+    resolution: {integrity: sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg==}
     engines: {node: '>=12'}
     dev: false
 
@@ -10894,8 +10911,8 @@ packages:
       safer-buffer: 2.1.2
     dev: true
 
-  /electron-to-chromium@1.4.656:
-    resolution: {integrity: sha512-9AQB5eFTHyR3Gvt2t/NwR0le2jBSUNwCnMbUCejFWHD+so4tH40/dRLgoE+jxlPeWS43XJewyvCv+I8LPMl49Q==}
+  /electron-to-chromium@1.4.673:
+    resolution: {integrity: sha512-zjqzx4N7xGdl5468G+vcgzDhaHkaYgVcf9MqgexcTqsl2UHSCmOj/Bi3HAprg4BZCpC7HyD8a6nZl6QAZf72gw==}
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -10943,26 +10960,28 @@ packages:
       stackframe: 1.3.4
     dev: false
 
-  /es-abstract@1.22.3:
-    resolution: {integrity: sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==}
+  /es-abstract@1.22.4:
+    resolution: {integrity: sha512-vZYJlk2u6qHYxBOTjAeg7qUxHdNfih64Uu2J8QqWgXZ2cri0ZpJAkzDUK/q593+mvKwlxyaxr6F1Q+3LKoQRgg==}
     engines: {node: '>= 0.4'}
     dependencies:
       array-buffer-byte-length: 1.0.1
-      arraybuffer.prototype.slice: 1.0.2
+      arraybuffer.prototype.slice: 1.0.3
       available-typed-arrays: 1.0.6
-      call-bind: 1.0.5
+      call-bind: 1.0.7
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
       es-set-tostringtag: 2.0.2
       es-to-primitive: 1.2.1
       function.prototype.name: 1.1.6
-      get-intrinsic: 1.2.3
-      get-symbol-description: 1.0.0
+      get-intrinsic: 1.2.4
+      get-symbol-description: 1.0.2
       globalthis: 1.0.3
       gopd: 1.0.1
-      has-property-descriptors: 1.0.1
+      has-property-descriptors: 1.0.2
       has-proto: 1.0.1
       has-symbols: 1.0.3
-      hasown: 2.0.0
-      internal-slot: 1.0.6
+      hasown: 2.0.1
+      internal-slot: 1.0.7
       is-array-buffer: 3.0.4
       is-callable: 1.2.7
       is-negative-zero: 2.0.2
@@ -10974,30 +10993,37 @@ packages:
       object-inspect: 1.13.1
       object-keys: 1.1.1
       object.assign: 4.1.5
-      regexp.prototype.flags: 1.5.1
+      regexp.prototype.flags: 1.5.2
       safe-array-concat: 1.1.0
-      safe-regex-test: 1.0.2
+      safe-regex-test: 1.0.3
       string.prototype.trim: 1.2.8
       string.prototype.trimend: 1.0.7
       string.prototype.trimstart: 1.0.7
-      typed-array-buffer: 1.0.0
+      typed-array-buffer: 1.0.1
       typed-array-byte-length: 1.0.0
-      typed-array-byte-offset: 1.0.0
+      typed-array-byte-offset: 1.0.1
       typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
       which-typed-array: 1.1.14
     dev: true
 
-  /es-errors@1.0.0:
-    resolution: {integrity: sha512-yHV74THqMJUyFKkHyN7hyENcEZM3Dj2a2IrdClY+IT4BFQHkIVwlh8s6uZfjsFydMdNHv0F5mWgAA3ajFbsvVQ==}
+  /es-define-property@1.0.0:
+    resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      get-intrinsic: 1.2.4
+    dev: true
+
+  /es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
     dev: true
 
   /es-get-iterator@1.1.3:
     resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
     dependencies:
-      call-bind: 1.0.5
-      get-intrinsic: 1.2.3
+      call-bind: 1.0.7
+      get-intrinsic: 1.2.4
       has-symbols: 1.0.3
       is-arguments: 1.1.1
       is-map: 2.0.2
@@ -11007,21 +11033,23 @@ packages:
       stop-iteration-iterator: 1.0.0
     dev: true
 
-  /es-iterator-helpers@1.0.15:
-    resolution: {integrity: sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==}
+  /es-iterator-helpers@1.0.17:
+    resolution: {integrity: sha512-lh7BsUqelv4KUbR5a/ZTaGGIMLCjPGPqJ6q+Oq24YP0RdyptX1uzm4vvaqzk7Zx3bpl/76YLTTDj9L7uYQ92oQ==}
+    engines: {node: '>= 0.4'}
     dependencies:
       asynciterator.prototype: 1.0.0
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.22.3
+      es-abstract: 1.22.4
+      es-errors: 1.3.0
       es-set-tostringtag: 2.0.2
       function-bind: 1.1.2
-      get-intrinsic: 1.2.3
+      get-intrinsic: 1.2.4
       globalthis: 1.0.3
-      has-property-descriptors: 1.0.1
+      has-property-descriptors: 1.0.2
       has-proto: 1.0.1
       has-symbols: 1.0.3
-      internal-slot: 1.0.6
+      internal-slot: 1.0.7
       iterator.prototype: 1.1.2
       safe-array-concat: 1.1.0
     dev: true
@@ -11034,15 +11062,15 @@ packages:
     resolution: {integrity: sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.3
+      get-intrinsic: 1.2.4
       has-tostringtag: 1.0.2
-      hasown: 2.0.0
+      hasown: 2.0.1
     dev: true
 
   /es-shim-unscopables@1.0.2:
     resolution: {integrity: sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==}
     dependencies:
-      hasown: 2.0.0
+      hasown: 2.0.1
     dev: true
 
   /es-to-primitive@1.2.1:
@@ -11140,8 +11168,8 @@ packages:
       '@esbuild/win32-x64': 0.19.12
     dev: true
 
-  /escalade@3.1.1:
-    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
+  /escalade@3.1.2:
+    resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
     engines: {node: '>=6'}
 
   /escape-carriage@1.3.1:
@@ -11173,7 +11201,7 @@ packages:
       eslint: '>=6.0.0'
     dependencies:
       eslint: 8.56.0
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /eslint-config-prettier@8.10.0(eslint@8.56.0):
@@ -11233,9 +11261,9 @@ packages:
       axobject-query: 3.2.1
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      es-iterator-helpers: 1.0.15
+      es-iterator-helpers: 1.0.17
       eslint: 8.56.0
-      hasown: 2.0.0
+      hasown: 2.0.1
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
       minimatch: 3.1.2
@@ -11343,9 +11371,9 @@ packages:
     dependencies:
       array-includes: 3.1.7
       array.prototype.flatmap: 1.3.2
-      array.prototype.tosorted: 1.1.2
+      array.prototype.tosorted: 1.1.3
       doctrine: 2.1.0
-      es-iterator-helpers: 1.0.15
+      es-iterator-helpers: 1.0.17
       eslint: 8.56.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.5
@@ -11380,7 +11408,7 @@ packages:
       read-pkg-up: 7.0.1
       regexp-tree: 0.1.27
       regjsparser: 0.10.0
-      semver: 7.5.4
+      semver: 7.6.0
       strip-indent: 3.0.0
     dev: true
 
@@ -11666,10 +11694,10 @@ packages:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
     dev: true
 
-  /fast-json-stringify@5.11.1:
-    resolution: {integrity: sha512-Lrj3tmc/qI1OCmr0WJEJFC4TxnAdLnbZZ0CvFvHv/PHNieLCX12PNBlV9KGIDS08w49T8h7vkMuzNoB+3NyX0g==}
+  /fast-json-stringify@5.12.0:
+    resolution: {integrity: sha512-7Nnm9UPa7SfHRbHVA1kJQrGXCRzB7LMlAAqHXQFkEQqueJm1V8owm0FsE/2Do55/4CcdhwiLQERaKomOnKQkyA==}
     dependencies:
-      '@fastify/deepmerge': 1.3.0
+      '@fastify/merge-json-schemas': 0.1.1
       ajv: 8.12.0
       ajv-formats: 2.1.1(ajv@8.12.0)
       fast-deep-equal: 3.1.3
@@ -11713,31 +11741,31 @@ packages:
     resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
     dev: true
 
-  /fastify@4.26.0:
-    resolution: {integrity: sha512-Fq/7ziWKc6pYLYLIlCRaqJqEVTIZ5tZYfcW/mDK2AQ9v/sqjGFpj0On0/7hU50kbPVjLO4de+larPA1WwPZSfw==}
+  /fastify@4.26.1:
+    resolution: {integrity: sha512-tznA/G55dsxzM5XChBfcvVSloG2ejeeotfPPJSFaWmHyCDVGMpvf3nRNbsCb/JTBF9RmQFBfuujWt3Nphjesng==}
     dependencies:
       '@fastify/ajv-compiler': 3.5.0
       '@fastify/error': 3.4.1
       '@fastify/fast-json-stringify-compiler': 4.3.0
       abstract-logging: 2.0.1
-      avvio: 8.2.1
+      avvio: 8.3.0
       fast-content-type-parse: 1.1.0
-      fast-json-stringify: 5.11.1
+      fast-json-stringify: 5.12.0
       find-my-way: 8.1.0
       light-my-request: 5.11.0
-      pino: 8.18.0
+      pino: 8.19.0
       process-warning: 3.0.0
       proxy-addr: 2.0.7
       rfdc: 1.3.1
       secure-json-parse: 2.7.0
-      semver: 7.5.4
+      semver: 7.6.0
       toad-cache: 3.7.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /fastq@1.17.0:
-    resolution: {integrity: sha512-zGygtijUMT7jnk3h26kUms3BkSDp4IfIKjmnqI2tvx6nuBfiF1UqOxbnLfzdv+apBy+53oaImsKtMw/xYbW+1w==}
+  /fastq@1.17.1:
+    resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
     dependencies:
       reusify: 1.0.4
 
@@ -11752,7 +11780,7 @@ packages:
     engines: {node: ^12.20 || >= 14.13}
     dependencies:
       node-domexception: 1.0.0
-      web-streams-polyfill: 3.3.2
+      web-streams-polyfill: 3.3.3
     dev: true
 
   /figures@3.2.0:
@@ -11931,9 +11959,9 @@ packages:
     resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.22.3
+      es-abstract: 1.22.4
       functions-have-names: 1.2.3
     dev: true
 
@@ -11954,15 +11982,15 @@ packages:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
     dev: true
 
-  /get-intrinsic@1.2.3:
-    resolution: {integrity: sha512-JIcZczvcMVE7AUOP+X72bh8HqHBRxFdz5PDHYtNG/lE3yk9b3KZBJlwFcTyPYjg3L4RLLmZJzvjxhaZVapxFrQ==}
+  /get-intrinsic@1.2.4:
+    resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      es-errors: 1.0.0
+      es-errors: 1.3.0
       function-bind: 1.1.2
       has-proto: 1.0.1
       has-symbols: 1.0.3
-      hasown: 2.0.0
+      hasown: 2.0.1
     dev: true
 
   /get-nonce@1.0.1:
@@ -11987,12 +12015,13 @@ packages:
     engines: {node: '>=16'}
     dev: true
 
-  /get-symbol-description@1.0.0:
-    resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
+  /get-symbol-description@1.0.2:
+    resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
-      get-intrinsic: 1.2.3
+      call-bind: 1.0.7
+      es-errors: 1.3.0
+      get-intrinsic: 1.2.4
     dev: true
 
   /getos@3.2.1:
@@ -12096,7 +12125,7 @@ packages:
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
-      get-intrinsic: 1.2.3
+      get-intrinsic: 1.2.4
     dev: true
 
   /graceful-fs@4.2.11:
@@ -12124,10 +12153,10 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  /has-property-descriptors@1.0.1:
-    resolution: {integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==}
+  /has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
     dependencies:
-      get-intrinsic: 1.2.3
+      es-define-property: 1.0.0
     dev: true
 
   /has-proto@1.0.1:
@@ -12147,8 +12176,8 @@ packages:
       has-symbols: 1.0.3
     dev: true
 
-  /hasown@2.0.0:
-    resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
+  /hasown@2.0.1:
+    resolution: {integrity: sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==}
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
@@ -12308,13 +12337,13 @@ packages:
       wrap-ansi: 6.2.0
     dev: true
 
-  /internal-slot@1.0.6:
-    resolution: {integrity: sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==}
+  /internal-slot@1.0.7:
+    resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.3
-      hasown: 2.0.0
-      side-channel: 1.0.4
+      es-errors: 1.3.0
+      hasown: 2.0.1
+      side-channel: 1.0.5
     dev: true
 
   /intersection-observer@0.10.0:
@@ -12354,7 +12383,7 @@ packages:
     resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       has-tostringtag: 1.0.2
     dev: true
 
@@ -12362,8 +12391,8 @@ packages:
     resolution: {integrity: sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
-      get-intrinsic: 1.2.3
+      call-bind: 1.0.7
+      get-intrinsic: 1.2.4
     dev: true
 
   /is-arrayish@0.2.1:
@@ -12393,7 +12422,7 @@ packages:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       has-tostringtag: 1.0.2
     dev: true
 
@@ -12424,7 +12453,7 @@ packages:
   /is-core-module@2.13.1:
     resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
     dependencies:
-      hasown: 2.0.0
+      hasown: 2.0.1
 
   /is-date-object@1.0.5:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
@@ -12455,7 +12484,7 @@ packages:
   /is-finalizationregistry@1.0.2:
     resolution: {integrity: sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
     dev: true
 
   /is-fullwidth-code-point@3.0.0:
@@ -12555,7 +12584,7 @@ packages:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       has-tostringtag: 1.0.2
     dev: true
 
@@ -12566,7 +12595,7 @@ packages:
   /is-shared-array-buffer@1.0.2:
     resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
     dev: true
 
   /is-stream@2.0.1:
@@ -12616,14 +12645,14 @@ packages:
   /is-weakref@1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
     dev: true
 
   /is-weakset@2.0.2:
     resolution: {integrity: sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==}
     dependencies:
-      call-bind: 1.0.5
-      get-intrinsic: 1.2.3
+      call-bind: 1.0.7
+      get-intrinsic: 1.2.4
     dev: true
 
   /is-wsl@2.2.0:
@@ -12652,9 +12681,9 @@ packages:
     resolution: {integrity: sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==}
     dependencies:
       define-properties: 1.2.1
-      get-intrinsic: 1.2.3
+      get-intrinsic: 1.2.4
       has-symbols: 1.0.3
-      reflect.getprototypeof: 1.0.4
+      reflect.getprototypeof: 1.0.5
       set-function-name: 2.0.1
     dev: true
 
@@ -12729,6 +12758,10 @@ packages:
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  /js-tokens@8.0.3:
+    resolution: {integrity: sha512-UfJMcSJc+SEXEl9lH/VLHSZbThQyLpw1vLO1Lb+j4RWDvG3N2f7yj3PVQA3cmkTBNldJ9eFnM+xEXxHIXrYiJw==}
+    dev: true
 
   /js-video-url-parser@0.5.1:
     resolution: {integrity: sha512-/vwqT67k0AyIGMHAvSOt+n4JfrZWF7cPKgKswDO35yr27GfW4HtjpQVlTx6JLF45QuPm8mkzFHkZgFVnFm4x/w==}
@@ -12811,7 +12844,7 @@ packages:
       acorn: 8.11.3
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /jsonc-parser@3.2.1:
@@ -12918,8 +12951,8 @@ packages:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
 
-  /lilconfig@3.0.0:
-    resolution: {integrity: sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==}
+  /lilconfig@3.1.1:
+    resolution: {integrity: sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==}
     engines: {node: '>=14'}
 
   /lines-and-columns@1.2.4:
@@ -13056,8 +13089,8 @@ packages:
       sourcemap-codec: 1.4.8
     dev: true
 
-  /magic-string@0.30.6:
-    resolution: {integrity: sha512-n62qCLbPjNjyo+owKtveQxZFZTBm+Ms6YoGD23Wew6Vw337PElFNifQpknPruVRQV57kVShPnLGo9vWxVhpPvA==}
+  /magic-string@0.30.7:
+    resolution: {integrity: sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -13539,7 +13572,7 @@ packages:
       acorn: 8.11.3
       pathe: 1.1.2
       pkg-types: 1.0.3
-      ufo: 1.3.2
+      ufo: 1.4.0
     dev: true
 
   /mnemonist@0.39.6:
@@ -13577,7 +13610,7 @@ packages:
       '@types/cookie': 0.4.1
       '@types/js-levenshtein': 1.1.3
       chalk: 4.1.2
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       cookie: 0.4.2
       graphql: 16.8.1
       headers-polyfill: 3.2.5
@@ -13741,7 +13774,7 @@ packages:
     resolution: {integrity: sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
     dev: true
 
@@ -13754,7 +13787,7 @@ packages:
     resolution: {integrity: sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
       has-symbols: 1.0.3
       object-keys: 1.1.1
@@ -13764,34 +13797,34 @@ packages:
     resolution: {integrity: sha512-jCBs/0plmPsOnrKAfFQXRG2NFjlhZgjjcBLSmTnEhU8U6vVTsVe8ANeQJCHTl3gSsI4J+0emOoCgoKlmQPMgmA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.22.3
+      es-abstract: 1.22.4
     dev: true
 
   /object.fromentries@2.0.7:
     resolution: {integrity: sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.22.3
+      es-abstract: 1.22.4
     dev: true
 
   /object.hasown@1.1.3:
     resolution: {integrity: sha512-fFI4VcYpRHvSLXxP7yiZOMAd331cPfd2p7PFDVbgUsYOfCT3tICVqXWngbjr4m49OvsBwUBQ6O2uQoJvy3RexA==}
     dependencies:
       define-properties: 1.2.1
-      es-abstract: 1.22.3
+      es-abstract: 1.22.4
     dev: true
 
   /object.values@1.1.7:
     resolution: {integrity: sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.22.3
+      es-abstract: 1.22.4
     dev: true
 
   /obliterator@2.0.4:
@@ -14053,8 +14086,8 @@ packages:
     resolution: {integrity: sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==}
     dev: true
 
-  /pino@8.18.0:
-    resolution: {integrity: sha512-Mz/gKiRyuXu4HnpHgi1YWdHQCoWMufapzooisvFn78zl4dZciAxS+YeRkUxXl1ee/SzU80YCz1zpECCh4oC6Aw==}
+  /pino@8.19.0:
+    resolution: {integrity: sha512-oswmokxkav9bADfJ2ifrvfHUwad6MLp73Uat0IkQWY3iAw5xTRoznXbXksZs8oaOUMpmhVWD+PZogNzllWpJaA==}
     hasBin: true
     dependencies:
       atomic-sleep: 1.0.0
@@ -14087,27 +14120,27 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /postcss-import@15.1.0(postcss@8.4.33):
+  /postcss-import@15.1.0(postcss@8.4.35):
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
-      postcss: 8.4.33
+      postcss: 8.4.35
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.8
 
-  /postcss-js@4.0.1(postcss@8.4.33):
+  /postcss-js@4.0.1(postcss@8.4.35):
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
       postcss: ^8.4.21
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.33
+      postcss: 8.4.35
 
-  /postcss-load-config@4.0.2(postcss@8.4.33)(ts-node@10.9.2):
+  /postcss-load-config@4.0.2(postcss@8.4.35)(ts-node@10.9.2):
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
     peerDependencies:
@@ -14119,18 +14152,18 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      lilconfig: 3.0.0
-      postcss: 8.4.33
-      ts-node: 10.9.2(@types/node@20.11.16)(typescript@5.3.3)
+      lilconfig: 3.1.1
+      postcss: 8.4.35
+      ts-node: 10.9.2(@types/node@20.11.19)(typescript@5.3.3)
       yaml: 2.3.4
 
-  /postcss-nested@6.0.1(postcss@8.4.33):
+  /postcss-nested@6.0.1(postcss@8.4.35):
     resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
     dependencies:
-      postcss: 8.4.33
+      postcss: 8.4.35
       postcss-selector-parser: 6.0.15
 
   /postcss-selector-parser@6.0.15:
@@ -14152,8 +14185,8 @@ packages:
       source-map-js: 1.0.2
     dev: false
 
-  /postcss@8.4.33:
-    resolution: {integrity: sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==}
+  /postcss@8.4.35:
+    resolution: {integrity: sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.7
@@ -14274,7 +14307,7 @@ packages:
     resolution: {integrity: sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==}
     engines: {node: '>=0.6'}
     dependencies:
-      side-channel: 1.0.4
+      side-channel: 1.0.5
     dev: true
 
   /querystringify@2.2.0:
@@ -14346,7 +14379,7 @@ packages:
       dnd-core: 16.0.1
     dev: false
 
-  /react-dnd@16.0.1(@types/node@20.11.16)(@types/react@18.2.52)(react@18.2.0):
+  /react-dnd@16.0.1(@types/node@20.11.19)(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==}
     peerDependencies:
       '@types/hoist-non-react-statics': '>= 3.3.1'
@@ -14363,8 +14396,8 @@ packages:
     dependencies:
       '@react-dnd/invariant': 4.0.2
       '@react-dnd/shallowequal': 4.0.2
-      '@types/node': 20.11.16
-      '@types/react': 18.2.52
+      '@types/node': 20.11.19
+      '@types/react': 18.2.56
       dnd-core: 16.0.1
       fast-deep-equal: 3.1.3
       hoist-non-react-statics: 3.3.2
@@ -14443,7 +14476,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-remove-scroll-bar@2.3.4(@types/react@18.2.52)(react@18.2.0):
+  /react-remove-scroll-bar@2.3.4(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -14453,13 +14486,13 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.2.52
+      '@types/react': 18.2.56
       react: 18.2.0
-      react-style-singleton: 2.2.1(@types/react@18.2.52)(react@18.2.0)
+      react-style-singleton: 2.2.1(@types/react@18.2.56)(react@18.2.0)
       tslib: 2.6.2
     dev: false
 
-  /react-remove-scroll@2.5.5(@types/react@18.2.52)(react@18.2.0):
+  /react-remove-scroll@2.5.5(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -14469,16 +14502,16 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.2.52
+      '@types/react': 18.2.56
       react: 18.2.0
-      react-remove-scroll-bar: 2.3.4(@types/react@18.2.52)(react@18.2.0)
-      react-style-singleton: 2.2.1(@types/react@18.2.52)(react@18.2.0)
+      react-remove-scroll-bar: 2.3.4(@types/react@18.2.56)(react@18.2.0)
+      react-style-singleton: 2.2.1(@types/react@18.2.56)(react@18.2.0)
       tslib: 2.6.2
-      use-callback-ref: 1.3.1(@types/react@18.2.52)(react@18.2.0)
-      use-sidecar: 1.1.2(@types/react@18.2.52)(react@18.2.0)
+      use-callback-ref: 1.3.1(@types/react@18.2.56)(react@18.2.0)
+      use-sidecar: 1.1.2(@types/react@18.2.56)(react@18.2.0)
     dev: false
 
-  /react-remove-scroll@2.5.7(@types/react@18.2.52)(react@18.2.0):
+  /react-remove-scroll@2.5.7(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -14488,16 +14521,16 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.2.52
+      '@types/react': 18.2.56
       react: 18.2.0
-      react-remove-scroll-bar: 2.3.4(@types/react@18.2.52)(react@18.2.0)
-      react-style-singleton: 2.2.1(@types/react@18.2.52)(react@18.2.0)
+      react-remove-scroll-bar: 2.3.4(@types/react@18.2.56)(react@18.2.0)
+      react-style-singleton: 2.2.1(@types/react@18.2.56)(react@18.2.0)
       tslib: 2.6.2
-      use-callback-ref: 1.3.1(@types/react@18.2.52)(react@18.2.0)
-      use-sidecar: 1.1.2(@types/react@18.2.52)(react@18.2.0)
+      use-callback-ref: 1.3.1(@types/react@18.2.56)(react@18.2.0)
+      use-sidecar: 1.1.2(@types/react@18.2.56)(react@18.2.0)
     dev: false
 
-  /react-style-singleton@2.2.1(@types/react@18.2.52)(react@18.2.0):
+  /react-style-singleton@2.2.1(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -14507,14 +14540,14 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.2.52
+      '@types/react': 18.2.56
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 18.2.0
       tslib: 2.6.2
     dev: false
 
-  /react-textarea-autosize@8.5.3(@types/react@18.2.52)(react@18.2.0):
+  /react-textarea-autosize@8.5.3(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -14523,7 +14556,7 @@ packages:
       '@babel/runtime': 7.23.9
       react: 18.2.0
       use-composed-ref: 1.3.0(react@18.2.0)
-      use-latest: 1.2.1(@types/react@18.2.52)(react@18.2.0)
+      use-latest: 1.2.1(@types/react@18.2.56)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -14667,14 +14700,15 @@ packages:
       '@babel/runtime': 7.23.9
     dev: false
 
-  /reflect.getprototypeof@1.0.4:
-    resolution: {integrity: sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==}
+  /reflect.getprototypeof@1.0.5:
+    resolution: {integrity: sha512-62wgfC8dJWrmxv44CA36pLDnP6KKl3Vhxb7PL+8+qrrFMMoJij4vgiMP8zV4O8+CBMXY1mHxI5fITGHXFHVmQQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.22.3
-      get-intrinsic: 1.2.3
+      es-abstract: 1.22.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.2.4
       globalthis: 1.0.3
       which-builtin-type: 1.1.3
     dev: true
@@ -14687,12 +14721,13 @@ packages:
     hasBin: true
     dev: true
 
-  /regexp.prototype.flags@1.5.1:
-    resolution: {integrity: sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==}
+  /regexp.prototype.flags@1.5.2:
+    resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
+      es-errors: 1.3.0
       set-function-name: 2.0.1
     dev: true
 
@@ -14826,26 +14861,26 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /rollup@4.9.6:
-    resolution: {integrity: sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==}
+  /rollup@4.12.0:
+    resolution: {integrity: sha512-wz66wn4t1OHIJw3+XU7mJJQV/2NAfw5OAk6G6Hoo3zcvz/XOfQ52Vgi+AN4Uxoxi0KBBwk2g8zPrTDA4btSB/Q==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
     dependencies:
       '@types/estree': 1.0.5
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.9.6
-      '@rollup/rollup-android-arm64': 4.9.6
-      '@rollup/rollup-darwin-arm64': 4.9.6
-      '@rollup/rollup-darwin-x64': 4.9.6
-      '@rollup/rollup-linux-arm-gnueabihf': 4.9.6
-      '@rollup/rollup-linux-arm64-gnu': 4.9.6
-      '@rollup/rollup-linux-arm64-musl': 4.9.6
-      '@rollup/rollup-linux-riscv64-gnu': 4.9.6
-      '@rollup/rollup-linux-x64-gnu': 4.9.6
-      '@rollup/rollup-linux-x64-musl': 4.9.6
-      '@rollup/rollup-win32-arm64-msvc': 4.9.6
-      '@rollup/rollup-win32-ia32-msvc': 4.9.6
-      '@rollup/rollup-win32-x64-msvc': 4.9.6
+      '@rollup/rollup-android-arm-eabi': 4.12.0
+      '@rollup/rollup-android-arm64': 4.12.0
+      '@rollup/rollup-darwin-arm64': 4.12.0
+      '@rollup/rollup-darwin-x64': 4.12.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.12.0
+      '@rollup/rollup-linux-arm64-gnu': 4.12.0
+      '@rollup/rollup-linux-arm64-musl': 4.12.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.12.0
+      '@rollup/rollup-linux-x64-gnu': 4.12.0
+      '@rollup/rollup-linux-x64-musl': 4.12.0
+      '@rollup/rollup-win32-arm64-msvc': 4.12.0
+      '@rollup/rollup-win32-ia32-msvc': 4.12.0
+      '@rollup/rollup-win32-x64-msvc': 4.12.0
       fsevents: 2.3.3
     dev: true
 
@@ -14889,8 +14924,8 @@ packages:
     resolution: {integrity: sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==}
     engines: {node: '>=0.4'}
     dependencies:
-      call-bind: 1.0.5
-      get-intrinsic: 1.2.3
+      call-bind: 1.0.7
+      get-intrinsic: 1.2.4
       has-symbols: 1.0.3
       isarray: 2.0.5
     dev: true
@@ -14903,12 +14938,12 @@ packages:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
     dev: true
 
-  /safe-regex-test@1.0.2:
-    resolution: {integrity: sha512-83S9w6eFq12BBIJYvjMux6/dkirb8+4zJRA9cxNBVb7Wq5fJBW+Xze48WqR8pxua7bDuAaaAxtVVd4Idjp1dBQ==}
+  /safe-regex-test@1.0.3:
+    resolution: {integrity: sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
-      get-intrinsic: 1.2.3
+      call-bind: 1.0.7
+      es-errors: 1.3.0
       is-regex: 1.1.4
     dev: true
 
@@ -14968,28 +15003,37 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
+  /semver@7.6.0:
+    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
+
   /set-cookie-parser@2.6.0:
     resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
     dev: true
 
-  /set-function-length@1.2.0:
-    resolution: {integrity: sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==}
+  /set-function-length@1.2.1:
+    resolution: {integrity: sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==}
     engines: {node: '>= 0.4'}
     dependencies:
-      define-data-property: 1.1.1
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
       function-bind: 1.1.2
-      get-intrinsic: 1.2.3
+      get-intrinsic: 1.2.4
       gopd: 1.0.1
-      has-property-descriptors: 1.0.1
+      has-property-descriptors: 1.0.2
     dev: true
 
   /set-function-name@2.0.1:
     resolution: {integrity: sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      define-data-property: 1.1.1
+      define-data-property: 1.1.4
       functions-have-names: 1.2.3
-      has-property-descriptors: 1.0.1
+      has-property-descriptors: 1.0.2
     dev: true
 
   /set-harmonic-interval@1.0.1:
@@ -15011,11 +15055,13 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  /side-channel@1.0.4:
-    resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
+  /side-channel@1.0.5:
+    resolution: {integrity: sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==}
+    engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
-      get-intrinsic: 1.2.3
+      call-bind: 1.0.7
+      es-errors: 1.3.0
+      get-intrinsic: 1.2.4
       object-inspect: 1.13.1
     dev: true
 
@@ -15037,7 +15083,7 @@ packages:
       '@sinonjs/commons': 3.0.1
       '@sinonjs/fake-timers': 11.2.2
       '@sinonjs/samsam': 8.0.0
-      diff: 5.1.0
+      diff: 5.2.0
       nise: 5.1.9
       supports-color: 7.2.0
 
@@ -15050,13 +15096,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /slate-history@0.100.0(slate@0.101.5):
+  /slate-history@0.100.0(slate@0.102.0):
     resolution: {integrity: sha512-x5rUuWLNtH97hs9PrFovGgt3Qc5zkTm/5mcUB+0NR/TK923eLax4HsL6xACLHMs245nI6aJElyM1y6hN0y5W/Q==}
     peerDependencies:
       slate: '>=0.65.3'
     dependencies:
       is-plain-object: 5.0.0
-      slate: 0.101.5
+      slate: 0.102.0
     dev: false
 
   /slate-history@0.100.0(slate@0.94.1):
@@ -15068,13 +15114,13 @@ packages:
       slate: 0.94.1
     dev: false
 
-  /slate-hyperscript@0.100.0(slate@0.101.5):
+  /slate-hyperscript@0.100.0(slate@0.102.0):
     resolution: {integrity: sha512-fb2KdAYg6RkrQGlqaIi4wdqz3oa0S4zKNBJlbnJbNOwa23+9FLD6oPVx9zUGqCSIpy+HIpOeqXrg0Kzwh/Ii4A==}
     peerDependencies:
       slate: '>=0.65.3'
     dependencies:
       is-plain-object: 5.0.0
-      slate: 0.101.5
+      slate: 0.102.0
     dev: false
 
   /slate-hyperscript@0.100.0(slate@0.94.1):
@@ -15107,8 +15153,8 @@ packages:
       tiny-invariant: 1.0.6
     dev: false
 
-  /slate@0.101.5:
-    resolution: {integrity: sha512-ZZt1ia8ayRqxtpILRMi2a4MfdvwdTu64CorxTVq9vNSd0GQ/t3YDkze6wKjdeUtENmBlq5wNIDInZbx38Hfu5Q==}
+  /slate@0.102.0:
+    resolution: {integrity: sha512-RT+tHgqOyZVB1oFV9Pv99ajwh4OUCN9p28QWdnDTIzaN/kZxMsHeQN39UNAgtkZTVVVygFqeg7/R2jiptCvfyA==}
     dependencies:
       immer: 10.0.3
       is-plain-object: 5.0.0
@@ -15169,22 +15215,22 @@ packages:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.16
+      spdx-license-ids: 3.0.17
     dev: true
 
-  /spdx-exceptions@2.4.0:
-    resolution: {integrity: sha512-hcjppoJ68fhxA/cjbN4T8N6uCUejN8yFw69ttpqtBeCbF3u13n7mb31NB9jKwGTTWWnt9IbRA/mf1FprYS8wfw==}
+  /spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
     dev: true
 
   /spdx-expression-parse@3.0.1:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
     dependencies:
-      spdx-exceptions: 2.4.0
-      spdx-license-ids: 3.0.16
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.17
     dev: true
 
-  /spdx-license-ids@3.0.16:
-    resolution: {integrity: sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==}
+  /spdx-license-ids@3.0.17:
+    resolution: {integrity: sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==}
     dev: true
 
   /split2@4.2.0:
@@ -15245,7 +15291,7 @@ packages:
     resolution: {integrity: sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==}
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
-      dotenv: 16.4.1
+      dotenv: 16.4.4
       mime-db: 1.52.0
       outvariant: 1.4.0
     dev: false
@@ -15258,14 +15304,16 @@ packages:
     resolution: {integrity: sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      internal-slot: 1.0.6
+      internal-slot: 1.0.7
     dev: true
 
-  /streamx@2.15.7:
-    resolution: {integrity: sha512-NPEKS5+yjyo597eafGbKW5ujh7Sm6lDLHZQd/lRSz6S0VarpADBJItqfB4PnwpS+472oob1GX5cCY9vzfJpHUA==}
+  /streamx@2.16.0:
+    resolution: {integrity: sha512-a7Fi0PoUeusrUcMS4+HxivnZqYsw2MFEP841TIyLxTcEIucHcJsk+0ARcq3tGq1xDn+xK7sKHetvfMzI1/CzMA==}
     dependencies:
       fast-fifo: 1.3.2
       queue-tick: 1.0.1
+    optionalDependencies:
+      bare-events: 2.2.0
     dev: true
 
   /strict-event-emitter@0.2.8:
@@ -15301,40 +15349,40 @@ packages:
   /string.prototype.matchall@4.0.10:
     resolution: {integrity: sha512-rGXbGmOEosIQi6Qva94HUjgPs9vKW+dkG7Y8Q5O2OYkWL6wFaTRZO8zM4mhP94uX55wgyrXzfS2aGtGzUL7EJQ==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.22.3
-      get-intrinsic: 1.2.3
+      es-abstract: 1.22.4
+      get-intrinsic: 1.2.4
       has-symbols: 1.0.3
-      internal-slot: 1.0.6
-      regexp.prototype.flags: 1.5.1
+      internal-slot: 1.0.7
+      regexp.prototype.flags: 1.5.2
       set-function-name: 2.0.1
-      side-channel: 1.0.4
+      side-channel: 1.0.5
     dev: true
 
   /string.prototype.trim@1.2.8:
     resolution: {integrity: sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.22.3
+      es-abstract: 1.22.4
     dev: true
 
   /string.prototype.trimend@1.0.7:
     resolution: {integrity: sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.22.3
+      es-abstract: 1.22.4
     dev: true
 
   /string.prototype.trimstart@1.0.7:
     resolution: {integrity: sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.22.3
+      es-abstract: 1.22.4
     dev: true
 
   /string_decoder@1.1.1:
@@ -15383,10 +15431,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /strip-literal@1.3.0:
-    resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
+  /strip-literal@2.0.0:
+    resolution: {integrity: sha512-f9vHgsCWBq2ugHAkGMiiYY+AYG0D/cbloKKg0nhaaaSNsujdGIpVXCNsrJpCKr5M0f4aI31mr13UjY6GAuXCKA==}
     dependencies:
-      acorn: 8.11.3
+      js-tokens: 8.0.3
     dev: true
 
   /stubborn-fs@1.2.5:
@@ -15482,7 +15530,7 @@ packages:
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       didyoumean: 1.2.2
       dlv: 1.1.3
       fast-glob: 3.3.2
@@ -15494,11 +15542,11 @@ packages:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.0.0
-      postcss: 8.4.33
-      postcss-import: 15.1.0(postcss@8.4.33)
-      postcss-js: 4.0.1(postcss@8.4.33)
-      postcss-load-config: 4.0.2(postcss@8.4.33)(ts-node@10.9.2)
-      postcss-nested: 6.0.1(postcss@8.4.33)
+      postcss: 8.4.35
+      postcss-import: 15.1.0(postcss@8.4.35)
+      postcss-js: 4.0.1(postcss@8.4.35)
+      postcss-load-config: 4.0.2(postcss@8.4.35)(ts-node@10.9.2)
+      postcss-nested: 6.0.1(postcss@8.4.35)
       postcss-selector-parser: 6.0.15
       resolve: 1.22.8
       sucrase: 3.35.0
@@ -15508,9 +15556,9 @@ packages:
   /tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
     dependencies:
-      b4a: 1.6.4
+      b4a: 1.6.6
       fast-fifo: 1.3.2
-      streamx: 2.15.7
+      streamx: 2.16.0
     dev: true
 
   /text-table@0.2.0:
@@ -15564,8 +15612,8 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /tinyspy@2.2.0:
-    resolution: {integrity: sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==}
+  /tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -15631,13 +15679,13 @@ packages:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
     dev: false
 
-  /trough@2.1.0:
-    resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
+  /trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
     dev: false
 
-  /ts-api-utils@1.0.3(typescript@5.3.3):
-    resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
-    engines: {node: '>=16.13.0'}
+  /ts-api-utils@1.2.1(typescript@5.3.3):
+    resolution: {integrity: sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==}
+    engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
@@ -15651,7 +15699,7 @@ packages:
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  /ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3):
+  /ts-node@10.9.2(@types/node@20.11.19)(typescript@5.3.3):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -15670,7 +15718,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.11.16
+      '@types/node': 20.11.19
       acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.3
@@ -15751,12 +15799,12 @@ packages:
     resolution: {integrity: sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==}
     dev: false
 
-  /typed-array-buffer@1.0.0:
-    resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
+  /typed-array-buffer@1.0.1:
+    resolution: {integrity: sha512-RSqu1UEuSlrBhHTWC8O9FnPjOduNs4M7rJ4pRKoEjtx1zUNOPN2sSXHLDX+Y2WPbHIxbvg4JFo2DNAEfPIKWoQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
-      get-intrinsic: 1.2.3
+      call-bind: 1.0.7
+      es-errors: 1.3.0
       is-typed-array: 1.1.13
     dev: true
 
@@ -15764,19 +15812,20 @@ packages:
     resolution: {integrity: sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       for-each: 0.3.3
       has-proto: 1.0.1
       is-typed-array: 1.1.13
     dev: true
 
-  /typed-array-byte-offset@1.0.0:
-    resolution: {integrity: sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==}
+  /typed-array-byte-offset@1.0.1:
+    resolution: {integrity: sha512-tcqKMrTRXjqvHN9S3553NPCaGL0VPgFI92lXszmrE8DMhiDPLBYLlvo8Uu4WZAAX/aGqp/T1sbA4ph8EWjDF9Q==}
     engines: {node: '>= 0.4'}
     dependencies:
       available-typed-arrays: 1.0.6
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       for-each: 0.3.3
+      gopd: 1.0.1
       has-proto: 1.0.1
       is-typed-array: 1.1.13
     dev: true
@@ -15784,7 +15833,7 @@ packages:
   /typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       for-each: 0.3.3
       is-typed-array: 1.1.13
     dev: true
@@ -15794,8 +15843,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /ufo@1.3.2:
-    resolution: {integrity: sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==}
+  /ufo@1.4.0:
+    resolution: {integrity: sha512-Hhy+BhRBleFjpJ2vchUNN40qgkh0366FWJGqVLYBHev0vpHTrXSA0ryT+74UiW6KWsldNurQMKGqCm1M2zBciQ==}
     dev: true
 
   /uint8array-extras@0.3.0:
@@ -15806,7 +15855,7 @@ packages:
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
@@ -15823,7 +15872,7 @@ packages:
       extend: 3.0.2
       is-buffer: 2.0.5
       is-plain-obj: 4.1.0
-      trough: 2.1.0
+      trough: 2.2.0
       vfile: 5.3.7
     dev: false
 
@@ -15891,14 +15940,14 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /update-browserslist-db@1.0.13(browserslist@4.22.3):
+  /update-browserslist-db@1.0.13(browserslist@4.23.0):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
-      browserslist: 4.22.3
-      escalade: 3.1.1
+      browserslist: 4.23.0
+      escalade: 3.1.2
       picocolors: 1.0.0
 
   /uri-js@4.4.1:
@@ -15914,7 +15963,7 @@ packages:
       requires-port: 1.0.0
     dev: true
 
-  /use-callback-ref@1.3.1(@types/react@18.2.52)(react@18.2.0):
+  /use-callback-ref@1.3.1(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-Lg4Vx1XZQauB42Hw3kK7JM6yjVjgFmFC5/Ab797s79aARomD2nEErc4mCgM8EZrARLmmbWpi5DGCadmK50DcAQ==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -15924,7 +15973,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.2.52
+      '@types/react': 18.2.56
       react: 18.2.0
       tslib: 2.6.2
     dev: false
@@ -15964,7 +16013,7 @@ packages:
       react: 18.2.0
     dev: false
 
-  /use-isomorphic-layout-effect@1.1.2(@types/react@18.2.52)(react@18.2.0):
+  /use-isomorphic-layout-effect@1.1.2(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
     peerDependencies:
       '@types/react': '*'
@@ -15973,11 +16022,11 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.2.52
+      '@types/react': 18.2.56
       react: 18.2.0
     dev: false
 
-  /use-latest@1.2.1(@types/react@18.2.52)(react@18.2.0):
+  /use-latest@1.2.1(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==}
     peerDependencies:
       '@types/react': '*'
@@ -15986,12 +16035,12 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.2.52
+      '@types/react': 18.2.56
       react: 18.2.0
-      use-isomorphic-layout-effect: 1.1.2(@types/react@18.2.52)(react@18.2.0)
+      use-isomorphic-layout-effect: 1.1.2(@types/react@18.2.56)(react@18.2.0)
     dev: false
 
-  /use-sidecar@1.1.2(@types/react@18.2.52)(react@18.2.0):
+  /use-sidecar@1.1.2(@types/react@18.2.56)(react@18.2.0):
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -16001,7 +16050,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.2.52
+      '@types/react': 18.2.56
       detect-node-es: 1.1.0
       react: 18.2.0
       tslib: 2.6.2
@@ -16048,7 +16097,7 @@ packages:
     hasBin: true
     dependencies:
       dequal: 2.0.3
-      diff: 5.1.0
+      diff: 5.2.0
       kleur: 4.1.5
       sade: 1.8.1
     dev: false
@@ -16108,8 +16157,8 @@ packages:
       vfile-message: 3.1.4
     dev: false
 
-  /vite-node@1.2.2(@types/node@20.11.16):
-    resolution: {integrity: sha512-1as4rDTgVWJO3n1uHmUYqq7nsFgINQ9u+mRcXpjeOMJUmviqNKjcZB7UfRZrlM7MjYXMKpuWp5oGkjaFLnjawg==}
+  /vite-node@1.3.0(@types/node@20.11.19):
+    resolution: {integrity: sha512-D/oiDVBw75XMnjAXne/4feCkCEwcbr2SU1bjAhCcfI5Bq3VoOHji8/wCPAfUkDIeohJ5nSZ39fNxM3dNZ6OBOA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
@@ -16117,7 +16166,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.0.12(@types/node@20.11.16)
+      vite: 5.1.3(@types/node@20.11.19)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -16129,7 +16178,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-dts@3.7.2(@types/node@20.11.16)(typescript@5.3.3)(vite@4.5.2):
+  /vite-plugin-dts@3.7.2(@types/node@20.11.19)(typescript@5.3.3)(vite@4.5.2):
     resolution: {integrity: sha512-kg//1nDA01b8rufJf4TsvYN8LMkdwv0oBYpiQi6nRwpHyue+wTlhrBiqgipdFpMnW1oOYv6ywmzE5B0vg6vSEA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -16139,13 +16188,13 @@ packages:
       vite:
         optional: true
     dependencies:
-      '@microsoft/api-extractor': 7.39.0(@types/node@20.11.16)
+      '@microsoft/api-extractor': 7.39.0(@types/node@20.11.19)
       '@rollup/pluginutils': 5.1.0
       '@vue/language-core': 1.8.27(typescript@5.3.3)
       debug: 4.3.4(supports-color@8.1.1)
       kolorist: 1.8.0
       typescript: 5.3.3
-      vite: 4.5.2(@types/node@20.11.16)
+      vite: 4.5.2(@types/node@20.11.19)
       vue-tsc: 1.8.27(typescript@5.3.3)
     transitivePeerDependencies:
       - '@types/node'
@@ -16163,10 +16212,10 @@ packages:
       es-module-lexer: 0.4.1
       fs-extra: 10.1.0
       magic-string: 0.25.9
-      vite: 4.5.2(@types/node@20.11.16)
+      vite: 4.5.2(@types/node@20.11.19)
     dev: true
 
-  /vite@4.5.2(@types/node@20.11.16):
+  /vite@4.5.2(@types/node@20.11.19):
     resolution: {integrity: sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -16194,16 +16243,16 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.11.16
+      '@types/node': 20.11.19
       esbuild: 0.18.20
-      postcss: 8.4.33
+      postcss: 8.4.35
       rollup: 3.29.4
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
 
-  /vite@5.0.12(@types/node@20.11.16):
-    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
+  /vite@5.1.3(@types/node@20.11.19):
+    resolution: {integrity: sha512-UfmUD36DKkqhi/F75RrxvPpry+9+tTkrXfMNZD+SboZqBCMsxKtO52XeGzzuh7ioz+Eo/SYDBbdb0Z7vgcDJew==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -16230,23 +16279,23 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.11.16
+      '@types/node': 20.11.19
       esbuild: 0.19.12
-      postcss: 8.4.33
-      rollup: 4.9.6
+      postcss: 8.4.35
+      rollup: 4.12.0
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.2.2(@types/node@20.11.16):
-    resolution: {integrity: sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==}
+  /vitest@1.3.0(@types/node@20.11.19):
+    resolution: {integrity: sha512-V9qb276J1jjSx9xb75T2VoYXdO1UKi+qfflY7V7w93jzX7oA/+RtYE6TcifxksxsZvygSSMwu2Uw6di7yqDMwg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': ^1.0.0
-      '@vitest/ui': ^1.0.0
+      '@vitest/browser': 1.3.0
+      '@vitest/ui': 1.3.0
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -16263,27 +16312,26 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@types/node': 20.11.16
-      '@vitest/expect': 1.2.2
-      '@vitest/runner': 1.2.2
-      '@vitest/snapshot': 1.2.2
-      '@vitest/spy': 1.2.2
-      '@vitest/utils': 1.2.2
+      '@types/node': 20.11.19
+      '@vitest/expect': 1.3.0
+      '@vitest/runner': 1.3.0
+      '@vitest/snapshot': 1.3.0
+      '@vitest/spy': 1.3.0
+      '@vitest/utils': 1.3.0
       acorn-walk: 8.3.2
-      cac: 6.7.14
       chai: 4.4.1
       debug: 4.3.4(supports-color@8.1.1)
       execa: 8.0.1
       local-pkg: 0.5.0
-      magic-string: 0.30.6
+      magic-string: 0.30.7
       pathe: 1.1.2
       picocolors: 1.0.0
       std-env: 3.7.0
-      strip-literal: 1.3.0
+      strip-literal: 2.0.0
       tinybench: 2.6.0
       tinypool: 0.8.2
-      vite: 5.0.12(@types/node@20.11.16)
-      vite-node: 1.2.2(@types/node@20.11.16)
+      vite: 5.1.3(@types/node@20.11.19)
+      vite-node: 1.3.0(@types/node@20.11.19)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -16310,7 +16358,7 @@ packages:
     dependencies:
       '@volar/typescript': 1.11.1
       '@vue/language-core': 1.8.27(typescript@5.3.3)
-      semver: 7.5.4
+      semver: 7.6.0
       typescript: 5.3.3
     dev: true
 
@@ -16338,8 +16386,8 @@ packages:
       '@zxing/text-encoding': 0.9.0
     dev: true
 
-  /web-streams-polyfill@3.3.2:
-    resolution: {integrity: sha512-3pRGuxRF5gpuZc0W+EpwQRmCD7gRqcDOMt688KmdlDAgAyaB1XlN0zq2njfDNm44XVdIouE7pZ6GzbdyH47uIQ==}
+  /web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
     dev: true
 
@@ -16400,7 +16448,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       available-typed-arrays: 1.0.6
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       for-each: 0.3.3
       gopd: 1.0.1
       has-tostringtag: 1.0.2
@@ -16490,7 +16538,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       cliui: 8.0.1
-      escalade: 3.1.1
+      escalade: 3.1.2
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3
@@ -16556,8 +16604,8 @@ packages:
       react: 18.2.0
     dev: false
 
-  /zustand@4.5.0(@types/react@18.2.52)(immer@9.0.12)(react@18.2.0):
-    resolution: {integrity: sha512-zlVFqS5TQ21nwijjhJlx4f9iGrXSL0o/+Dpy4txAP22miJ8Ti6c1Ol1RLNN98BMib83lmDH/2KmLwaNXpjrO1A==}
+  /zustand@4.5.1(@types/react@18.2.56)(immer@9.0.12)(react@18.2.0):
+    resolution: {integrity: sha512-XlauQmH64xXSC1qGYNv00ODaQ3B+tNPoy22jv2diYiP4eoDKr9LA+Bh5Bc3gplTrFdb6JVI+N4kc1DZ/tbtfPg==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
       '@types/react': '>=16.8'
@@ -16571,7 +16619,7 @@ packages:
       react:
         optional: true
     dependencies:
-      '@types/react': 18.2.52
+      '@types/react': 18.2.56
       immer: 9.0.12
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -158,8 +158,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -225,8 +225,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -295,8 +295,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -365,8 +365,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -432,8 +432,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -502,8 +502,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -602,8 +602,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -681,8 +681,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -757,8 +757,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -824,8 +824,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -900,8 +900,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -967,8 +967,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1043,8 +1043,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1113,8 +1113,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1180,8 +1180,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1247,8 +1247,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1320,8 +1320,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1393,8 +1393,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1466,8 +1466,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1536,8 +1536,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1606,8 +1606,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: 0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: 0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@uiw/react-codemirror':
         specifier: ^4.21.12
         version: 4.21.22(@babel/runtime@7.23.9)(@codemirror/autocomplete@6.12.0)(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.6)(@codemirror/state@6.4.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.24.0)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0)
@@ -1694,8 +1694,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1761,8 +1761,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1831,8 +1831,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1901,8 +1901,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1986,8 +1986,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -2068,8 +2068,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.33.0
-        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+        specifier: ^0.33.1
+        version: 0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -3707,8 +3707,60 @@ packages:
       - terser
     dev: true
 
-  /@frontify/guideline-blocks-settings@0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1):
-    resolution: {integrity: sha512-Q1NZjM0RfF7Jr6fFttyjIWDY/J0IE0xQcDvPwHr2BAOijOpYo2Pqiw+FB1cNIRS9NRkso9+aWjvaSG/e5siuEA==}
+  /@frontify/guideline-blocks-settings@0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1):
+    resolution: {integrity: sha512-IF5lo92IJC1kAqdDT85HrAy+pPiAmdbIsT6ts4jsL2kseVeW3WMeaDhu4YbSRMaH3miXQfxc4vOZCbDcw9VWWA==}
+    peerDependencies:
+      '@frontify/app-bridge': ^3.0.0 || ^4.0.0-alpha.0
+      react: ^18
+      react-dom: ^18
+    dependencies:
+      '@ctrl/tinycolor': 4.0.3
+      '@dnd-kit/core': 6.1.0(react-dom@18.2.0)(react@18.2.0)
+      '@dnd-kit/modifiers': 7.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
+      '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
+      '@frontify/app-bridge': 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+      '@frontify/fondue': 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+      '@frontify/sidebar-settings': 0.9.2(@babel/core@7.23.9)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1)
+      '@react-aria/focus': 3.16.2(react@18.2.0)
+      '@react-stately/overlays': 3.6.5(react@18.2.0)
+      '@udecode/plate': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-react: 0.98.4(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/hoist-non-react-statics'
+      - '@types/node'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@xstate/fsm'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-dnd
+      - react-dnd-html5-backend
+      - react-is
+      - react-native
+      - scheduler
+      - slate-history
+      - slate-hyperscript
+      - styled-components
+      - supports-color
+      - tailwindcss
+      - ts-node
+      - zustand
+    dev: false
+
+  /@frontify/guideline-blocks-settings@0.33.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.19)(@types/react-dom@18.2.19)(@types/react@18.2.56)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.1):
+    resolution: {integrity: sha512-IF5lo92IJC1kAqdDT85HrAy+pPiAmdbIsT6ts4jsL2kseVeW3WMeaDhu4YbSRMaH3miXQfxc4vOZCbDcw9VWWA==}
     peerDependencies:
       '@frontify/app-bridge': ^3.0.0 || ^4.0.0-alpha.0
       react: ^18

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -158,8 +158,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -225,8 +225,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -295,8 +295,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -365,8 +365,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -432,8 +432,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -502,8 +502,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -602,8 +602,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -681,8 +681,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -757,8 +757,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -824,8 +824,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -900,8 +900,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -967,8 +967,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1043,8 +1043,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1113,8 +1113,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1180,8 +1180,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1247,8 +1247,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1320,8 +1320,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1393,8 +1393,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1466,8 +1466,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1536,8 +1536,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1605,6 +1605,9 @@ importers:
       '@frontify/fondue':
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+      '@frontify/guideline-blocks-settings':
+        specifier: 0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@uiw/react-codemirror':
         specifier: ^4.21.12
         version: 4.21.21(@babel/runtime@7.23.9)(@codemirror/autocomplete@6.12.0)(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.5)(@codemirror/state@6.4.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.23.1)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0)
@@ -1691,8 +1694,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1758,8 +1761,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1828,8 +1831,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1898,8 +1901,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -1983,8 +1986,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -2065,8 +2068,8 @@ importers:
         specifier: 12.0.0-beta.396
         version: 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-settings':
-        specifier: ^0.32.1
-        version: 0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+        specifier: ^0.33.0
+        version: 0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@frontify/guideline-blocks-shared':
         specifier: workspace:*
         version: link:../shared
@@ -3703,8 +3706,8 @@ packages:
       - terser
     dev: true
 
-  /@frontify/guideline-blocks-settings@0.32.1(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0):
-    resolution: {integrity: sha512-kA0buSknJ1UAsK1IF2grM8xcKdBvT78rD6gjH0Xly49Hpeuv8/Eh2rGI0IGSml7F/q/4GHe73IPvliUp4F4aCg==}
+  /@frontify/guideline-blocks-settings@0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0):
+    resolution: {integrity: sha512-Q1NZjM0RfF7Jr6fFttyjIWDY/J0IE0xQcDvPwHr2BAOijOpYo2Pqiw+FB1cNIRS9NRkso9+aWjvaSG/e5siuEA==}
     peerDependencies:
       '@frontify/app-bridge': ^3.0.0 || ^4.0.0-alpha.0
       react: ^18
@@ -3716,7 +3719,59 @@ packages:
       '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
       '@frontify/app-bridge': 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
       '@frontify/fondue': 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
-      '@frontify/sidebar-settings': 0.9.1(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+      '@frontify/sidebar-settings': 0.9.2(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+      '@react-aria/focus': 3.16.0(react@18.2.0)
+      '@react-stately/overlays': 3.6.4(react@18.2.0)
+      '@udecode/plate': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@15.1.3)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      slate: 0.94.1
+      slate-react: 0.98.4(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/template'
+      - '@types/hoist-non-react-statics'
+      - '@types/node'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@xstate/fsm'
+      - jotai-devtools
+      - jotai-immer
+      - jotai-optics
+      - jotai-redux
+      - jotai-tanstack-query
+      - jotai-urql
+      - jotai-valtio
+      - jotai-xstate
+      - jotai-zustand
+      - react-dnd
+      - react-dnd-html5-backend
+      - react-is
+      - react-native
+      - scheduler
+      - slate-history
+      - slate-hyperscript
+      - styled-components
+      - supports-color
+      - tailwindcss
+      - ts-node
+      - zustand
+    dev: false
+
+  /@frontify/guideline-blocks-settings@0.33.0(@babel/core@7.23.9)(@frontify/app-bridge@3.3.0)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0):
+    resolution: {integrity: sha512-Q1NZjM0RfF7Jr6fFttyjIWDY/J0IE0xQcDvPwHr2BAOijOpYo2Pqiw+FB1cNIRS9NRkso9+aWjvaSG/e5siuEA==}
+    peerDependencies:
+      '@frontify/app-bridge': ^3.0.0 || ^4.0.0-alpha.0
+      react: ^18
+      react-dom: ^18
+    dependencies:
+      '@ctrl/tinycolor': 4.0.3
+      '@dnd-kit/core': 6.1.0(react-dom@18.2.0)(react@18.2.0)
+      '@dnd-kit/modifiers': 7.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
+      '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.1.0)(react@18.2.0)
+      '@frontify/app-bridge': 3.3.0(react-dom@18.2.0)(react@18.2.0)(sinon@17.0.1)
+      '@frontify/fondue': 12.0.0-beta.396(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
+      '@frontify/sidebar-settings': 0.9.2(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0)
       '@react-aria/focus': 3.16.0(react@18.2.0)
       '@react-stately/overlays': 3.6.4(react@18.2.0)
       '@udecode/plate': 21.5.0(@babel/core@7.23.9)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(scheduler@0.23.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(slate-react@0.98.4)(slate@0.94.1)(styled-components@6.1.8)
@@ -3755,8 +3810,8 @@ packages:
       - zustand
     dev: false
 
-  /@frontify/sidebar-settings@0.9.1(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0):
-    resolution: {integrity: sha512-F874z4CdGCBSGWixDvrAp21iHaigLEYq29TSzvqw4D+fK7li6jh+tkHSmkRnq3O5Za8KK+HdewgxGeSoCTPYeg==}
+  /@frontify/sidebar-settings@0.9.2(@babel/core@7.23.9)(@types/node@20.11.16)(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0)(react@18.2.0)(slate-history@0.100.0)(slate-hyperscript@0.100.0)(styled-components@6.1.8)(tailwindcss@3.4.1)(ts-node@10.9.2)(zustand@4.5.0):
+    resolution: {integrity: sha512-P4UmcjDtou88yiGc/wvYJkhIqkuDe73rd3tCQUCBVpnKm1b008JE7dGnp9tiul9Twwp4OaXjr2gEKzwctr3XPw==}
     peerDependencies:
       react: ^18
       react-dom: ^18


### PR DESCRIPTION
Update guideline-blocks settings to 0.33.1 and remove all instances of the `toolbarFlyoutItems` prop. There are no functional changes. For testing all blocks that had a block wrapper should behave the same as before.