### PR TITLE
fix(CSS): remove radix overlays from CSS scoping

### DIFF
--- a/postcss/scope.js
+++ b/postcss/scope.js
@@ -42,5 +42,5 @@ const getModalExtensions = (individualSelector) => {
         return "";
     }
 
-    return `, body > [role='toolbar'] ${individualSelector}, body > [data-overlay-container] ${individualSelector}, body > [data-radix-popper-content-wrapper]  ${individualSelector}`;
+    return `, body > [role='toolbar'] ${individualSelector}, body > [data-overlay-container] ${individualSelector}`;
 };


### PR DESCRIPTION
With the new fondue components there are a lot of conflicts in CSS, so removing it from blocks scoping.