### PR TITLE
fix(CalloutBlock): hug contents is collapsing

### DIFF
--- a/packages/callout-block/src/CalloutBlock.spec.ct.tsx
+++ b/packages/callout-block/src/CalloutBlock.spec.ct.tsx
@@ -281,7 +281,8 @@ describe('Callout Block', () => {
 
         cy.get(CalloutBlockSelector).should(($el) => {
             const width = parseFloat($el.css('width'));
-            expect(width).to.be.greaterThan(100);
+            expect(width).to.be.greaterThan(130);
+            expect(width).to.be.lessThan(140);
         });
     });
 });

--- a/packages/callout-block/src/CalloutBlock.spec.ct.tsx
+++ b/packages/callout-block/src/CalloutBlock.spec.ct.tsx
@@ -266,4 +266,22 @@ describe('Callout Block', () => {
         cy.get(CalloutBlockSelector).should('have.css', 'background-color', 'rgb(50, 40, 145)');
         cy.get(HtmlContentSelector).should('have.css', 'color', 'rgb(255, 255, 255)');
     });
+
+    it('renders a callout block with the content hugged', () => {
+        const [CalloutBlockWithStubs] = withAppBridgeBlockStubs(CalloutBlock, {
+            blockSettings: {
+                textValue: 'Some random text',
+                type: Type.Note,
+                appearance: Appearance.Strong,
+                width: Width.HugContents,
+            },
+        });
+
+        mount(<CalloutBlockWithStubs />);
+
+        cy.get(CalloutBlockSelector).should(($el) => {
+            const width = parseFloat($el.css('width'));
+            expect(width).to.be.greaterThan(100);
+        });
+    });
 });

--- a/packages/callout-block/src/CalloutBlock.tsx
+++ b/packages/callout-block/src/CalloutBlock.tsx
@@ -69,6 +69,7 @@ export const CalloutBlock = ({ appBridge }: BlockProps): ReactElement => {
         '[&>div>*:last-child>span]:!tw-mb-0',
         '[&>div>div>*:last-child]:tw-mb-0', // Remove margin bottom from last child in edit mode
         '[&>div>div>*:last-child>span]:!tw-mb-0',
+        blockSettings.width === Width.HugContents && '[&>div]:!tw-@container-normal',
     ]);
 
     const customPaddingStyle = {


### PR DESCRIPTION
[From MDN docs:](https://developer.mozilla.org/en-US/docs/Web/CSS/container-type)

`Size containment turns off the ability of an element to get size information from its contents, which is important for container queries to avoid infinite loops.`

Meaning with container queries it is not possible to get the width of the content inside, so hugging the content width is not possible.