### PR TITLE
fix(DoDont): overlapping and background color

### DIFF
--- a/packages/dos-donts-block/src/DoDontItem.tsx
+++ b/packages/dos-donts-block/src/DoDontItem.tsx
@@ -186,8 +186,9 @@ export const DoDontItem = memo((props: DoDontItemProps) => {
     );
 
     return (
-        <div className="tw-bg-base tw-relative">
+        <div className="tw-relative">
             <BlockItemWrapper
+                outlineOffset={0}
                 isDragging={isDragging}
                 shouldHideWrapper={replaceWithPlaceholder || !editing}
                 shouldHideComponent={replaceWithPlaceholder}

--- a/packages/dos-donts-block/src/DoDontItem.tsx
+++ b/packages/dos-donts-block/src/DoDontItem.tsx
@@ -10,6 +10,7 @@ import {
     IconSpeechBubbleQuote20,
     IconTrashBin16,
     IconTrashBin20,
+    merge,
 } from '@frontify/fondue';
 import {
     AssetChooserObjectType,
@@ -173,7 +174,7 @@ export const DoDontItem = memo((props: DoDontItemProps) => {
     const memoizedRichTextEditor = useMemo(
         () => (
             <RichTextEditor
-                id={`${appBridge.getBlockId()}-${id}-editor`}
+                id={`${appBridge.context('blockId').get()}-${id}-editor`}
                 isEditing={editing}
                 value={body}
                 onTextChange={onBodyTextChange}
@@ -186,7 +187,7 @@ export const DoDontItem = memo((props: DoDontItemProps) => {
     );
 
     return (
-        <div className="tw-relative">
+        <div className={merge(['tw-relative', isDragging && 'tw-bg-base'])}>
             <BlockItemWrapper
                 outlineOffset={0}
                 isDragging={isDragging}

--- a/postcss/scope.js
+++ b/postcss/scope.js
@@ -9,6 +9,8 @@
  * @type {import('postcss').PluginCreator}
  */
 module.exports = (opts = {}) => {
+    const tagSelectorRegex = /^[a-zA-Z][a-zA-Z0-9-]*$/;
+
     return {
         postcssPlugin: "scope",
         Root(root) {
@@ -23,9 +25,11 @@ module.exports = (opts = {}) => {
                 rule.selectors = rule.selectors.map((originalSelector) =>
                     originalSelector
                         .split(/(?<!\\),\s*/g)
-                        .map(
-                            (individualSelector) =>
-                                `${opts.scope} ${individualSelector}${getModalExtensions(individualSelector)}`,
+                        .map((individualSelector) =>
+                            individualSelector.includes("tw-") ||
+                            tagSelectorRegex.test(individualSelector)
+                                ? `${opts.scope} ${individualSelector}${getModalExtensions(individualSelector)}`
+                                : individualSelector,
                         )
                         .join(", "),
                 );


### PR DESCRIPTION
Issue found during testing:
- background color of block (removed)
- overlapping outline of the blockItemWrapper (offset to 0)

Also replaced deprecated `getBlockId()`

Also found an issue with the scoping around tooltips, as the class was prefixed but lived on the root. 
So now we only prefix tailwind classes and tags and no other classes this fixes the issue bolding without introducing new issues. 

https://app.clickup.com/t/2523021/TASK-13279