### PR TITLE
fix(CSS): scoping is not applied

### DIFF
--- a/postcss/scope.js
+++ b/postcss/scope.js
@@ -24,7 +24,7 @@ module.exports = (opts = {}) => {
                     originalSelector
                         .split(/(?<!\\),\s*/g)
                         .map((individualSelector) =>
-                            !individualSelector.startsWith("tw")
+                            !individualSelector.includes("tw-")
                                 ? individualSelector
                                 : `${opts.scope} ${individualSelector}${getModalExtensions(individualSelector)}`,
                         )


### PR DESCRIPTION
The fix applied in https://github.com/Frontify/guideline-blocks/pull/940 was not working as the classes start with `.tw` not `tw` 🤦 

Changed the approach so now classes like `group-hover:tw-bg-red-40` are also applied.

Fixes
https://app.clickup.com/t/2523021/TASK-12450