### PR TITLE
feat(Callout): use `MutationObserver` instead of `HubAppearanceUpdated` event listener

### DIFF
--- a/packages/callout-block/src/CalloutBlock.tsx
+++ b/packages/callout-block/src/CalloutBlock.tsx
@@ -30,6 +30,9 @@ export const CalloutBlock = ({ appBridge }: BlockProps): ReactElement => {
     const { blockAssets, deleteAssetIdsFromKey } = useBlockAssets(appBridge);
     const customIcon = blockAssets?.[ICON_ASSET_ID]?.[0];
 
+    const designSettingsStyleTag =
+        document.getElementById('theme-design-settings') ?? document.getElementById('design-settings')!;
+
     useEffect(() => {
         if (!blockSettings.iconSwitch && customIcon && isEditing) {
             deleteAssetIdsFromKey(ICON_ASSET_ID, [customIcon.id]);
@@ -43,12 +46,14 @@ export const CalloutBlock = ({ appBridge }: BlockProps): ReactElement => {
             setTextColor(textColor);
         };
 
-        window.emitter.on('HubAppearanceUpdated', updateStyles);
-
         updateStyles();
 
+        const styleChangeObserver = new MutationObserver(() => updateStyles());
+
+        styleChangeObserver.observe(designSettingsStyleTag, { childList: true });
+
         return () => {
-            window.emitter.off('HubAppearanceUpdated', updateStyles);
+            styleChangeObserver.disconnect();
         };
     }, [appearance, type]);
 


### PR DESCRIPTION
Instead of listening for the `HubAppearanceUpdated` event we can just observe the style tag that contains all CSS variables, to update the styles of the callout block. This makes sure that the callout block is compatible with the new design settings, which don't emit the `HubAppearanceUpdated` event anymore when changed.

CU-86989mrb0