### PR TITLE
fix: image focus styles

### DIFF
--- a/packages/image-block/src/ImageBlock.spec.ct.tsx
+++ b/packages/image-block/src/ImageBlock.spec.ct.tsx
@@ -15,9 +15,10 @@ import {
 import { Security } from '@frontify/guideline-blocks-settings';
 
 const ImageBlockSelector = '[data-test-id="image-block"]';
-const ImageBlockImageWrapperSelector = '[data-test-id="image-block-img-wrapper"]';
-const ImageBlockAssetViewerButtonSelector = '[data-test-id="image-block-asset-viewer-button"]';
-const ImageBlockImageSelector = '[data-test-id="image-block-img"]';
+const ImageBlockImageSelector = '[data-test-id="image-block-image"]';
+const ImageBlockImageComponentSelector = '[data-test-id="image-block-image-component"]';
+const ImageBlockAssetViewerButtonSelector = '[data-test-id="image-block-asset-viewer-wrapper"]';
+const ImageBlockDefaultWrapperSelector = '[data-test-id="image-block-default-wrapper"]';
 const ImageBlockCaption = '[data-test-id="image-caption"]';
 const PlaceholderSelector = '[data-test-id="block-inject-button"]';
 const DownloadSelector = '[data-test-id="download-button"]';
@@ -65,10 +66,10 @@ describe('Image Block', () => {
             },
         });
         mount(<ImageBlockWithStubs />);
-        cy.get(ImageBlockImageSelector).should('exist');
+        cy.get(ImageBlockImageComponentSelector).should('exist');
     });
 
-    it('should render the image responsively rounded to the nearest hundred pixel', () => {
+    it.only('should render the image responsively rounded to the nearest hundred pixel', () => {
         cy.viewport(240, 800);
         const ImageBlockWithStubs = getImageBlockWithContainer({
             blockAssets: {
@@ -76,26 +77,26 @@ describe('Image Block', () => {
             },
         });
         mount(<ImageBlockWithStubs />);
-        cy.get(ImageBlockImageSelector).should('exist');
-        cy.get(ImageBlockImageSelector).should(
+        cy.get(ImageBlockImageComponentSelector).should('exist');
+        cy.get(ImageBlockImageComponentSelector).should(
             'have.attr',
             'src',
             'https://generic.url?width=300&format=webp&quality=75'
         );
         cy.viewport(280, 800);
-        cy.get(ImageBlockImageSelector).should(
+        cy.get(ImageBlockImageComponentSelector).should(
             'have.attr',
             'src',
             'https://generic.url?width=300&format=webp&quality=75'
         );
         cy.viewport(400, 800);
-        cy.get(ImageBlockImageSelector).should(
+        cy.get(ImageBlockImageComponentSelector).should(
             'have.attr',
             'src',
             'https://generic.url?width=400&format=webp&quality=75'
         );
         cy.viewport(401, 800);
-        cy.get(ImageBlockImageSelector).should(
+        cy.get(ImageBlockImageComponentSelector).should(
             'have.attr',
             'src',
             'https://generic.url?width=500&format=webp&quality=75'
@@ -144,7 +145,7 @@ describe('Image Block', () => {
             },
         });
         mount(<ImageBlockWithStubs />);
-        cy.get(ImageBlockImageSelector).should('exist');
+        cy.get(ImageBlockImageComponentSelector).should('exist');
         cy.get(ImageBlockAssetViewerButtonSelector).should('exist');
     });
 
@@ -164,7 +165,7 @@ describe('Image Block', () => {
             },
         });
         mount(<ImageBlockWithStubs />);
-        cy.get(ImageBlockImageSelector).should('exist');
+        cy.get(ImageBlockImageComponentSelector).should('exist');
         cy.get(ImageBlockAssetViewerButtonSelector).should('not.exist');
     });
 
@@ -183,7 +184,7 @@ describe('Image Block', () => {
             },
         });
         mount(<ImageBlockWithStubs />);
-        cy.get(ImageBlockImageSelector).should('exist');
+        cy.get(ImageBlockImageComponentSelector).should('exist');
         cy.get(ImageBlockAssetViewerButtonSelector).should('not.exist');
     });
 
@@ -202,7 +203,7 @@ describe('Image Block', () => {
             },
         });
         mount(<ImageBlockWithStubs />);
-        cy.get(ImageBlockImageSelector).should('exist');
+        cy.get(ImageBlockImageComponentSelector).should('exist');
         cy.get(ImageBlockAssetViewerButtonSelector).should('exist');
     });
 
