### PR TITLE
feat(ImageBlock): allow attachments when block is empty

### DIFF
--- a/packages/image-block/src/ImageBlock.spec.ct.tsx
+++ b/packages/image-block/src/ImageBlock.spec.ct.tsx
@@ -116,6 +116,23 @@ describe('Image Block', () => {
         cy.get(DownloadSelector).should('exist');
     });
 
+    it('should not render the download button if the image is not uploaded but there are attachments', () => {
+        const ImageBlockWithStubs = getImageBlockWithContainer({
+            editorState: false,
+            blockSettings: {
+                security: Security.Custom,
+                downloadable: true,
+            },
+            blockAssets: {
+                [IMAGE_ID]: [],
+                [ATTACHMENTS_ASSET_ID]: [AssetDummy.with(1)],
+            },
+        });
+        mount(<ImageBlockWithStubs />);
+        cy.get(DownloadSelector).should('not.exist');
+        cy.get(AttachmentsSelector).should('exist');
+    });
+
     it('should not render the download button if the security settings disallow it', () => {
         const ImageBlockWithStubs = getImageBlockWithContainer({
             blockSettings: {

--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -135,7 +135,7 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
             <div data-test-id="image-block" className={`tw-flex tw-h-auto ${mapCaptionPositionClasses[positioning]}`}>
                 <div
                     className={merge([
-                        'tw-min-h-11',
+                        attachmentCount > 0 && 'tw-min-h-11',
                         positioning === CaptionPosition.Above || positioning === CaptionPosition.Below
                             ? 'tw-w-full'
                             : imageRatioValues[ratio],

--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -12,15 +12,11 @@ import {
     usePrivacySettings,
 } from '@frontify/app-bridge';
 import {
-    Attachments,
     BlockItemWrapper,
     BlockProps,
-    DownloadButton,
     TextStyles,
     convertToRteValue,
     hasRichTextValue,
-    isDownloadable,
-    useAttachmentsContext,
     withAttachmentsProvider,
 } from '@frontify/guideline-blocks-settings';
 import { getEditAltTextToolbarButton } from '@frontify/guideline-blocks-shared';
@@ -45,13 +41,10 @@ import { CaptionPosition, type Settings, imageRatioValues, mapCaptionPositionCla
 import '@frontify/guideline-blocks-settings/styles';
 import '@frontify/fondue/style';
 import 'tailwindcss/tailwind.css';
-import { getTotalImagePadding } from './components/helpers';
+import { DownloadAndAttachments } from './components/DownloadAndAttachments';
 
 export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) => {
-    const { attachments, onAttachmentsAdd, onAttachmentDelete, onAttachmentReplace, onAttachmentsSorted } =
-        useAttachmentsContext();
     const { assetDownloadEnabled, assetViewerEnabled } = usePrivacySettings(appBridge);
-
     const [blockSettings, setBlockSettings] = useBlockSettings<Settings>(appBridge);
     const [titleKey, setTitleKey] = useState(generateRandomId());
     const { openAssetChooser, closeAssetChooser } = useAssetChooser(appBridge);
@@ -141,36 +134,13 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
                             : imageRatioValues[ratio],
                     ])}
                 >
-                    {!isEditing && (
-                        <div className="tw-absolute tw-top-2 tw-right-2 tw-z-50">
-                            <div
-                                className="tw-flex tw-gap-2"
-                                data-test-id="buttons-wrapper"
-                                style={getTotalImagePadding(blockSettings)}
-                            >
-                                {isDownloadable(
-                                    blockSettings.security,
-                                    blockSettings.downloadable,
-                                    assetDownloadEnabled
-                                ) && (
-                                    <DownloadButton
-                                        onDownload={() => appBridge.dispatch({ name: 'downloadAsset', payload: image })}
-                                    />
-                                )}
-
-                                <Attachments
-                                    onUpload={onAttachmentsAdd}
-                                    onDelete={onAttachmentDelete}
-                                    onReplaceWithBrowse={onAttachmentReplace}
-                                    onReplaceWithUpload={onAttachmentReplace}
-                                    onSorted={onAttachmentsSorted}
-                                    onBrowse={onAttachmentsAdd}
-                                    items={attachments}
-                                    appBridge={appBridge}
-                                />
-                            </div>
-                        </div>
-                    )}
+                    <DownloadAndAttachments
+                        appBridge={appBridge}
+                        assetDownloadEnabled={assetDownloadEnabled}
+                        blockSettings={blockSettings}
+                        image={image}
+                        isEditing={isEditing}
+                    />
                     {image ? (
                         <BlockItemWrapper
                             shouldHideWrapper={!isEditing}

--- a/packages/image-block/src/components/DownloadAndAttachments.tsx
+++ b/packages/image-block/src/components/DownloadAndAttachments.tsx
@@ -35,7 +35,7 @@ export const DownloadAndAttachments = ({
                 data-test-id="buttons-wrapper"
                 style={getTotalImagePadding(blockSettings)}
             >
-                {isDownloadable(blockSettings.security, blockSettings.downloadable, assetDownloadEnabled) && (
+                {image && isDownloadable(blockSettings.security, blockSettings.downloadable, assetDownloadEnabled) && (
                     <DownloadButton onDownload={() => appBridge.dispatch({ name: 'downloadAsset', payload: image })} />
                 )}
 

--- a/packages/image-block/src/components/DownloadAndAttachments.tsx
+++ b/packages/image-block/src/components/DownloadAndAttachments.tsx
@@ -1,0 +1,55 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import {
+    Attachments,
+    DownloadButton,
+    isDownloadable,
+    useAttachmentsContext,
+} from '@frontify/guideline-blocks-settings';
+import { getTotalImagePadding } from './helpers';
+import { AppBridgeBlock, Asset } from '@frontify/app-bridge';
+import { Settings } from '../types';
+
+type DownloadAndAttachmentsProps = {
+    appBridge: AppBridgeBlock;
+    isEditing: boolean;
+    image: Asset;
+    blockSettings: Settings;
+    assetDownloadEnabled: boolean;
+};
+
+export const DownloadAndAttachments = ({
+    appBridge,
+    isEditing,
+    image,
+    blockSettings,
+    assetDownloadEnabled,
+}: DownloadAndAttachmentsProps) => {
+    const { attachments, onAttachmentsAdd, onAttachmentDelete, onAttachmentReplace, onAttachmentsSorted } =
+        useAttachmentsContext();
+
+    return !isEditing ? (
+        <div className="tw-absolute tw-top-2 tw-right-2 tw-z-50">
+            <div
+                className="tw-flex tw-gap-2"
+                data-test-id="buttons-wrapper"
+                style={getTotalImagePadding(blockSettings)}
+            >
+                {isDownloadable(blockSettings.security, blockSettings.downloadable, assetDownloadEnabled) && (
+                    <DownloadButton onDownload={() => appBridge.dispatch({ name: 'downloadAsset', payload: image })} />
+                )}
+
+                <Attachments
+                    onUpload={onAttachmentsAdd}
+                    onDelete={onAttachmentDelete}
+                    onReplaceWithBrowse={onAttachmentReplace}
+                    onReplaceWithUpload={onAttachmentReplace}
+                    onSorted={onAttachmentsSorted}
+                    onBrowse={onAttachmentsAdd}
+                    items={attachments}
+                    appBridge={appBridge}
+                />
+            </div>
+        </div>
+    ) : null;
+};

--- a/packages/image-block/src/components/Image.tsx
+++ b/packages/image-block/src/components/Image.tsx
@@ -1,17 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
 import { Settings, mapAlignmentClasses } from '../types';
-import {
-    Attachments,
-    DownloadButton,
-    Security,
-    isDownloadable,
-    joinClassNames,
-    useAttachmentsContext,
-} from '@frontify/guideline-blocks-settings';
+import { Security, joinClassNames } from '@frontify/guideline-blocks-settings';
 import { useFocusRing } from '@react-aria/focus';
-import { AppBridgeBlock, Asset, useAssetViewer, usePrivacySettings } from '@frontify/app-bridge';
-import { getImageWrapperStyle, getTotalImagePadding } from './helpers';
+import { AppBridgeBlock, Asset, useAssetViewer } from '@frontify/app-bridge';
+import { getImageWrapperStyle } from './helpers';
 import { FOCUS_STYLE } from '@frontify/fondue';
 import { ResponsiveImage, useImageContainer } from '@frontify/guideline-blocks-shared';
 
@@ -20,6 +13,7 @@ type ImageProps = {
     blockSettings: Settings;
     isEditing: boolean;
     appBridge: AppBridgeBlock;
+    globalAssetViewerEnabled: boolean;
 };
 
 export const ImageComponent = ({
@@ -81,12 +75,10 @@ export const ImageComponent = ({
     return Image;
 };
 
-export const Image = ({ image, appBridge, blockSettings, isEditing }: ImageProps) => {
+export const Image = ({ image, appBridge, blockSettings, isEditing, globalAssetViewerEnabled }: ImageProps) => {
     const { containerWidth, setContainerRef } = useImageContainer();
-    const { attachments, onAttachmentsAdd, onAttachmentDelete, onAttachmentReplace, onAttachmentsSorted } =
-        useAttachmentsContext();
+
     const imageWrapperStyle = getImageWrapperStyle(blockSettings);
-    const { assetDownloadEnabled, assetViewerEnabled: globalAssetViewerEnabled } = usePrivacySettings(appBridge);
     const { assetViewerEnabled, security } = blockSettings;
 
     const isAssetViewerEnabled = security === Security.Custom ? assetViewerEnabled : globalAssetViewerEnabled;
@@ -107,37 +99,8 @@ export const Image = ({ image, appBridge, blockSettings, isEditing }: ImageProps
                         image={image}
                         isEditing={isEditing}
                         isAssetViewerEnabled={isAssetViewerEnabled}
+                        globalAssetViewerEnabled={globalAssetViewerEnabled}
                     />
-                )}
-                {!isEditing && (
-                    <div className="tw-absolute tw-top-2 tw-right-2 tw-z-50">
-                        <div
-                            className="tw-flex tw-gap-2"
-                            data-test-id="buttons-wrapper"
-                            style={getTotalImagePadding(blockSettings)}
-                        >
-                            {isDownloadable(
-                                blockSettings.security,
-                                blockSettings.downloadable,
-                                assetDownloadEnabled
-                            ) && (
-                                <DownloadButton
-                                    onDownload={() => appBridge.dispatch({ name: 'downloadAsset', payload: image })}
-                                />
-                            )}
-
-                            <Attachments
-                                onUpload={onAttachmentsAdd}
-                                onDelete={onAttachmentDelete}
-                                onReplaceWithBrowse={onAttachmentReplace}
-                                onReplaceWithUpload={onAttachmentReplace}
-                                onSorted={onAttachmentsSorted}
-                                onBrowse={onAttachmentsAdd}
-                                items={attachments}
-                                appBridge={appBridge}
-                            />
-                        </div>
-                    </div>
                 )}
             </div>
         </div>

--- a/packages/image-block/src/components/ImageCaption.tsx
+++ b/packages/image-block/src/components/ImageCaption.tsx
@@ -9,7 +9,7 @@ import {
 } from '@frontify/guideline-blocks-settings';
 import { getCaptionPlugins, titlePlugins } from './helpers';
 import { AppBridgeBlock } from '@frontify/app-bridge';
-import { CaptionPosition, Ratio, type Settings, textRatioValues } from '../types';
+import { CaptionPosition, type Ratio, type Settings, textRatioValues } from '../types';
 
 type ImageCaptionProps = {
     blockId: string;
@@ -36,7 +36,12 @@ export const ImageCaption = ({
 }: ImageCaptionProps) => {
     const hasTitle = hasRichTextValue(name);
     const hasDescription = hasRichTextValue(description);
-    return isEditing || hasTitle || hasDescription ? (
+
+    if (!isEditing && !hasTitle && !hasDescription) {
+        return null;
+    }
+
+    return (
         <div
             className={
                 positioning === CaptionPosition.Above || positioning === CaptionPosition.Below
@@ -73,5 +78,5 @@ export const ImageCaption = ({
                 />
             </div>
         </div>
-    ) : null;
+    );
 };

--- a/packages/image-block/src/components/ImageCaption.tsx
+++ b/packages/image-block/src/components/ImageCaption.tsx
@@ -9,7 +9,7 @@ import {
 } from '@frontify/guideline-blocks-settings';
 import { getCaptionPlugins, titlePlugins } from './helpers';
 import { AppBridgeBlock } from '@frontify/app-bridge';
-import { CaptionPosition, type Settings } from '../types';
+import { CaptionPosition, Ratio, type Settings, textRatioValues } from '../types';
 
 type ImageCaptionProps = {
     blockId: string;
@@ -20,6 +20,7 @@ type ImageCaptionProps = {
     name?: string;
     description?: string;
     setBlockSettings: (newBlockSettings: Partial<Settings>) => void;
+    ratio: Ratio;
 };
 
 export const ImageCaption = ({
@@ -30,36 +31,47 @@ export const ImageCaption = ({
     description,
     name,
     positioning,
+    ratio,
     setBlockSettings,
 }: ImageCaptionProps) => {
-    return (
+    const hasTitle = hasRichTextValue(name);
+    const hasDescription = hasRichTextValue(description);
+    return isEditing || hasTitle || hasDescription ? (
         <div
-            className={joinClassNames([
-                positioning === CaptionPosition.Below && 'tw-mt-3',
-                'tw-gap-1 tw-flex-1 tw-w-full',
-            ])}
-            style={{ wordBreak: 'break-word' }}
-            data-test-id="image-caption"
+            className={
+                positioning === CaptionPosition.Above || positioning === CaptionPosition.Below
+                    ? 'tw-w-full'
+                    : textRatioValues[ratio]
+            }
         >
-            <RichTextEditor
-                key={titleKey}
-                id={`${blockId}_title`}
-                isEditing={isEditing}
-                plugins={titlePlugins}
-                placeholder="Asset name"
-                showSerializedText={hasRichTextValue(name)}
-                value={name ?? convertToRteValue(TextStyles.imageTitle, '', 'center')}
-                onTextChange={(name) => setBlockSettings({ name })}
-            />
-            <RichTextEditor
-                id={`${blockId}_description`}
-                isEditing={isEditing}
-                plugins={getCaptionPlugins(appBridge)}
-                onTextChange={(description) => setBlockSettings({ description })}
-                placeholder="Add a description here"
-                showSerializedText={hasRichTextValue(description)}
-                value={description ?? convertToRteValue(TextStyles.imageCaption, '', 'center')}
-            />
+            <div
+                className={joinClassNames([
+                    positioning === CaptionPosition.Below && 'tw-mt-3',
+                    'tw-gap-1 tw-flex-1 tw-w-full',
+                ])}
+                style={{ wordBreak: 'break-word' }}
+                data-test-id="image-caption"
+            >
+                <RichTextEditor
+                    key={titleKey}
+                    id={`${blockId}_title`}
+                    isEditing={isEditing}
+                    plugins={titlePlugins}
+                    placeholder="Asset name"
+                    showSerializedText={hasTitle}
+                    value={name ?? convertToRteValue(TextStyles.imageTitle, '', 'center')}
+                    onTextChange={(name) => setBlockSettings({ name })}
+                />
+                <RichTextEditor
+                    id={`${blockId}_description`}
+                    isEditing={isEditing}
+                    plugins={getCaptionPlugins(appBridge)}
+                    onTextChange={(description) => setBlockSettings({ description })}
+                    placeholder="Add a description here"
+                    showSerializedText={hasDescription}
+                    value={description ?? convertToRteValue(TextStyles.imageCaption, '', 'center')}
+                />
+            </div>
         </div>
-    );
+    ) : null;
 };


### PR DESCRIPTION
https://www.figma.com/file/pYt8ECuB6Sc63cVtpKiDgf/Blocks---Updated?type=design&node-id=485-128059&mode=design&t=Ax3uS4Y06OpRKh6h-0

https://www.loom.com/share/911b7fb9330b4b9a8ac98dd2aae8a03f

CU-86947yy57

https://app.clickup.com/t/86947yy57



## Changes

1. Attachments moved to parent component so overflow:hidden is not applied to that.
2. Added a 44px min height to the image component if there are attachments.
3. Hide captions if there is none in view mode.