### PR TITLE
fix(ImageBlock): image attachments position is wrong

### DIFF
--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -128,6 +128,7 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
             <div data-test-id="image-block" className={`tw-flex tw-h-auto ${mapCaptionPositionClasses[positioning]}`}>
                 <div
                     className={merge([
+                        'tw-relative',
                         attachmentCount > 0 && 'tw-min-h-11',
                         positioning === CaptionPosition.Above || positioning === CaptionPosition.Below
                             ? 'tw-w-full'


### PR DESCRIPTION
 Relative positioning was missing from the image holder, so attachments were off on some layouts.