### PR TITLE
fix(ImageBlock): gif loop count is not respected

### DIFF
--- a/packages/image-block/src/components/Image.tsx
+++ b/packages/image-block/src/components/Image.tsx
@@ -26,12 +26,19 @@ export const ImageComponent = ({ image, blockSettings, isEditing, appBridge }: I
     const imageStyle = getImageStyle(blockSettings, image.width);
     const { isFocused, focusProps } = useFocusRing();
 
+    // Gif images can have a loop count property
+    // Which is lost during our image processing
+    const src =
+        image.extension === 'gif'
+            ? image.originUrl
+            : image.genericUrl.replace('{width}', `${800 * Math.max(1, window?.devicePixelRatio ?? 1)}`);
+
     const Image = (
         <img
             data-test-id="image-block-img"
             className="tw-flex tw-w-full"
             loading="lazy"
-            src={image.genericUrl.replace('{width}', `${800 * Math.max(1, window?.devicePixelRatio ?? 1)}`)}
+            src={src}
             alt={blockSettings.altText || undefined}
             style={imageStyle}
         />


### PR DESCRIPTION
You can change a GIF's loop count using several tools, like https://ezgif.com/loop-count .

During our processing this is lost, and GIFs served via the frontify CDN loop infinitely. 
The image at the originURL still contains this property.

https://app.clickup.com/t/8693vp7d0