### PR TITLE
feat(AssetKitBlock): remove race condition

### DIFF
--- a/packages/asset-kit-block/src/AssetKitBlock.spec.ct.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.spec.ct.tsx
@@ -373,7 +373,6 @@ describe('AssetKit Block', () => {
         const [AssetKitBlockWithStubs] = withAppBridgeBlockStubs(AssetKitBlock, {
             blockSettings: {
                 downloadUrlBlock: 'dummy-download-url',
-                downloadExpiration: Math.floor(Date.now() / 1000) + 1000,
             },
             blockAssets: {
                 [ASSET_SETTINGS_ID]: [AssetDummy.with(1)],

--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -39,7 +39,6 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
         hasBorder_blocks,
         hasBackgroundBlocks,
         downloadUrlBlock,
-        downloadExpiration,
         showThumbnails = true,
         showCount = true,
         assetCountColor,
@@ -51,7 +50,7 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
     const { generateBulkDownload, status, downloadUrl } = useAssetBulkDownload(appBridge);
 
     const startDownload = () => {
-        if (downloadUrlBlock && downloadExpiration && downloadExpiration > Math.floor(Date.now() / 1000)) {
+        if (downloadUrlBlock && getExpirationTimestamp(downloadUrlBlock) > Math.floor(Date.now() / 1000)) {
             return downloadAssets(downloadUrlBlock);
         }
         generateBulkDownload(blockAssets);
@@ -73,7 +72,6 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
     const saveDownloadUrl = (newDownloadUrlBlock: string) => {
         if (downloadUrlBlock !== newDownloadUrlBlock) {
             setBlockSettings({ downloadUrlBlock: newDownloadUrlBlock });
-            setBlockSettings({ downloadExpiration: getExpirationTimestamp(newDownloadUrlBlock) });
         }
     };
 

--- a/packages/asset-kit-block/src/types.ts
+++ b/packages/asset-kit-block/src/types.ts
@@ -26,7 +26,6 @@ export type Settings = {
     radiusValue_thumbnails?: number;
     description?: string;
     title?: string;
-    downloadExpiration?: number;
     downloadUrlBlock: string;
     showThumbnails?: boolean;
     showCount?: boolean;


### PR DESCRIPTION
Previously the expiration and the url was set at the same time with different `setBlockSettings` which resulted in race condition.

Since the download expiration is extracted from the URL, I removed the `downloadExpiration` from the settings and now we only rely on the `downloadUrlBlock` to determine the expiration.

https://app.clickup.com/t/2523021/TASK-10645