### PR TITLE
fix(ThumbnailGridBlock): only store items if isEditing

### DIFF
--- a/packages/thumbnail-grid-block/src/ThumbnailGridBlock.tsx
+++ b/packages/thumbnail-grid-block/src/ThumbnailGridBlock.tsx
@@ -80,9 +80,11 @@ export const ThumbnailGridBlock = ({ appBridge }: BlockProps) => {
     };
 
     useEffect(() => {
-        setBlockSettings({ items: itemsState });
+        if (isEditing) {
+            setBlockSettings({ items: itemsState });
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [itemsState]);
+    }, [itemsState, isEditing]);
 
     const addItems = useCallback(
         (items: Thumbnail[]) => {


### PR DESCRIPTION
Just saw that error: https://sentry.appsupport.frontify.dev/organizations/frontify/issues/131754/?project=3&referrer=slack
This should be prevented if we only store if the user is edit mode, wdyt?