### PR TITLE
fix(ThumbnailGridBlock): breakpoints are not set correctly

### DIFF
--- a/packages/thumbnail-grid-block/src/components/Grid/Grid.tsx
+++ b/packages/thumbnail-grid-block/src/components/Grid/Grid.tsx
@@ -10,11 +10,11 @@ type GridProps = {
     gap: string;
 };
 const mapColumnCountToClassGrid = {
-    1: '',
-    2: '@sm:tw-grid-cols-2',
-    3: '@sm:tw-grid-cols-2 @md:tw-grid-cols-3',
-    4: '@sm:tw-grid-cols-2 @md:tw-grid-cols-3 @lg:tw-grid-cols-4',
-    5: '@sm:tw-grid-cols-2 @md:tw-grid-cols-3 @lg:tw-grid-cols-5',
+    1: 'tw-grid-cols-1 ',
+    2: 'tw-grid-cols-1 @sm:tw-grid-cols-2',
+    3: 'tw-grid-cols-1 @sm:tw-grid-cols-2 @md:tw-grid-cols-3',
+    4: 'tw-grid-cols-1 @sm:tw-grid-cols-2 @md:tw-grid-cols-4',
+    5: 'tw-grid-cols-1 @sm:tw-grid-cols-2 @md:tw-grid-cols-5',
 };
 
 export const Grid = ({ children, columnCount, gap }: GridProps) => (


### PR DESCRIPTION
New breakpoints are set according to this chart:
![image](https://github.com/Frontify/guideline-blocks/assets/30796791/98663c5c-964e-474d-8088-50bd775e75f0)

And this loom:
https://www.loom.com/share/f6b6fa5599d94e5282ba3ec4c2c29e16

CU:
https://app.clickup.com/t/8694ky6tc