@@ -269,7 +270,7 @@ describe('Image Block', () => {
             },
         });
         mount(<ImageBlockWithStubs />);
-        cy.get(ImageBlockImageWrapperSelector).should('have.css', 'border', '1px solid rgb(0, 0, 255)');
+        cy.get(ImageBlockDefaultWrapperSelector).should('have.css', 'border', '1px solid rgb(0, 0, 255)');
     });
 
     it('should change layout according to provided positioning', () => {
@@ -309,7 +310,7 @@ describe('Image Block', () => {
             },
         });
         mount(<ImageBlockWithStubs />);
-        cy.get(ImageBlockImageWrapperSelector).should('have.css', 'backgroundColor', 'rgb(0, 0, 255)');
+        cy.get(ImageBlockDefaultWrapperSelector).should('have.css', 'backgroundColor', 'rgb(0, 0, 255)');
     });
 
     it('should add padding provided', () => {
@@ -323,7 +324,7 @@ describe('Image Block', () => {
             },
         });
         mount(<ImageBlockWithStubs />);
-        cy.get(ImageBlockImageWrapperSelector).should('have.css', 'padding', '16px');
+        cy.get(ImageBlockDefaultWrapperSelector).should('have.css', 'padding', '16px');
     });
 
     it('should add alignment of the image if provided', () => {
@@ -336,7 +337,7 @@ describe('Image Block', () => {
             },
         });
         mount(<ImageBlockWithStubs />);
-        cy.get(`${ImageBlockImageWrapperSelector} > div`).should('have.class', mapAlignmentClasses[Alignment.Right]);
+        cy.get(ImageBlockImageSelector).should('have.class', mapAlignmentClasses[Alignment.Right]);
     });
 
     it('should add padding to buttons when padding is added to image', () => {

--- a/packages/image-block/src/ImageBlock.spec.ct.tsx
+++ b/packages/image-block/src/ImageBlock.spec.ct.tsx
@@ -15,7 +15,6 @@ import {
 import { Security } from '@frontify/guideline-blocks-settings';
 
 const ImageBlockSelector = '[data-test-id="image-block"]';
-const ImageBlockImageSelector = '[data-test-id="image-block-image"]';
 const ImageBlockImageComponentSelector = '[data-test-id="image-block-image-component"]';
 const ImageBlockAssetViewerButtonSelector = '[data-test-id="image-block-asset-viewer-wrapper"]';
 const ImageBlockDefaultWrapperSelector = '[data-test-id="image-block-default-wrapper"]';

--- a/packages/image-block/src/ImageBlock.spec.ct.tsx
+++ b/packages/image-block/src/ImageBlock.spec.ct.tsx
@@ -69,7 +69,7 @@ describe('Image Block', () => {
         cy.get(ImageBlockImageComponentSelector).should('exist');
     });
 
-    it.only('should render the image responsively rounded to the nearest hundred pixel', () => {
+    it('should render the image responsively rounded to the nearest hundred pixel', () => {
         cy.viewport(240, 800);
         const ImageBlockWithStubs = getImageBlockWithContainer({
             blockAssets: {

--- a/packages/image-block/src/ImageBlock.spec.ct.tsx
+++ b/packages/image-block/src/ImageBlock.spec.ct.tsx
@@ -75,6 +75,9 @@ describe('Image Block', () => {
             blockAssets: {
                 [IMAGE_ID]: [{ ...AssetDummy.with(1), genericUrl: 'https://generic.url?width={width}' }],
             },
+            blockSettings: {
+                positioning: CaptionPosition.Above,
+            },
         });
         mount(<ImageBlockWithStubs />);
         cy.get(ImageBlockImageComponentSelector).should('exist');

--- a/packages/image-block/src/ImageBlock.spec.ct.tsx
+++ b/packages/image-block/src/ImageBlock.spec.ct.tsx
@@ -357,7 +357,7 @@ describe('Image Block', () => {
             },
         });
         mount(<ImageBlockWithStubs />);
-        cy.get(ImageBlockImageSelector).should('have.class', mapAlignmentClasses[Alignment.Right]);
+        cy.get(ImageBlockDefaultWrapperSelector).should('have.class', mapAlignmentClasses[Alignment.Right]);
     });
 
     it('should add padding to buttons when padding is added to image', () => {

--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -132,6 +132,7 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
                         <BlockItemWrapper
                             shouldHideWrapper={!isEditing}
                             showAttachments
+                            shouldFillContainer={false}
                             toolbarItems={[
                                 image
                                     ? getEditAltTextToolbarButton({

--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -132,7 +132,6 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
                         <BlockItemWrapper
                             shouldHideWrapper={!isEditing}
                             showAttachments
-                            shouldFillContainer={false}
                             toolbarItems={[
                                 image
                                     ? getEditAltTextToolbarButton({

--- a/packages/image-block/src/components/Image.tsx
+++ b/packages/image-block/src/components/Image.tsx
@@ -6,7 +6,7 @@ import { Security, joinClassNames } from '@frontify/guideline-blocks-settings';
 import { ResponsiveImage, useImageContainer } from '@frontify/guideline-blocks-shared';
 import { type CSSProperties, type ReactNode } from 'react';
 
-import { type Link, type Settings, mapAlignmentClasses } from '../types';
+import { Alignment, type Link, type Settings, mapAlignmentClasses } from '../types';
 
 import { getImageWrapperStyle } from './helpers';
 
@@ -26,6 +26,7 @@ type ImageWrapperProps = {
     style: CSSProperties;
     isEditing: boolean;
     isAssetViewerEnabled: boolean;
+    alignment: Alignment;
 };
 
 type ImageComponentProps = {
@@ -42,11 +43,16 @@ const ImageWrapper = ({
     style,
     isEditing,
     isAssetViewerEnabled,
+    alignment,
 }: ImageWrapperProps) => {
     const { open } = useAssetViewer(appBridge);
 
     const sharedProps = {
-        className: joinClassNames(['tw-block tw-overflow-hidden', FOCUS_VISIBLE_STYLE]),
+        className: joinClassNames([
+            'tw-flex tw-overflow-hidden tw-w-full',
+            FOCUS_VISIBLE_STYLE,
+            mapAlignmentClasses[alignment],
+        ]),
         style,
     };
 
@@ -104,14 +110,7 @@ export const Image = ({ image, appBridge, blockSettings, isEditing, globalAssetV
     const link = blockSettings?.hasLink && blockSettings?.linkObject?.link ? blockSettings?.linkObject : null;
 
     return (
-        <div
-            data-test-id="image-block-image"
-            ref={setContainerRef}
-            className={joinClassNames([
-                'tw-flex tw-w-full tw-h-auto tw-relative',
-                mapAlignmentClasses[blockSettings.alignment],
-            ])}
-        >
+        <div data-test-id="image-block-image" ref={setContainerRef} className="tw-flex tw-w-full tw-h-auto tw-relative">
             {containerWidth && (
                 <ImageWrapper
                     appBridge={appBridge}
@@ -120,6 +119,7 @@ export const Image = ({ image, appBridge, blockSettings, isEditing, globalAssetV
                     style={imageWrapperStyle}
                     isEditing={isEditing}
                     image={image}
+                    alignment={blockSettings.alignment}
                 >
                     <ImageComponent containerWidth={containerWidth} image={image} alt={blockSettings.altText ?? ''} />
                 </ImageWrapper>

--- a/packages/image-block/src/components/Image.tsx
+++ b/packages/image-block/src/components/Image.tsx
@@ -56,15 +56,7 @@ const ImageWrapper = ({
         style,
     };
 
-    if (isEditing || (!link && !isAssetViewerEnabled)) {
-        return (
-            <div {...sharedProps} data-test-id="image-block-default-wrapper">
-                {children}
-            </div>
-        );
-    }
-
-    if (link) {
+    if (!isEditing && link) {
         return (
             <a
                 {...sharedProps}
@@ -78,7 +70,7 @@ const ImageWrapper = ({
         );
     }
 
-    if (isAssetViewerEnabled) {
+    if (!isEditing && isAssetViewerEnabled) {
         return (
             <button data-test-id="image-block-asset-viewer-wrapper" {...sharedProps} onClick={() => open(image)}>
                 {children}
@@ -86,7 +78,11 @@ const ImageWrapper = ({
         );
     }
 
-    return null;
+    return (
+        <div {...sharedProps} data-test-id="image-block-default-wrapper">
+            {children}
+        </div>
+    );
 };
 
 export const ImageComponent = ({ image, alt, containerWidth }: ImageComponentProps) => (

--- a/packages/image-block/src/components/Image.tsx
+++ b/packages/image-block/src/components/Image.tsx
@@ -50,7 +50,7 @@ const ImageWrapper = ({
     const { open } = useAssetViewer(appBridge);
 
     const sharedProps = {
-        className: joinClassNames(['tw-flex tw-overflow-hidden', FOCUS_VISIBLE_STYLE]),
+        className: joinClassNames(['tw-block tw-overflow-hidden', FOCUS_VISIBLE_STYLE]),
         style,
     };
 

--- a/packages/image-block/src/components/Image.tsx
+++ b/packages/image-block/src/components/Image.tsx
@@ -55,7 +55,11 @@ const ImageWrapper = ({
     };
 
     if (isEditing || (!link && !isAssetViewerEnabled)) {
-        return <div {...sharedProps}>{children}</div>;
+        return (
+            <div {...sharedProps} data-test-id="image-block-default-wrapper">
+                {children}
+            </div>
+        );
     }
 
     if (link) {
@@ -65,6 +69,7 @@ const ImageWrapper = ({
                 href={link.link.link}
                 target={link.openInNewTab ? '_blank' : undefined}
                 rel={link.openInNewTab ? 'noopener noreferrer' : 'noreferrer'}
+                data-test-id="image-block-link-wrapper"
             >
                 {children}
             </a>
@@ -73,7 +78,7 @@ const ImageWrapper = ({
 
     if (isAssetViewerEnabled) {
         return (
-            <button data-test-id="image-block-asset-viewer-button" {...sharedProps} onClick={() => open(image)}>
+            <button data-test-id="image-block-asset-viewer-wrapper" {...sharedProps} onClick={() => open(image)}>
                 {children}
             </button>
         );
@@ -84,7 +89,7 @@ const ImageWrapper = ({
 
 export const ImageComponent = ({ image, alt, containerWidth }: ImageComponentProps) => (
     <ResponsiveImage
-        testId="image-block-img"
+        testId="image-block-image-component"
         image={image}
         containerWidth={containerWidth}
         alt={alt}
@@ -106,9 +111,12 @@ export const Image = ({ image, appBridge, blockSettings, isEditing }: ImageProps
 
     return (
         <div
-            data-test-id="image-block-img-wrapper"
+            data-test-id="image-block-image"
             ref={setContainerRef}
-            className={joinClassNames(['tw-flex tw-h-auto tw-relative', mapAlignmentClasses[blockSettings.alignment]])}
+            className={joinClassNames([
+                'tw-flex tw-w-full tw-h-auto tw-relative',
+                mapAlignmentClasses[blockSettings.alignment],
+            ])}
         >
             {containerWidth && (
                 <ImageWrapper

--- a/packages/image-block/src/types.ts
+++ b/packages/image-block/src/types.ts
@@ -3,7 +3,7 @@
 import { Color } from '@frontify/fondue';
 import { Security } from '@frontify/guideline-blocks-settings';
 
-type Link = { link: { link: string }; openInNewTab: boolean };
+export type Link = { link: { link: string }; openInNewTab: boolean };
 
 export type Settings = {
     hasLink?: boolean;


### PR DESCRIPTION
Focus styles were hidden by the image wrapper due to an overflow:hidden style being applied. To fix this some refactoring was needed. This also adjusts the image functionality, as now the container of the image will always wrap to the image itself, meaning that if the image is not 100% of the width of the container and you apply a background, it will only be added to the area of padding around the image, instead of the full width, which is also shown in the Figma design to be the correct behaviour 