### PR TITLE
fix(Image-block): apply title when rte is empty

### DIFF
--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -26,6 +26,7 @@ import {
     IconTrashBin20,
     LoadingCircle,
     MenuItemStyle,
+    generateRandomId,
 } from '@frontify/fondue';
 import { useEffect, useState } from 'react';
 
@@ -41,6 +42,7 @@ import '@frontify/fondue/style';
 
 export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) => {
     const [blockSettings, setBlockSettings] = useBlockSettings<Settings>(appBridge);
+    const [titleKey, setTitleKey] = useState(generateRandomId());
     const { openAssetChooser, closeAssetChooser } = useAssetChooser(appBridge);
     const isEditing = useEditorState(appBridge);
     const blockId = String(appBridge.context('blockId').get());
@@ -57,7 +59,8 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
 
     const updateImage = async (image: Asset) => {
         if (!hasRichTextValue(blockSettings.name)) {
-            setBlockSettings({ name: convertToRteValue(TextStyles.imageTitle, image?.title, 'center') });
+            await setBlockSettings({ name: convertToRteValue(TextStyles.imageTitle, image?.title, 'center') });
+            setTitleKey(generateRandomId());
         }
         setBlockSettings({ altText: image?.title ?? image?.fileName ?? '' });
         await updateAssetIdsFromKey(IMAGE_ID, [image.id]);
@@ -188,7 +191,7 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
                         )
                     )}
                 </div>
-                <ImageCaption blockId={blockId} isEditing={isEditing} appBridge={appBridge} />
+                <ImageCaption titleKey={titleKey} blockId={blockId} isEditing={isEditing} appBridge={appBridge} />
             </div>
         </div>
     );

--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -10,14 +10,7 @@ import {
     useEditorState,
     useFileInput,
 } from '@frontify/app-bridge';
-import {
-    BlockItemWrapper,
-    BlockProps,
-    TextStyles,
-    convertToRteValue,
-    hasRichTextValue,
-    withAttachmentsProvider,
-} from '@frontify/guideline-blocks-settings';
+import { BlockItemWrapper, BlockProps, withAttachmentsProvider } from '@frontify/guideline-blocks-settings';
 import { getEditAltTextToolbarButton } from '@frontify/guideline-blocks-shared';
 import {
     IconArrowCircleUp20,
@@ -26,7 +19,6 @@ import {
     IconTrashBin20,
     LoadingCircle,
     MenuItemStyle,
-    generateRandomId,
 } from '@frontify/fondue';
 import { useEffect, useState } from 'react';
 
@@ -42,7 +34,6 @@ import '@frontify/fondue/style';
 
 export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) => {
     const [blockSettings, setBlockSettings] = useBlockSettings<Settings>(appBridge);
-    const [titleKey, setTitleKey] = useState(generateRandomId());
     const { openAssetChooser, closeAssetChooser } = useAssetChooser(appBridge);
     const isEditing = useEditorState(appBridge);
     const blockId = String(appBridge.context('blockId').get());
@@ -58,10 +49,6 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
     });
 
     const updateImage = async (image: Asset) => {
-        if (!hasRichTextValue(blockSettings.name)) {
-            await setBlockSettings({ name: convertToRteValue(TextStyles.imageTitle, image?.title, 'center') });
-            setTitleKey(generateRandomId());
-        }
         setBlockSettings({ altText: image?.title ?? image?.fileName ?? '' });
         await updateAssetIdsFromKey(IMAGE_ID, [image.id]);
         setIsLoading(false);
@@ -191,7 +178,12 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
                         )
                     )}
                 </div>
-                <ImageCaption titleKey={titleKey} blockId={blockId} isEditing={isEditing} appBridge={appBridge} />
+                <ImageCaption
+                    defaultName={image?.title ?? image?.fileName ?? ''}
+                    blockId={blockId}
+                    isEditing={isEditing}
+                    appBridge={appBridge}
+                />
             </div>
         </div>
     );

--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -57,13 +57,20 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
         onUploadProgress: () => !isLoading && setIsLoading(true),
     });
 
