### PR TITLE
fix(ImageBlock): in some cases the image is not crisp

### DIFF
--- a/packages/image-block/src/ImageBlock.spec.ct.tsx
+++ b/packages/image-block/src/ImageBlock.spec.ct.tsx
@@ -106,6 +106,41 @@ describe('Image Block', () => {
         );
     });
 
+    it('should render the image responsively rounded to the second nearest hundred pixel if border is applied', () => {
+        cy.viewport(240, 800);
+        const ImageBlockWithStubs = getImageBlockWithContainer({
+            blockAssets: {
+                [IMAGE_ID]: [{ ...AssetDummy.with(1), genericUrl: 'https://generic.url?width={width}' }],
+            },
+            blockSettings: {
+                positioning: CaptionPosition.Above,
+                hasBorder: true,
+                borderWidth: '1px',
+                borderColor: { r: 0, g: 0, b: 255 },
+                borderStyle: 'solid',
+            },
+        });
+        mount(<ImageBlockWithStubs />);
+        cy.get(ImageBlockImageComponentSelector).should('exist');
+        cy.get(ImageBlockImageComponentSelector).should(
+            'have.attr',
+            'src',
+            'https://generic.url?width=400&format=webp&quality=75'
+        );
+        cy.viewport(340, 800);
+        cy.get(ImageBlockImageComponentSelector).should(
+            'have.attr',
+            'src',
+            'https://generic.url?width=500&format=webp&quality=75'
+        );
+        cy.viewport(440, 800);
+        cy.get(ImageBlockImageComponentSelector).should(
+            'have.attr',
+            'src',
+            'https://generic.url?width=600&format=webp&quality=75'
+        );
+    });
+
     it('should render the download button if the image is uploaded and security settings allows it', () => {
         const ImageBlockWithStubs = getImageBlockWithContainer({
             blockSettings: {

--- a/packages/image-block/src/components/Image.tsx
+++ b/packages/image-block/src/components/Image.tsx
@@ -96,16 +96,15 @@ const ImageWrapper = ({
     );
 };
 
-export const ImageComponent = ({ image, alt, containerWidth, style }: ImageComponentProps) =>
-    containerWidth ? (
-        <ResponsiveImage
-            testId="image-block-image-component"
-            image={image}
-            containerWidth={containerWidth}
-            alt={alt}
-            style={{ ...style, maxWidth: image.width }}
-        />
-    ) : null;
+export const ImageComponent = ({ image, alt, containerWidth, style }: ImageComponentProps) => (
+    <ResponsiveImage
+        testId="image-block-image-component"
+        image={image}
+        containerWidth={containerWidth}
+        alt={alt}
+        style={{ ...style, maxWidth: image.width }}
+    />
+);
 
 export const Image = ({
     image,

--- a/packages/image-block/src/components/Image.tsx
+++ b/packages/image-block/src/components/Image.tsx
@@ -29,12 +29,13 @@ type ImageWrapperProps = {
     isAssetViewerEnabled: boolean;
     alignment: Alignment;
     isDownloadable: boolean;
+    setContainerRef: (element: HTMLElement | null) => void;
 };
 
 type ImageComponentProps = {
     image: Asset;
     alt: string;
-    containerWidth: number;
+    containerWidth: number | undefined;
     style: CSSProperties;
 };
 
@@ -47,6 +48,7 @@ const ImageWrapper = ({
     isEditing,
     isAssetViewerEnabled,
     alignment,
+    setContainerRef,
     isDownloadable,
 }: ImageWrapperProps) => {
     const { open } = useAssetViewer(appBridge);
@@ -58,6 +60,7 @@ const ImageWrapper = ({
             mapAlignmentClasses[alignment],
         ]),
         style,
+        ref: setContainerRef,
     };
 
     if (!isEditing && link) {
@@ -93,15 +96,16 @@ const ImageWrapper = ({
     );
 };
 
-export const ImageComponent = ({ image, alt, containerWidth, style }: ImageComponentProps) => (
-    <ResponsiveImage
-        testId="image-block-image-component"
-        image={image}
-        containerWidth={containerWidth}
-        alt={alt}
-        style={{ ...style, maxWidth: image.width }}
-    />
-);
+export const ImageComponent = ({ image, alt, containerWidth, style }: ImageComponentProps) =>
+    containerWidth ? (
+        <ResponsiveImage
+            testId="image-block-image-component"
+            image={image}
+            containerWidth={containerWidth}
+            alt={alt}
+            style={{ ...style, maxWidth: image.width }}
+        />
+    ) : null;
 
 export const Image = ({
     image,
@@ -122,26 +126,25 @@ export const Image = ({
     const link = blockSettings?.hasLink && blockSettings?.linkObject?.link ? blockSettings?.linkObject : null;
 
     return (
-        <div data-test-id="image-block-image" ref={setContainerRef} className="tw-flex tw-w-full tw-h-auto tw-relative">
-            {containerWidth && (
-                <ImageWrapper
-                    appBridge={appBridge}
-                    isAssetViewerEnabled={isAssetViewerEnabled}
-                    link={link}
-                    style={imageWrapperStyle}
-                    isEditing={isEditing}
+        <div data-test-id="image-block-image" className="tw-flex tw-w-full tw-h-auto tw-relative">
+            <ImageWrapper
+                appBridge={appBridge}
+                isAssetViewerEnabled={isAssetViewerEnabled}
+                link={link}
+                style={imageWrapperStyle}
+                setContainerRef={setContainerRef}
+                isEditing={isEditing}
+                image={image}
+                alignment={blockSettings.alignment}
+                isDownloadable={isDownloadable}
+            >
+                <ImageComponent
+                    style={imageStyle}
+                    containerWidth={containerWidth}
                     image={image}
-                    alignment={blockSettings.alignment}
-                    isDownloadable={isDownloadable}
-                >
-                    <ImageComponent
-                        style={imageStyle}
-                        containerWidth={containerWidth}
-                        image={image}
-                        alt={blockSettings.altText ?? ''}
-                    />
-                </ImageWrapper>
-            )}
+                    alt={blockSettings.altText ?? ''}
+                />
+            </ImageWrapper>
         </div>
     );
 };

--- a/packages/shared/src/components/ResponsiveImage/ResponsiveImage.tsx
+++ b/packages/shared/src/components/ResponsiveImage/ResponsiveImage.tsx
@@ -7,7 +7,7 @@ import { joinClassNames } from '@frontify/guideline-blocks-settings';
 
 type ResponsiveImageProps = {
     image: Asset;
-    containerWidth: number;
+    containerWidth: number | undefined;
     alt: string;
     format?: ImageFormat;
     quality?: number;
@@ -18,7 +18,7 @@ type ResponsiveImageProps = {
 
 export const ResponsiveImage = ({
     image,
-    containerWidth,
+    containerWidth = 0,
     alt,
     format = ImageFormat.WEBP,
     className = '',

--- a/packages/shared/src/hooks/useImageContainer.tsx
+++ b/packages/shared/src/hooks/useImageContainer.tsx
@@ -16,8 +16,12 @@ export const useImageContainer = () => {
 
         const containerObserver = new ResizeObserver(
             debounce((entries) => {
-                const container = entries[0];
-                const newContainerWidth = roundToNextHundred(container.contentRect.width);
+                const container = entries[0] as ResizeObserverEntry;
+                const borderWidth = container.borderBoxSize[0].inlineSize - container.contentBoxSize[0].inlineSize;
+                const shouldRequestLargerImage = borderWidth > 0;
+                const newImageWidth = container.contentRect.width + (shouldRequestLargerImage ? 100 : 0);
+
+                const newContainerWidth = roundToNextHundred(newImageWidth);
                 const oldContainerWidth = roundToNextHundred(containerWidth ?? 0);
                 const containerWidthHasGrown = oldContainerWidth < newContainerWidth;
                 if (containerWidthHasGrown) {
@@ -33,7 +37,13 @@ export const useImageContainer = () => {
     const setContainerRef = (container: HTMLElement | null) => {
         if (!containerRef.current) {
             containerRef.current = container;
-            setContainerWidth(roundToNextHundred(container?.offsetWidth ?? 0));
+            const clientWidth = container?.clientWidth || 0;
+            const offsetWidth = container?.offsetWidth || 0;
+            const borderWidth = offsetWidth - clientWidth;
+            const shouldRequestLargerImage = borderWidth > 0;
+            const imageWidthToRequest = offsetWidth + (shouldRequestLargerImage ? 100 : 0);
+
+            setContainerWidth(roundToNextHundred(imageWidthToRequest));
         }
     };
 


### PR DESCRIPTION
If the image had borders applied, in some cases the image got blurred a bit. E.g. 1px border caused the container to shrink to 798px, while the image remained 800px wide. This very small discrepancy blurred the image. 

I experimented with different solutions.

1. If the border is applied, then remove that value from the requested image size. E.g. instead of 500, 600, 700, 800, request 498, 598, 698, 798. This worked, but on small screens the container is not always a multiple of 100, so it is possible to have a container of 580px wide, while requesting an image of 598px. This resulted in blurred images once again.

2. Always add 100px to the requested image size if there is border applied. This seems to be enough to always result crisp images. This PR implements this approach.