### PR TITLE
fix(AssetKitBlock): created date is not taken into account

### DIFF
--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -50,7 +50,8 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
     const { generateBulkDownload, status, downloadUrl } = useAssetBulkDownload(appBridge);
 
     const startDownload = () => {
-        if (downloadUrlBlock && getExpirationTimestamp(downloadUrlBlock) > Date.now()) {
+        const expirationTimestamp = getExpirationTimestamp(downloadUrlBlock);
+        if (downloadUrlBlock && !isNaN(expirationTimestamp) && expirationTimestamp > Date.now()) {
             return downloadAssets(downloadUrlBlock);
         }
         generateBulkDownload(blockAssets);

--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -50,10 +50,13 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
     const { generateBulkDownload, status, downloadUrl } = useAssetBulkDownload(appBridge);
 
     const startDownload = () => {
-        const expirationTimestamp = getExpirationTimestamp(downloadUrlBlock);
-        if (downloadUrlBlock && !isNaN(expirationTimestamp) && expirationTimestamp > Date.now()) {
-            return downloadAssets(downloadUrlBlock);
+        if (downloadUrlBlock) {
+            const expirationTimestamp = getExpirationTimestamp(downloadUrlBlock);
+            if (!isNaN(expirationTimestamp) && expirationTimestamp > Date.now()) {
+                return downloadAssets(downloadUrlBlock);
+            }
         }
+
         generateBulkDownload(blockAssets);
     };
 

--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -22,7 +22,7 @@ import 'tailwindcss/tailwind.css';
 import '@frontify/guideline-blocks-settings/styles';
 import '@frontify/fondue/style';
 import { AssetGrid, AssetSelection, DownloadMessage, InformationSection } from './components';
-import { blockStyle } from './helpers';
+import { blockStyle, transformDateStringToDate } from './helpers';
 import { ASSET_SETTINGS_ID } from './settings';
 import { Settings } from './types';
 
@@ -64,22 +64,10 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
         announceToScreenReader();
     };
 
-    const transformDateStringToDate = (dateString: string) => {
-        const year = dateString.substring(0, 4);
-        const month = dateString.substring(4, 6);
-        const day = dateString.substring(6, 8);
-        const hour = dateString.substring(9, 11);
-        const minute = dateString.substring(11, 13);
-        const second = dateString.substring(13, 15);
-
-        return new Date(`${year}-${month}-${day}T${hour}:${minute}:${second}Z`);
-    };
-
     const getExpirationTimestamp = (downloadUrl: string) => {
         const creationDate = transformDateStringToDate(downloadUrl.split('X-Amz-Date=')[1]?.split('&')[0] ?? '');
         const lifetime = downloadUrl.split('X-Amz-Expires=')[1]?.split('&')[0] ?? 0;
-        const expirationTimestamp = creationDate.getTime() + Number(lifetime) * 1000;
-        return expirationTimestamp;
+        return creationDate.getTime() + Number(lifetime) * 1000;
     };
 
     const saveDownloadUrl = (newDownloadUrlBlock: string) => {

--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -50,7 +50,7 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
     const { generateBulkDownload, status, downloadUrl } = useAssetBulkDownload(appBridge);
 
     const startDownload = () => {
-        if (downloadUrlBlock && getExpirationTimestamp(downloadUrlBlock) > Math.floor(Date.now() / 1000)) {
+        if (downloadUrlBlock && getExpirationTimestamp(downloadUrlBlock) > Date.now()) {
             return downloadAssets(downloadUrlBlock);
         }
         generateBulkDownload(blockAssets);
@@ -64,9 +64,22 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement => {
         announceToScreenReader();
     };
 
+    const transformDateStringToDate = (dateString: string) => {
+        const year = dateString.substring(0, 4);
+        const month = dateString.substring(4, 6);
+        const day = dateString.substring(6, 8);
+        const hour = dateString.substring(9, 11);
+        const minute = dateString.substring(11, 13);
+        const second = dateString.substring(13, 15);
+
+        return new Date(`${year}-${month}-${day}T${hour}:${minute}:${second}Z`);
+    };
+
     const getExpirationTimestamp = (downloadUrl: string) => {
-        const expirationTimestamp = downloadUrl.split('X-Amz-Expires=')[1]?.split('&')[0] ?? 0;
-        return parseInt(expirationTimestamp, 10) + Math.floor(Date.now() / 1000);
+        const creationDate = transformDateStringToDate(downloadUrl.split('X-Amz-Date=')[1]?.split('&')[0] ?? '');
+        const lifetime = downloadUrl.split('X-Amz-Expires=')[1]?.split('&')[0] ?? 0;
+        const expirationTimestamp = creationDate.getTime() + Number(lifetime) * 1000;
+        return expirationTimestamp;
     };
 
     const saveDownloadUrl = (newDownloadUrlBlock: string) => {

--- a/packages/asset-kit-block/src/helpers/assetKitHelpers.spec.ts
+++ b/packages/asset-kit-block/src/helpers/assetKitHelpers.spec.ts
@@ -1,0 +1,26 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { describe, expect, it } from 'vitest';
+
+import { transformDateStringToDate } from './assetKitHelpers';
+
+describe('transformDateStringToDate', () => {
+    const testCases = [
+        {
+            input: '20240204T123044Z',
+            output: new Date('2024-02-04T12:30:44Z'),
+        },
+        {
+            input: '20241231T000000Z',
+            output: new Date('2024-12-31T00:00:00Z'),
+        },
+    ];
+    for (const testCase of testCases) {
+        it('should return the correct output', () => {
+            expect(transformDateStringToDate(testCase.input).getTime()).toBe(testCase.output.getTime());
+        });
+    }
+    it('should return invalid date for invalid input', () => {
+        expect(transformDateStringToDate('invalid-input').getTime()).toBe(NaN);
+    });
+});

--- a/packages/asset-kit-block/src/helpers/assetKitHelpers.ts
+++ b/packages/asset-kit-block/src/helpers/assetKitHelpers.ts
@@ -48,3 +48,14 @@ export const blockStyle = (blockSetting: Settings): CSSProperties => {
 export const getSmallPreviewUrl = (url: string) => {
     return url.replace('{width}', '218');
 };
+
+export const transformDateStringToDate = (dateString: string) => {
+    const year = dateString.substring(0, 4);
+    const month = dateString.substring(4, 6);
+    const day = dateString.substring(6, 8);
+    const hour = dateString.substring(9, 11);
+    const minute = dateString.substring(11, 13);
+    const second = dateString.substring(13, 15);
+
+    return new Date(`${year}-${month}-${day}T${hour}:${minute}:${second}Z`);
+};

--- a/packages/asset-kit-block/src/types.ts
+++ b/packages/asset-kit-block/src/types.ts
@@ -26,7 +26,7 @@ export type Settings = {
     radiusValue_thumbnails?: number;
     description?: string;
     title?: string;
-    downloadUrlBlock: string;
+    downloadUrlBlock?: string;
     showThumbnails?: boolean;
     showCount?: boolean;
     assetCountColor?: 'inherit' | 'override';


### PR DESCRIPTION
With the new approach we need to calculate the expiration timestamp with the following formula:

CreationDate + Lifetime.

Previously it was:

Date.now() + Lifetime