### PR TITLE
feat(TemplateBlock): template editing setting and CTA action update

### DIFF
--- a/packages/template-block/src/TemplateBlock.tsx
+++ b/packages/template-block/src/TemplateBlock.tsx
@@ -9,7 +9,7 @@ import { AlertError } from './components/AlertError';
 import { CtaButton } from './components/CtaButton';
 import { TemplatePreview } from './components/TemplatePreview';
 import { TemplateText } from './components/TemplateText';
-import { PreviewType } from './types';
+import { PreviewType, TemplateEditing } from './types';
 import { useTemplateBlockData } from './hooks/useTemplateBlockData';
 
 export const TemplateBlock = ({ appBridge }: BlockProps): ReactElement => {
@@ -38,6 +38,15 @@ export const TemplateBlock = ({ appBridge }: BlockProps): ReactElement => {
 
     const handleNewPublication = async () => {
         if (selectedTemplate !== null) {
+            const { templateEditing } = blockSettings;
+            if (templateEditing === TemplateEditing.Simple) {
+                const uri = `/publishing/template/${selectedTemplate.id}?referer=${window.location.href.replaceAll(
+                    '/',
+                    '%2F'
+                )}`;
+                open(uri, '_self');
+                return;
+            }
             const previewUrl =
                 preview === PreviewType.Custom && previewCustom
                     ? previewCustom.previewUrl

--- a/packages/template-block/src/settings.ts
+++ b/packages/template-block/src/settings.ts
@@ -15,12 +15,14 @@ import {
     numericalOrPixelRule,
     presetCustomValue,
     radiusStyleMap,
+    NotificationStyleType,
 } from '@frontify/guideline-blocks-settings';
 import {
     AnchoringType,
     PreviewDisplayType,
     PreviewHeightType,
     PreviewType,
+    TemplateEditing,
     TextPositioningType,
     TextRatioType,
     paddingStyleMap,
@@ -73,6 +75,44 @@ export const settings = defineSettings({
             label: 'Custom Preview',
             show: (bundle: Bundle) => bundle.getBlock('preview')?.value === PreviewType.Custom,
             showForTranslations: true,
+        },
+        {
+            id: 'templateEditingHeading',
+            type: 'sectionHeading',
+            blocks: [
+                {
+                    id: 'templateEditing',
+                    label: 'Template Editing',
+                    info: 'Choose how users can make changes to the template.',
+                    type: 'slider',
+                    choices: [
+                        { label: 'Simple', value: TemplateEditing.Simple },
+                        { label: 'Advanced', value: TemplateEditing.Advanced },
+                    ],
+                    defaultValue: TemplateEditing.Simple,
+                    showForTranslations: true,
+                },
+                {
+                    id: 'templateEditingNotificationSimple',
+                    type: 'notification',
+                    text: 'Users can only make changes by selecting and editing fields in the settings panel without approvals. Read <article name> to learn more.',
+                    show: (bundle: Bundle) => bundle.getBlock('templateEditing')?.value === TemplateEditing.Simple,
+                    styles: {
+                        type: NotificationStyleType.Info,
+                    },
+                    showForTranslations: true,
+                },
+                {
+                    id: 'templateEditingNotificationAdvanced',
+                    type: 'notification',
+                    text: 'Users can select layers and edit text directly. Read <article name> to learn more.',
+                    show: (bundle: Bundle) => bundle.getBlock('templateEditing')?.value === TemplateEditing.Advanced,
+                    styles: {
+                        type: NotificationStyleType.Info,
+                    },
+                    showForTranslations: true,
+                },
+            ],
         },
     ],
     layout: [

--- a/packages/template-block/src/types.ts
+++ b/packages/template-block/src/types.ts
@@ -11,6 +11,7 @@ export type Settings = {
     // Basics
     template?: TemplateLegacy;
     templateId?: number;
+    templateEditing: TemplateEditing;
     preview: PreviewType;
     previewCustom?: Asset;
     buttonText?: string;
@@ -179,3 +180,8 @@ export const paddingStyleMap: Record<Padding, string> = {
     [Padding.Medium]: '20px',
     [Padding.Large]: '30px',
 };
+
+export enum TemplateEditing {
+    Simple = 'simple',
+    Advanced = 'advanced',
+}


### PR DESCRIPTION
Implements the new `Template Editing` `switch` setting which sets the CTA action to navigate to the new `CreationForm` when `simple` OR use the current template editor when `advanced`.

How to test:
1. `Simple` Editing Mode
  a. navigate to a new `TemplateBlock`
  b. move to `editMode`
  c. open the `settings` sidebar
  d. select `Simple` under the `Template Editing` section (this should be the default)
  e. move back to `viewMode`
  f. `click` the CTA ("Use this Template")
  g. browser should navigate to the `CreationForm` `route` with a `referer` `param`

2. `Advanced` Editing Mode
  a. navigate to a new `TemplateBlock`
  b. move to `editMode`
  c. open the `settings` sidebar
  d. select `Advanced` under the `Template Editing` section
  e. move back to `viewMode`
  f. `click` the CTA ("Use this Template")
  g. should render a `modal` to `CreatePublication`

CU-8694auyrh