### PR TITLE
fix(PostCSS): only scope tailwind classes

### DIFF
--- a/postcss/scope.js
+++ b/postcss/scope.js
@@ -24,7 +24,7 @@ module.exports = (opts = {}) => {
                     originalSelector
                         .split(/(?<!\\),\s*/g)
                         .map((individualSelector) =>
-                            individualSelector === opts.selector
+                            !individualSelector.startsWith("tw")
                                 ? individualSelector
                                 : `${opts.scope} ${individualSelector}${getModalExtensions(individualSelector)}`,
                         )


### PR DESCRIPTION
Otherwise classes like `_root-4kx7u` in modals are not applied.