### PR TITLE
feat: Template block button styling [CU-8693y5d2j]

### DIFF
--- a/packages/template-block/src/TemplateBlock.spec.ct.tsx
+++ b/packages/template-block/src/TemplateBlock.spec.ct.tsx
@@ -56,6 +56,15 @@ const getTemplateDummyWithPages = () => {
     return templateDummy;
 };
 
+const getValueFromCssVariable = (cssVarName: string, styleName: string) => {
+    const dummy = document.createElement('span');
+    dummy.style.setProperty(styleName, `var(${cssVarName})`);
+    document.body.appendChild(dummy);
+    const value = window.getComputedStyle(dummy).getPropertyValue(styleName).trim();
+    dummy.remove();
+    return value;
+};
+
 describe('Template Block', () => {
     it('should render an empty slate if no template provided', () => {
         const [TemplateBlockWithStubs] = withAppBridgeBlockStubs(TemplateBlock);
@@ -606,5 +615,43 @@ describe('Template Block', () => {
 
         mount(<TemplateBlockWithStubs />);
         cy.get(PREVIEW_WRAPPER_SELECTOR).should('have.css', 'borderRadius', '4px');
+    });
+
+    it('should render the CTA button with primary styling by default', () => {
+        const [TemplateBlockWithStubs] = withAppBridgeBlockStubs(TemplateBlock, {
+            editorState: false,
+            blockSettings: {},
+            blockTemplates: {
+                template: [getTemplateDummyWithPages()],
+            },
+        });
+
+        mount(<TemplateBlockWithStubs />);
+
+        const primaryFontFace = getValueFromCssVariable('--f-theme-settings-button-primary-font-size', 'font-size');
+        cy.get(CTA_BUTTON_SELECTOR)
+            .then(($element) => window.getComputedStyle($element[0]))
+            .invoke('getPropertyValue', 'font-size')
+            .should('equal', primaryFontFace);
+    });
+
+    it('should render the CTA button respecting the button styling', () => {
+        const [TemplateBlockWithStubs] = withAppBridgeBlockStubs(TemplateBlock, {
+            editorState: false,
+            blockSettings: {
+                ctaButtonStyle: 'secondary',
+            },
+            blockTemplates: {
+                template: [getTemplateDummyWithPages()],
+            },
+        });
+
+        mount(<TemplateBlockWithStubs />);
+
+        const secondaryFontFace = getValueFromCssVariable('--f-theme-settings-button-secondary-font-size', 'font-size');
+        cy.get(CTA_BUTTON_SELECTOR)
+            .then(($element) => window.getComputedStyle($element[0]))
+            .invoke('getPropertyValue', 'font-size')
+            .should('equal', secondaryFontFace);
     });
 });

--- a/packages/template-block/src/TemplateBlock.spec.ct.tsx
+++ b/packages/template-block/src/TemplateBlock.spec.ct.tsx
@@ -627,7 +627,7 @@ describe('Template Block', () => {
         const [TemplateBlockWithStubs] = withAppBridgeBlockStubs(TemplateBlock, {
             editorState: false,
             blockSettings: {
-                ctaButtonStyle: 'secondary',
+                buttonStyle: 'secondary',
             },
             blockTemplates: {
                 template: [getTemplateDummyWithPages()],

--- a/packages/template-block/src/TemplateBlock.spec.ct.tsx
+++ b/packages/template-block/src/TemplateBlock.spec.ct.tsx
@@ -56,15 +56,6 @@ const getTemplateDummyWithPages = () => {
     return templateDummy;
 };
 
-const getValueFromCssVariable = (cssVarName: string, styleName: string) => {
-    const dummy = document.createElement('span');
-    dummy.style.setProperty(styleName, `var(${cssVarName})`);
-    document.body.appendChild(dummy);
-    const value = window.getComputedStyle(dummy).getPropertyValue(styleName).trim();
-    dummy.remove();
-    return value;
-};
-
 describe('Template Block', () => {
     it('should render an empty slate if no template provided', () => {
         const [TemplateBlockWithStubs] = withAppBridgeBlockStubs(TemplateBlock);
@@ -627,12 +618,9 @@ describe('Template Block', () => {
         });
 
         mount(<TemplateBlockWithStubs />);
-
-        const primaryFontFace = getValueFromCssVariable('--f-theme-settings-button-primary-font-size', 'font-size');
         cy.get(CTA_BUTTON_SELECTOR)
-            .then(($element) => window.getComputedStyle($element[0]))
-            .invoke('getPropertyValue', 'font-size')
-            .should('equal', primaryFontFace);
+            .should('have.attr', 'style')
+            .and('match', /font-size: var\(--f-theme-settings-button-primary-font-size\)/);
     });
 
     it('should render the CTA button respecting the button styling', () => {
@@ -647,11 +635,8 @@ describe('Template Block', () => {
         });
 
         mount(<TemplateBlockWithStubs />);
-
-        const secondaryFontFace = getValueFromCssVariable('--f-theme-settings-button-secondary-font-size', 'font-size');
         cy.get(CTA_BUTTON_SELECTOR)
-            .then(($element) => window.getComputedStyle($element[0]))
-            .invoke('getPropertyValue', 'font-size')
-            .should('equal', secondaryFontFace);
+            .should('have.attr', 'style')
+            .and('match', /font-size: var\(--f-theme-settings-button-secondary-font-size\)/);
     });
 });

--- a/packages/template-block/src/components/CtaButton.tsx
+++ b/packages/template-block/src/components/CtaButton.tsx
@@ -15,10 +15,26 @@ export const CtaButton = ({
     handleNewPublication,
 }: CtaButtonProps) => {
     const [buttonHover, setButtonHover] = useState<boolean>(false);
-    const { buttonText, preview } = blockSettings;
+    const { buttonText, preview, ctaButtonStyle } = blockSettings;
     const blockId = appBridge.context('blockId').get();
 
     const marginOverwrites = preview === PreviewType.None ? '!tw-m-0' : '!tw-mb-0';
+
+    const buttonStyle = (() => {
+        switch (ctaButtonStyle) {
+            case 'primary':
+                return BlockStyles.buttonPrimary;
+
+            case 'secondary':
+                return BlockStyles.buttonSecondary;
+
+            case 'tertiary':
+                return BlockStyles.buttonTertiary;
+
+            default:
+                return BlockStyles.buttonPrimary;
+        }
+    })();
 
     return (
         <button
@@ -29,8 +45,8 @@ export const CtaButton = ({
             onMouseLeave={() => setButtonHover(false)}
             className={`disabled:tw-opacity-50 ${marginOverwrites}`}
             style={{
-                ...BlockStyles.buttonPrimary,
-                ...(buttonHover ? BlockStyles.buttonPrimary?.hover : null),
+                ...buttonStyle,
+                ...(buttonHover ? buttonStyle?.hover : null),
             }}
         >
             <RichTextEditor

--- a/packages/template-block/src/components/CtaButton.tsx
+++ b/packages/template-block/src/components/CtaButton.tsx
@@ -15,22 +15,19 @@ export const CtaButton = ({
     handleNewPublication,
 }: CtaButtonProps) => {
     const [buttonHover, setButtonHover] = useState<boolean>(false);
-    const { buttonText, preview, ctaButtonStyle } = blockSettings;
+    const { buttonText, preview, buttonStyle } = blockSettings;
     const blockId = appBridge.context('blockId').get();
 
     const marginOverwrites = preview === PreviewType.None ? '!tw-m-0' : '!tw-mb-0';
 
-    const buttonStyle = (() => {
-        switch (ctaButtonStyle) {
+    const buttonStyles = (() => {
+        switch (buttonStyle) {
             case 'primary':
                 return BlockStyles.buttonPrimary;
-
             case 'secondary':
                 return BlockStyles.buttonSecondary;
-
             case 'tertiary':
                 return BlockStyles.buttonTertiary;
-
             default:
                 return BlockStyles.buttonPrimary;
         }
@@ -45,8 +42,8 @@ export const CtaButton = ({
             onMouseLeave={() => setButtonHover(false)}
             className={`disabled:tw-opacity-50 ${marginOverwrites}`}
             style={{
-                ...buttonStyle,
-                ...(buttonHover ? buttonStyle?.hover : null),
+                ...buttonStyles,
+                ...(buttonHover ? buttonStyles?.hover : null),
             }}
         >
             <RichTextEditor

--- a/packages/template-block/src/settings.ts
+++ b/packages/template-block/src/settings.ts
@@ -311,6 +311,34 @@ export const settings = defineSettings({
         {
             id: 'cardStyleHeading',
             type: 'sectionHeading',
+            label: 'Button',
+            blocks: [
+                {
+                    id: 'ctaButtonStyle',
+                    type: 'dropdown',
+                    size: 'small',
+                    defaultValue: 'primary',
+                    label: 'Style',
+                    choices: [
+                        {
+                            label: 'Primary',
+                            value: 'primary',
+                        },
+                        {
+                            label: 'Secondary',
+                            value: 'secondary',
+                        },
+                        {
+                            label: 'Tertiary',
+                            value: 'tertiary',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            id: 'cardStyleHeading',
+            type: 'sectionHeading',
             label: 'Card',
             blocks: [
                 {

--- a/packages/template-block/src/settings.ts
+++ b/packages/template-block/src/settings.ts
@@ -314,7 +314,7 @@ export const settings = defineSettings({
             label: 'Button',
             blocks: [
                 {
-                    id: 'ctaButtonStyle',
+                    id: 'buttonStyle',
                     type: 'dropdown',
                     size: 'small',
                     defaultValue: 'primary',

--- a/packages/template-block/src/types.ts
+++ b/packages/template-block/src/types.ts
@@ -39,7 +39,7 @@ export type Settings = {
     previewImageAnchoring?: AnchoringType;
 
     // Style
-    ctaButtonStyle: RichTextButtonStyle;
+    buttonStyle: RichTextButtonStyle;
 
     hasBackground: boolean;
     backgroundColor: Color;

--- a/packages/template-block/src/types.ts
+++ b/packages/template-block/src/types.ts
@@ -2,7 +2,7 @@
 
 import { Asset, TemplateLegacy } from '@frontify/app-bridge';
 import { Color } from '@frontify/fondue';
-import { BorderStyle, Padding, Radius } from '@frontify/guideline-blocks-settings';
+import { BorderStyle, Padding, Radius, RichTextButtonStyle } from '@frontify/guideline-blocks-settings';
 
 export type Settings = {
     title: string;
@@ -39,6 +39,8 @@ export type Settings = {
     previewImageAnchoring?: AnchoringType;
 
     // Style
+    ctaButtonStyle: RichTextButtonStyle;
+
     hasBackground: boolean;
     backgroundColor: Color;
 


### PR DESCRIPTION
This PR adds support to choose the CTA button styling between Primary, Secondary or Tertiary; before it was hardcoded to primary. Closes https://app.clickup.com/t/8693y5d2j

- [x] Fix styling issues #762 
- [x] Add test

![image](https://github.com/Frontify/guideline-blocks/assets/9266535/1d207d80-5346-4e77-b0de-61019157e34c)
