### PR TITLE
fix(PostCss): improve scoping

### DIFF
--- a/postcss/scope.js
+++ b/postcss/scope.js
@@ -23,10 +23,9 @@ module.exports = (opts = {}) => {
                 rule.selectors = rule.selectors.map((originalSelector) =>
                     originalSelector
                         .split(/(?<!\\),\s*/g)
-                        .map((individualSelector) =>
-                            !individualSelector.includes("tw-")
-                                ? individualSelector
-                                : `${opts.scope} ${individualSelector}${getModalExtensions(individualSelector)}`,
+                        .map(
+                            (individualSelector) =>
+                                `${opts.scope} ${individualSelector}${getModalExtensions(individualSelector)}`,
                         )
                         .join(", "),
                 );


### PR DESCRIPTION
https://app.clickup.com/t/2523021/TASK-13279

`strong` was before defined directly with `strong { font-weight: bolder }`, (this then interfered also with different other stuff)

which now is also scoped to 

`.callout-block strong { font-weight: bolder }`, 