### PR TITLE
fix(template-block): add rte converter to description

### DIFF
--- a/packages/template-block/src/hooks/useTemplateBlockData.ts
+++ b/packages/template-block/src/hooks/useTemplateBlockData.ts
@@ -82,7 +82,7 @@ export const useTemplateBlockData = (appBridge: BlockProps['appBridge']) => {
                 await updateTemplateIdsFromKey(TEMPLATE_BLOCK_SETTING_ID, [result.template.id]);
                 await updateBlockSettings({
                     title: convertToRteValue(TextStyles.heading3, result.template.title),
-                    description: result.template.description,
+                    description: convertToRteValue(TextStyles.p, result.template.description),
                 });
                 setTemplateTextKey(templateTextKey + 1);
             } catch (error) {


### PR DESCRIPTION
### What is this?
When adding a template to the block that has a description, the text was visible in the textarea in edit mode, but was not applied to the block settings for view mode, unless the textarea was actioned in some way (e.g. focused).

### Solution
Add the RTE converter to the `description` value `onTemplateSelected` as this triggers the `updateBlockSettings` method correctly. (THe method in `TemplateText` compares the values to update so without the converter it returns false and the two strings are the same on initial load.

### How to test
1. navigate to a guideline and add a new template block
2. select a template that has a description that was set at the time pr `Publishing`
3. the description should render in the textarea in edit mode
4. switch to view mode and the description should render with the same value.


CU-8694j4dd6