### PR TITLE
fix(ThumbnailGrid): update calls on viewer and without changes

### DIFF
--- a/packages/thumbnail-grid-block/src/ThumbnailGridBlock.tsx
+++ b/packages/thumbnail-grid-block/src/ThumbnailGridBlock.tsx
@@ -89,7 +89,9 @@ export const ThumbnailGridBlock = ({ appBridge }: BlockProps) => {
     };
 
     useEffect(() => {
-        setBlockSettings({ items: itemsState });
+        if (blockSettings.items !== itemsState && isEditing) {
+            setBlockSettings({ items: itemsState });
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [itemsState]);
 


### PR DESCRIPTION
Basically fixes this error: https://sentryapp.appsupport.frontify.dev/organizations/frontify/issues/371203/events/latest/?project=48&referrer=latest-event

Also if the block is referenced it tries to update (even in view mode). 

With this adjustment we only update if an item has changes and if the block is in edit mode.