### PR TITLE
feat: Template Block Performance Improvements [CU-86940ffk3]

### DIFF
--- a/packages/template-block/src/TemplateBlock.tsx
+++ b/packages/template-block/src/TemplateBlock.tsx
@@ -39,8 +39,8 @@ export const TemplateBlock = ({ appBridge }: BlockProps): ReactElement => {
     const handleNewPublication = async () => {
         if (selectedTemplate !== null) {
             const previewUrl =
-                preview === PreviewType.Custom && previewCustom?.length > 0
-                    ? previewCustom[0].previewUrl
+                preview === PreviewType.Custom && previewCustom
+                    ? previewCustom.previewUrl
                     : selectedTemplate.previewUrl;
 
             const options: OpenNewPublicationPayload = {

--- a/packages/template-block/src/TemplateBlock.tsx
+++ b/packages/template-block/src/TemplateBlock.tsx
@@ -39,7 +39,7 @@ export const TemplateBlock = ({ appBridge }: BlockProps): ReactElement => {
     const handleNewPublication = async () => {
         if (selectedTemplate !== null) {
             const previewUrl =
-                preview === PreviewType.Custom && Array.isArray(previewCustom) && previewCustom.length > 0
+                preview === PreviewType.Custom && previewCustom?.length > 0
                     ? previewCustom[0].previewUrl
                     : selectedTemplate.previewUrl;
 

--- a/packages/template-block/src/TemplateBlock.tsx
+++ b/packages/template-block/src/TemplateBlock.tsx
@@ -19,9 +19,10 @@ export const TemplateBlock = ({ appBridge }: BlockProps): ReactElement => {
         contentClasses,
         ctaClasses,
         description,
+        handleDeleteCustomPreview,
+        hasLoggedInUser,
         hasPreview,
         hasTitleOnly,
-        hasLoggedInUser,
         isEditing,
         lastErrorMessage,
         preview,
@@ -70,10 +71,12 @@ export const TemplateBlock = ({ appBridge }: BlockProps): ReactElement => {
                             appBridge={appBridge}
                             blockSettings={blockSettings}
                             template={selectedTemplate}
+                            previewCustom={previewCustom}
                             previewClasses={previewClasses}
                             updateBlockSettings={updateBlockSettings}
                             onOpenTemplateChooser={handleOpenTemplateChooser}
                             handleNewPublication={handleNewPublication}
+                            handleDeleteCustomPreview={handleDeleteCustomPreview}
                         />
                     )}
 

--- a/packages/template-block/src/components/PreviewImage.tsx
+++ b/packages/template-block/src/components/PreviewImage.tsx
@@ -54,7 +54,7 @@ export const PreviewImage = ({
         if (hasCustomPreview) {
             menuItems.push({
                 title: 'Delete custom preview',
-                onClick: handleDeleteCustomPreview,
+                onClick: () => handleDeleteCustomPreview(previewCustom[0].id),
                 style: MenuItemStyle.Danger,
                 icon: <IconTrashBin />,
             });

--- a/packages/template-block/src/components/PreviewImage.tsx
+++ b/packages/template-block/src/components/PreviewImage.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { useBlockAssets, useEditorState } from '@frontify/app-bridge';
+import { useEditorState } from '@frontify/app-bridge';
 import { PreviewType, previewDisplayValues, previewImageAnchoringValues } from '../types';
 import { IconArrowSync, IconSpeechBubbleQuote20, IconTrashBin, MenuItemStyle, merge } from '@frontify/fondue';
 import { BlockItemWrapper, ToolbarFlyoutMenuItem } from '@frontify/guideline-blocks-settings';
@@ -12,39 +12,31 @@ export const PreviewImage = ({
     appBridge,
     blockSettings,
     template,
+    previewCustom,
     updateBlockSettings,
     onOpenTemplateChooser,
+    handleDeleteCustomPreview,
 }: PreviewImageProps) => {
     const isEditing = useEditorState(appBridge);
-    const { blockAssets, deleteAssetIdsFromKey } = useBlockAssets(appBridge);
     const { preview, previewImageAnchoring, previewDisplay } = blockSettings;
+
     const previewSrc = useMemo(
         () =>
-            preview === PreviewType.Custom && blockAssets.previewCustom !== undefined
-                ? blockAssets.previewCustom[0].previewUrl
+            preview === PreviewType.Custom && previewCustom !== undefined
+                ? previewCustom[0].previewUrl
                 : template?.previewUrl,
-        [blockAssets.previewCustom, preview, template?.previewUrl]
+        [previewCustom, preview, template?.previewUrl]
     );
+    const hasCustomPreview = preview === PreviewType.Custom && previewCustom.length > 0;
+
     const [currentPreviewSrc, setCurrentPreviewSrc] = useState(previewSrc);
     const [showAltTextMenu, setShowAltTextMenu] = useState(false);
     const [localAltText, setLocalAltText] = useState<string | undefined>(blockSettings.altText);
     const [isHovered, setIsHovered] = useState(false);
-    const hasCustomPreview = useMemo(
-        () => preview === PreviewType.Custom && blockAssets.previewCustom?.length > 0,
-        [blockAssets.previewCustom?.length, preview]
-    );
 
     useEffect(() => {
         setCurrentPreviewSrc(previewSrc);
     }, [previewSrc]);
-
-    const handleDeleteCustomPreview = async () => {
-        if (hasCustomPreview) {
-            await deleteAssetIdsFromKey('previewCustom', [blockAssets.previewCustom[0].id]);
-            await updateBlockSettings({ altText: undefined });
-            setLocalAltText(undefined);
-        }
-    };
 
     const getItemWrapperMenu = () => {
         const menuItems: ToolbarFlyoutMenuItem[] = [
@@ -83,16 +75,8 @@ export const PreviewImage = ({
                         ? previewImageAnchoringValues[previewImageAnchoring]
                         : 'center',
                 }}
-                width={
-                    preview === PreviewType.Custom && blockAssets.previewCustom
-                        ? blockAssets.previewCustom[0].width
-                        : 'auto'
-                }
-                height={
-                    preview === PreviewType.Custom && blockAssets.previewCustom
-                        ? blockAssets.previewCustom[0].height
-                        : 'auto'
-                }
+                width={preview === PreviewType.Custom && previewCustom ? previewCustom[0].width : 'auto'}
+                height={preview === PreviewType.Custom && previewCustom ? previewCustom[0].height : 'auto'}
                 alt={blockSettings.altText ?? 'Template preview'}
                 onMouseEnter={() => setIsHovered(true)}
                 onMouseLeave={() => setIsHovered(false)}

--- a/packages/template-block/src/components/PreviewImage.tsx
+++ b/packages/template-block/src/components/PreviewImage.tsx
@@ -20,12 +20,12 @@ export const PreviewImage = ({
     const isEditing = useEditorState(appBridge);
     const { preview, previewImageAnchoring, previewDisplay } = blockSettings;
 
-    const hasCustomPreview = preview === PreviewType.Custom && previewCustom?.length > 0;
+    const hasCustomPreview = preview === PreviewType.Custom && previewCustom;
     const { previewSrc, width, height } = hasCustomPreview
         ? {
-              previewSrc: previewCustom[0].previewUrl,
-              width: previewCustom[0].width,
-              height: previewCustom[0].height,
+              previewSrc: previewCustom.previewUrl,
+              width: previewCustom.width,
+              height: previewCustom.height,
           }
         : {
               previewSrc: template?.previewUrl,
@@ -54,7 +54,7 @@ export const PreviewImage = ({
         if (hasCustomPreview) {
             menuItems.push({
                 title: 'Delete custom preview',
-                onClick: () => handleDeleteCustomPreview(previewCustom[0].id),
+                onClick: () => handleDeleteCustomPreview(previewCustom.id),
                 style: MenuItemStyle.Danger,
                 icon: <IconTrashBin />,
             });

--- a/packages/template-block/src/components/PreviewImage.tsx
+++ b/packages/template-block/src/components/PreviewImage.tsx
@@ -5,7 +5,7 @@ import { PreviewType, previewDisplayValues, previewImageAnchoringValues } from '
 import { IconArrowSync, IconSpeechBubbleQuote20, IconTrashBin, MenuItemStyle, merge } from '@frontify/fondue';
 import { BlockItemWrapper, ToolbarFlyoutMenuItem } from '@frontify/guideline-blocks-settings';
 import { EditAltTextFlyout } from '@frontify/guideline-blocks-shared';
-import { useEffect, useMemo, useState } from 'react';
+import { useState } from 'react';
 import { PreviewImageProps } from './types';
 
 export const PreviewImage = ({
@@ -20,23 +20,22 @@ export const PreviewImage = ({
     const isEditing = useEditorState(appBridge);
     const { preview, previewImageAnchoring, previewDisplay } = blockSettings;
 
-    const previewSrc = useMemo(
-        () =>
-            preview === PreviewType.Custom && previewCustom !== undefined
-                ? previewCustom[0].previewUrl
-                : template?.previewUrl,
-        [previewCustom, preview, template?.previewUrl]
-    );
-    const hasCustomPreview = preview === PreviewType.Custom && previewCustom.length > 0;
+    const hasCustomPreview = preview === PreviewType.Custom && previewCustom?.length > 0;
+    const { previewSrc, width, height } = hasCustomPreview
+        ? {
+              previewSrc: previewCustom[0].previewUrl,
+              width: previewCustom[0].width,
+              height: previewCustom[0].height,
+          }
+        : {
+              previewSrc: template?.previewUrl,
+              width: 'auto',
+              height: 'auto',
+          };
 
-    const [currentPreviewSrc, setCurrentPreviewSrc] = useState(previewSrc);
     const [showAltTextMenu, setShowAltTextMenu] = useState(false);
     const [localAltText, setLocalAltText] = useState<string | undefined>(blockSettings.altText);
     const [isHovered, setIsHovered] = useState(false);
-
-    useEffect(() => {
-        setCurrentPreviewSrc(previewSrc);
-    }, [previewSrc]);
 
     const getItemWrapperMenu = () => {
         const menuItems: ToolbarFlyoutMenuItem[] = [
@@ -68,15 +67,15 @@ export const PreviewImage = ({
         <>
             <img
                 data-test-id="preview-img"
-                src={currentPreviewSrc}
+                src={previewSrc}
                 className={merge(['tw-relative tw-w-full tw-h-full', previewDisplayValues[previewDisplay]])}
                 style={{
                     objectPosition: previewImageAnchoring
                         ? previewImageAnchoringValues[previewImageAnchoring]
                         : 'center',
                 }}
-                width={preview === PreviewType.Custom && previewCustom ? previewCustom[0].width : 'auto'}
-                height={preview === PreviewType.Custom && previewCustom ? previewCustom[0].height : 'auto'}
+                width={width}
+                height={height}
                 alt={blockSettings.altText ?? 'Template preview'}
                 onMouseEnter={() => setIsHovered(true)}
                 onMouseLeave={() => setIsHovered(false)}

--- a/packages/template-block/src/components/TemplatePreview.tsx
+++ b/packages/template-block/src/components/TemplatePreview.tsx
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { useBlockAssets, useEditorState } from '@frontify/app-bridge';
+import { useEditorState } from '@frontify/app-bridge';
 import { IconPlus24 } from '@frontify/fondue';
 import { PreviewHeightType, previewHeightValues } from '../types';
 import {
@@ -16,12 +16,13 @@ export const TemplatePreview = ({
     appBridge,
     blockSettings,
     template,
+    previewCustom,
     previewClasses,
     updateBlockSettings,
     onOpenTemplateChooser,
     handleNewPublication,
+    handleDeleteCustomPreview,
 }: TemplatePreviewProps) => {
-    const { blockAssets } = useBlockAssets(appBridge);
     const isEditing = useEditorState(appBridge);
 
     const {
@@ -38,8 +39,6 @@ export const TemplatePreview = ({
         radiusChoice_templatePreview,
         radiusValue_templatePreview,
     } = blockSettings;
-
-    const { previewCustom } = blockAssets;
 
     const borderRadius = hasRadius_templatePreview
         ? radiusValue_templatePreview
@@ -72,8 +71,10 @@ export const TemplatePreview = ({
                         appBridge={appBridge}
                         blockSettings={blockSettings}
                         template={template}
+                        previewCustom={previewCustom}
                         updateBlockSettings={updateBlockSettings}
                         onOpenTemplateChooser={onOpenTemplateChooser}
+                        handleDeleteCustomPreview={handleDeleteCustomPreview}
                     />
                 </button>
             ) : (

--- a/packages/template-block/src/components/types.ts
+++ b/packages/template-block/src/components/types.ts
@@ -23,7 +23,7 @@ export type PreviewImageProps = {
     previewCustom: Asset[];
     updateBlockSettings: (newSettings: Partial<Settings>) => Promise<void>;
     onOpenTemplateChooser: () => void;
-    handleDeleteCustomPreview: () => void;
+    handleDeleteCustomPreview: (assetId: number) => void;
 };
 
 export type TemplatePreviewProps = {
@@ -35,7 +35,7 @@ export type TemplatePreviewProps = {
     updateBlockSettings: (newSettings: Partial<Settings>) => Promise<void>;
     onOpenTemplateChooser: () => void;
     handleNewPublication: () => void;
-    handleDeleteCustomPreview: () => void;
+    handleDeleteCustomPreview: (assetId: number) => void;
 };
 
 export type TemplateTextProps = {

--- a/packages/template-block/src/components/types.ts
+++ b/packages/template-block/src/components/types.ts
@@ -1,6 +1,6 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { AppBridgeBlock, Template } from '@frontify/app-bridge';
+import { AppBridgeBlock, Asset, Template } from '@frontify/app-bridge';
 import { Settings } from '../types';
 
 export type AlertErrorProps = {
@@ -20,18 +20,22 @@ export type PreviewImageProps = {
     appBridge: AppBridgeBlock;
     blockSettings: Settings;
     template: Template | null;
+    previewCustom: Asset[];
     updateBlockSettings: (newSettings: Partial<Settings>) => Promise<void>;
     onOpenTemplateChooser: () => void;
+    handleDeleteCustomPreview: () => void;
 };
 
 export type TemplatePreviewProps = {
     appBridge: AppBridgeBlock;
     blockSettings: Settings;
     template: Template | null;
+    previewCustom: Asset[];
     previewClasses: string;
     updateBlockSettings: (newSettings: Partial<Settings>) => Promise<void>;
     onOpenTemplateChooser: () => void;
     handleNewPublication: () => void;
+    handleDeleteCustomPreview: () => void;
 };
 
 export type TemplateTextProps = {

--- a/packages/template-block/src/components/types.ts
+++ b/packages/template-block/src/components/types.ts
@@ -20,7 +20,7 @@ export type PreviewImageProps = {
     appBridge: AppBridgeBlock;
     blockSettings: Settings;
     template: Template | null;
-    previewCustom: Asset[];
+    previewCustom: Asset | null;
     updateBlockSettings: (newSettings: Partial<Settings>) => Promise<void>;
     onOpenTemplateChooser: () => void;
     handleDeleteCustomPreview: (assetId: number) => void;
@@ -30,7 +30,7 @@ export type TemplatePreviewProps = {
     appBridge: AppBridgeBlock;
     blockSettings: Settings;
     template: Template | null;
-    previewCustom: Asset[];
+    previewCustom: Asset | null;
     previewClasses: string;
     updateBlockSettings: (newSettings: Partial<Settings>) => Promise<void>;
     onOpenTemplateChooser: () => void;

--- a/packages/template-block/src/hooks/useTemplateBlockData.ts
+++ b/packages/template-block/src/hooks/useTemplateBlockData.ts
@@ -47,9 +47,7 @@ export const useTemplateBlockData = (appBridge: BlockProps['appBridge']) => {
     const [hasLoggedInUser, setHasLoggedInUser] = useState(false);
     const isEditing = useEditorState(appBridge);
 
-    const {
-        blockAssets: { previewCustom },
-    } = useBlockAssets(appBridge);
+    const { blockAssets, deleteAssetIdsFromKey } = useBlockAssets(appBridge);
     const { blockTemplates, updateTemplateIdsFromKey, error } = useBlockTemplates(appBridge);
 
     const {
@@ -75,6 +73,9 @@ export const useTemplateBlockData = (appBridge: BlockProps['appBridge']) => {
         title,
     } = blockSettings;
 
+    const hasPreview = preview !== PreviewType.None;
+    const hasTitleOnly = !hasPreview && !hasPageCount && !hasRichTextValue(description);
+
     const onTemplateSelected = useCallback(
         async (result: { template: TemplateLegacy }) => {
             try {
@@ -92,6 +93,11 @@ export const useTemplateBlockData = (appBridge: BlockProps['appBridge']) => {
         },
         [appBridge, templateTextKey, updateBlockSettings, updateTemplateIdsFromKey]
     );
+
+    const handleDeleteCustomPreview = useCallback(async () => {
+        await deleteAssetIdsFromKey('previewCustom', [blockAssets.previewCustom[0].id]);
+        await updateBlockSettings({ altText: undefined });
+    }, [blockAssets.previewCustom, deleteAssetIdsFromKey, updateBlockSettings]);
 
     useEffect(() => {
         const unsubscribeTemplateChooser = appBridge.subscribe('templateChosen', onTemplateSelected);
@@ -120,9 +126,6 @@ export const useTemplateBlockData = (appBridge: BlockProps['appBridge']) => {
             setSelectedTemplate(lastTemplate);
         }
     }, [blockTemplates]);
-
-    const hasPreview = preview !== PreviewType.None;
-    const hasTitleOnly = !hasPreview && !hasPageCount && !hasRichTextValue(description);
 
     useEffect(() => {
         const getCurrentLoggedUser = async () => {
@@ -155,14 +158,15 @@ export const useTemplateBlockData = (appBridge: BlockProps['appBridge']) => {
         contentClasses: getContentClasses(hasPreview, textPositioning, textAnchoringVertical),
         ctaClasses: getCtaClasses(hasPreview, hasTitleOnly, textPositioning, textAnchoringHorizontal),
         description,
+        handleDeleteCustomPreview,
+        hasLoggedInUser,
         hasPreview,
         hasTitleOnly,
-        hasLoggedInUser,
         isEditing,
         lastErrorMessage,
         preview,
         previewClasses: getPreviewClasses(hasPreview, textPositioning, textRatio),
-        previewCustom,
+        previewCustom: blockAssets.previewCustom,
         selectedTemplate,
         templateTextKey,
         textClasses: getTextClasses(hasPreview, hasTitleOnly, textPositioning, textAnchoringHorizontal),

--- a/packages/template-block/src/hooks/useTemplateBlockData.ts
+++ b/packages/template-block/src/hooks/useTemplateBlockData.ts
@@ -172,7 +172,7 @@ export const useTemplateBlockData = (appBridge: BlockProps['appBridge']) => {
         lastErrorMessage,
         preview,
         previewClasses: getPreviewClasses(hasPreview, textPositioning, textRatio),
-        previewCustom: blockAssets.previewCustom,
+        previewCustom: blockAssets.previewCustom?.length > 0 ? blockAssets.previewCustom[0] : null,
         selectedTemplate,
         templateTextKey,
         textClasses: getTextClasses(hasPreview, hasTitleOnly, textPositioning, textAnchoringHorizontal),

--- a/packages/template-block/src/hooks/useTemplateBlockData.ts
+++ b/packages/template-block/src/hooks/useTemplateBlockData.ts
@@ -94,13 +94,16 @@ export const useTemplateBlockData = (appBridge: BlockProps['appBridge']) => {
         [appBridge, templateTextKey, updateBlockSettings, updateTemplateIdsFromKey]
     );
 
-    const handleDeleteCustomPreview = useCallback(async () => {
-        await deleteAssetIdsFromKey('previewCustom', [blockAssets.previewCustom[0].id]);
-        await updateBlockSettings({
-            preview: PreviewType.Template,
-            altText: undefined,
-        });
-    }, [blockAssets.previewCustom, deleteAssetIdsFromKey, updateBlockSettings]);
+    const handleDeleteCustomPreview = useCallback(
+        async (assetId: number) => {
+            await deleteAssetIdsFromKey('previewCustom', [assetId]);
+            await updateBlockSettings({
+                preview: PreviewType.Template,
+                altText: undefined,
+            });
+        },
+        [deleteAssetIdsFromKey, updateBlockSettings]
+    );
 
     useEffect(() => {
         const unsubscribeTemplateChooser = appBridge.subscribe('templateChosen', onTemplateSelected);

--- a/packages/template-block/src/hooks/useTemplateBlockData.ts
+++ b/packages/template-block/src/hooks/useTemplateBlockData.ts
@@ -96,7 +96,10 @@ export const useTemplateBlockData = (appBridge: BlockProps['appBridge']) => {
 
     const handleDeleteCustomPreview = useCallback(async () => {
         await deleteAssetIdsFromKey('previewCustom', [blockAssets.previewCustom[0].id]);
-        await updateBlockSettings({ altText: undefined });
+        await updateBlockSettings({
+            preview: PreviewType.Template,
+            altText: undefined,
+        });
     }, [blockAssets.previewCustom, deleteAssetIdsFromKey, updateBlockSettings]);
 
     useEffect(() => {


### PR DESCRIPTION
This PR reduces the amount of `/asset` API requests by only using the `useBlockAssets` hook once, instead of 3x. It also cleans up data handling, esp. regarding the `previewCustom`.

What to test: Set the preview to "Custom", and check that there actually is only 1 `/asset` API call. Before this PR, there should be 3 API calls.

Would be nice:
- [ ] Don't use `useBlockAssets` at all if preview is not set to custom -> blocked because `handleNewPublication` needs the custom `previewUrl`; could be circumvented by using the `useBlockAsset` hook conditionally only if the custom preview is actually set, but this gets extremely fiddly with state management.