### PR TITLE
fix(TemplateBlock): update default value and label for template editing

### DIFF
--- a/packages/template-block/src/settings.ts
+++ b/packages/template-block/src/settings.ts
@@ -82,14 +82,14 @@ export const settings = defineSettings({
             blocks: [
                 {
                     id: 'templateEditing',
-                    label: 'Template Editing',
+                    label: 'Template editing',
                     info: 'Choose how users can make changes to the template.',
                     type: 'slider',
                     choices: [
                         { label: 'Simple', value: TemplateEditing.Simple },
                         { label: 'Advanced', value: TemplateEditing.Advanced },
                     ],
-                    defaultValue: TemplateEditing.Simple,
+                    defaultValue: TemplateEditing.Advanced,
                     showForTranslations: true,
                 },
                 {


### PR DESCRIPTION
Changes the `defaultValue` for the Template Block setting `Template editing` as well as fixes a typo in the label.