-    const updateImage = async (image: Asset) => {
-        if (!hasRichTextValue(blockSettings.name)) {
-            await setBlockSettings({ name: convertToRteValue(TextStyles.imageTitle, image?.title, 'center') });
-            setTitleKey(generateRandomId());
+    const updateImage = async (newImage: Asset) => {
+        const isFirstImageUpload = !image;
+
+        if (isFirstImageUpload) {
+            setBlockSettings({ altText: newImage?.title ?? newImage?.fileName ?? '' });
+
+            const hasManuallyEditedName = !hasRichTextValue(blockSettings.name);
+            if (!hasManuallyEditedName) {
+                await setBlockSettings({ name: convertToRteValue(TextStyles.imageTitle, newImage?.title, 'center') });
+                setTitleKey(generateRandomId());
+            }
         }
-        setBlockSettings({ altText: image?.title ?? image?.fileName ?? '' });
-        await updateAssetIdsFromKey(IMAGE_ID, [image.id]);
+
+        await updateAssetIdsFromKey(IMAGE_ID, [newImage.id]);
         setIsLoading(false);
     };
 

--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -61,13 +61,14 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
         const isFirstImageUpload = !image;
 
         if (isFirstImageUpload) {
-            const altText = newImage?.title ?? newImage?.fileName ?? '';
-            setBlockSettings({ altText });
-            setLocalAltText(altText);
+            const defaultImageName = newImage?.title ?? newImage?.fileName ?? '';
+
+            setBlockSettings({ altText: defaultImageName });
+            setLocalAltText(defaultImageName);
 
             const hasManuallyEditedName = hasRichTextValue(blockSettings.name);
             if (!hasManuallyEditedName) {
-                await setBlockSettings({ name: convertToRteValue(TextStyles.imageTitle, newImage?.title, 'center') });
+                await setBlockSettings({ name: convertToRteValue(TextStyles.imageTitle, defaultImageName, 'center') });
                 setTitleKey(generateRandomId());
             }
         }

--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -65,7 +65,7 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
             setBlockSettings({ altText });
             setLocalAltText(altText);
 
-            const hasManuallyEditedName = !hasRichTextValue(blockSettings.name);
+            const hasManuallyEditedName = hasRichTextValue(blockSettings.name);
             if (!hasManuallyEditedName) {
                 await setBlockSettings({ name: convertToRteValue(TextStyles.imageTitle, newImage?.title, 'center') });
                 setTitleKey(generateRandomId());

--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -10,7 +10,14 @@ import {
     useEditorState,
     useFileInput,
 } from '@frontify/app-bridge';
-import { BlockItemWrapper, BlockProps, withAttachmentsProvider } from '@frontify/guideline-blocks-settings';
+import {
+    BlockItemWrapper,
+    BlockProps,
+    TextStyles,
+    convertToRteValue,
+    hasRichTextValue,
+    withAttachmentsProvider,
+} from '@frontify/guideline-blocks-settings';
 import { getEditAltTextToolbarButton } from '@frontify/guideline-blocks-shared';
 import {
     IconArrowCircleUp20,
@@ -19,6 +26,7 @@ import {
     IconTrashBin20,
     LoadingCircle,
     MenuItemStyle,
+    generateRandomId,
 } from '@frontify/fondue';
 import { useEffect, useState } from 'react';
 
@@ -34,6 +42,7 @@ import '@frontify/fondue/style';
 
 export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) => {
     const [blockSettings, setBlockSettings] = useBlockSettings<Settings>(appBridge);
+    const [titleKey, setTitleKey] = useState(generateRandomId());
     const { openAssetChooser, closeAssetChooser } = useAssetChooser(appBridge);
     const isEditing = useEditorState(appBridge);
     const blockId = String(appBridge.context('blockId').get());
@@ -49,6 +58,10 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
     });
 
     const updateImage = async (image: Asset) => {
+        if (!hasRichTextValue(blockSettings.name)) {
+            await setBlockSettings({ name: convertToRteValue(TextStyles.imageTitle, image?.title, 'center') });
+            setTitleKey(generateRandomId());
+        }
         setBlockSettings({ altText: image?.title ?? image?.fileName ?? '' });
         await updateAssetIdsFromKey(IMAGE_ID, [image.id]);
         setIsLoading(false);
@@ -178,12 +191,7 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
                         )
                     )}
                 </div>
-                <ImageCaption
-                    defaultName={image?.title ?? image?.fileName ?? ''}
-                    blockId={blockId}
-                    isEditing={isEditing}
-                    appBridge={appBridge}
-                />
+                <ImageCaption titleKey={titleKey} blockId={blockId} isEditing={isEditing} appBridge={appBridge} />
             </div>
         </div>
     );

