### PR TITLE
refactor(Audio): remove CC

### DIFF
--- a/packages/audio-block/src/AudioBlock.tsx
+++ b/packages/audio-block/src/AudioBlock.tsx
@@ -29,7 +29,7 @@ import { useEffect, useState } from 'react';
 
 import { AudioPlayer, BlockAttachments, UploadPlaceholder } from './components';
 import { getDescriptionPlugins, titlePlugins } from './helpers/plugins';
-import { ATTACHMENTS_ASSET_ID, AUDIO_ID, CAPTION_ID } from './settings';
+import { ATTACHMENTS_ASSET_ID, AUDIO_ID } from './settings';
 import { type BlockSettings, TextPosition } from './types';
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 
@@ -46,7 +46,6 @@ export const AudioBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
     const [openFileDialog, { selectedFiles }] = useFileInput({ accept: 'audio/*' });
     const { assetDownloadEnabled } = usePrivacySettings(appBridge);
     const audio = blockAssets?.[AUDIO_ID]?.[0];
-    const caption = blockAssets?.[CAPTION_ID]?.[0];
     const blockId = appBridge.context('blockId').get();
 
     const [uploadFile, { results: uploadResults, doneAll }] = useAssetUpload({
@@ -128,7 +127,6 @@ export const AudioBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
                     {audio ? (
                         <AudioPlayer
                             audio={audio}
-                            caption={caption}
                             isEditing={isEditing}
                             isLoading={isLoading}
                             openFileDialog={openFileDialog}

--- a/packages/audio-block/src/components/AudioPlayer.tsx
+++ b/packages/audio-block/src/components/AudioPlayer.tsx
@@ -13,7 +13,6 @@ import { ReactElement } from 'react';
 
 type AudioPlayerProps = {
     audio: Asset;
-    caption: null | Asset;
     isEditing: boolean;
     isLoading: boolean;
     openFileDialog: () => void;
@@ -23,7 +22,6 @@ type AudioPlayerProps = {
 
 export const AudioPlayer = ({
     audio,
-    caption,
     isEditing,
     isLoading,
     openFileDialog,
@@ -70,7 +68,6 @@ export const AudioPlayer = ({
                     preload="metadata"
                 >
                     <source src={audio.genericUrl} />
-                    {caption && <track src={caption?.originUrl} kind="captions" />}
                 </audio>
             )}
         </BlockItemWrapper>

--- a/packages/audio-block/src/settings.ts
+++ b/packages/audio-block/src/settings.ts
@@ -12,7 +12,6 @@ import {
 } from '@frontify/guideline-blocks-settings';
 
 export const AUDIO_ID = 'audio';
-export const CAPTION_ID = 'caption';
 export const ATTACHMENTS_ASSET_ID = 'attachments';
 
 export const settings = defineSettings({
@@ -24,16 +23,6 @@ export const settings = defineSettings({
             info: 'Select an audio file to play.',
             size: 'small',
             extensions: FileExtensionSets.Audio,
-            objectTypes: [AssetChooserObjectType.File],
-            showForTranslations: true,
-        },
-        {
-            id: CAPTION_ID,
-            type: 'assetInput',
-            label: 'Closed Captions',
-            info: 'Select a VTT or SRT file for closed captions.',
-            size: 'small',
-            extensions: ['vtt', 'srt'],
             objectTypes: [AssetChooserObjectType.File],
             showForTranslations: true,
         },


### PR DESCRIPTION
After discussion of it, this is useless on Audio Block and only needed for video. 

For Audio we need transscript which is a different concept, and needs to be checked on how we gonna implement it.