--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -61,7 +61,9 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
         const isFirstImageUpload = !image;
 
         if (isFirstImageUpload) {
-            setBlockSettings({ altText: newImage?.title ?? newImage?.fileName ?? '' });
+            const altText = newImage?.title ?? newImage?.fileName ?? '';
+            setBlockSettings({ altText });
+            setLocalAltText(altText);
 
             const hasManuallyEditedName = !hasRichTextValue(blockSettings.name);
             if (!hasManuallyEditedName) {

--- a/packages/image-block/src/components/ImageCaption.tsx
+++ b/packages/image-block/src/components/ImageCaption.tsx
@@ -9,10 +9,10 @@ type ImageCaptionProps = {
     blockId: string;
     isEditing: boolean;
     appBridge: AppBridgeBlock;
-    titleKey: string;
+    defaultName: string;
 };
 
-export const ImageCaption = ({ isEditing, blockId, appBridge, titleKey }: ImageCaptionProps) => {
+export const ImageCaption = ({ isEditing, blockId, appBridge, defaultName }: ImageCaptionProps) => {
     const [blockSettings, setBlockSettings] = useBlockSettings<Settings>(appBridge);
 
     const { name, description } = blockSettings;
@@ -24,13 +24,13 @@ export const ImageCaption = ({ isEditing, blockId, appBridge, titleKey }: ImageC
             data-test-id="image-caption"
         >
             <RichTextEditor
-                key={titleKey}
+                key={defaultName}
                 id={`${blockId}_title`}
                 isEditing={isEditing}
                 plugins={titlePlugins}
                 placeholder="Asset name"
                 showSerializedText={hasRichTextValue(name)}
-                value={name ?? convertToRteValue(TextStyles.imageTitle, '', 'center')}
+                value={name ?? convertToRteValue(TextStyles.imageTitle, defaultName, 'center')}
                 onTextChange={(name) => setBlockSettings({ name })}
             />
             <RichTextEditor

--- a/packages/image-block/src/components/ImageCaption.tsx
+++ b/packages/image-block/src/components/ImageCaption.tsx
@@ -9,10 +9,10 @@ type ImageCaptionProps = {
     blockId: string;
     isEditing: boolean;
     appBridge: AppBridgeBlock;
-    defaultName: string;
+    titleKey: string;
 };
 
-export const ImageCaption = ({ isEditing, blockId, appBridge, defaultName }: ImageCaptionProps) => {
+export const ImageCaption = ({ isEditing, blockId, appBridge, titleKey }: ImageCaptionProps) => {
     const [blockSettings, setBlockSettings] = useBlockSettings<Settings>(appBridge);
 
     const { name, description } = blockSettings;
@@ -24,13 +24,13 @@ export const ImageCaption = ({ isEditing, blockId, appBridge, defaultName }: Ima
             data-test-id="image-caption"
         >
             <RichTextEditor
-                key={defaultName}
+                key={titleKey}
                 id={`${blockId}_title`}
                 isEditing={isEditing}
                 plugins={titlePlugins}
                 placeholder="Asset name"
                 showSerializedText={hasRichTextValue(name)}
-                value={name ?? convertToRteValue(TextStyles.imageTitle, defaultName, 'center')}
+                value={name ?? convertToRteValue(TextStyles.imageTitle, '', 'center')}
                 onTextChange={(name) => setBlockSettings({ name })}
             />
             <RichTextEditor

--- a/packages/image-block/src/components/ImageCaption.tsx
+++ b/packages/image-block/src/components/ImageCaption.tsx
@@ -9,9 +9,10 @@ type ImageCaptionProps = {
     blockId: string;
     isEditing: boolean;
     appBridge: AppBridgeBlock;
+    titleKey: string;
 };
 
-export const ImageCaption = ({ isEditing, blockId, appBridge }: ImageCaptionProps) => {
+export const ImageCaption = ({ isEditing, blockId, appBridge, titleKey }: ImageCaptionProps) => {
     const [blockSettings, setBlockSettings] = useBlockSettings<Settings>(appBridge);
 
     const { name, description } = blockSettings;
@@ -23,6 +24,7 @@ export const ImageCaption = ({ isEditing, blockId, appBridge }: ImageCaptionProp
             data-test-id="image-caption"
         >
             <RichTextEditor
+                key={titleKey}
                 id={`${blockId}_title`}
                 isEditing={isEditing}
                 plugins={titlePlugins}


### PR DESCRIPTION
When an image is first uploaded the name and alt-text will be set to the uploaded image title, and to the filename if the title does not exist. When a second image is uploaded neither of these are updated