### PR TITLE
fix(Image): improve handling for asset viewer

### DIFF
--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -17,6 +17,7 @@ import {
     TextStyles,
     convertToRteValue,
     hasRichTextValue,
+    isDownloadable,
     withAttachmentsProvider,
 } from '@frontify/guideline-blocks-settings';
 import { StyleProvider, getEditAltTextToolbarButton } from '@frontify/guideline-blocks-shared';
@@ -39,7 +40,6 @@ import { ALLOWED_EXTENSIONS, ATTACHMENTS_ASSET_ID, IMAGE_ID } from './settings';
 import { CaptionPosition, type Settings, imageRatioValues, mapCaptionPositionClasses } from './types';
 
 import { DownloadAndAttachments } from './components/DownloadAndAttachments';
-import { isImageDownloadable } from './helpers/isImageDownloadable';
 
 export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) => {
     const { assetDownloadEnabled, assetViewerEnabled } = usePrivacySettings(appBridge);
@@ -54,11 +54,10 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
     const { blockAssets, deleteAssetIdsFromKey, updateAssetIdsFromKey } = useBlockAssets(appBridge);
     const image = blockAssets?.[IMAGE_ID]?.[0];
     const attachmentCount = blockAssets[ATTACHMENTS_ASSET_ID]?.length || 0;
-    const isDownloadable = isImageDownloadable(
+    const isAssetDownloadable = isDownloadable(
         blockSettings.security,
         blockSettings.downloadable,
-        assetDownloadEnabled,
-        image
+        assetDownloadEnabled
     );
 
     const [openFileDialog, { selectedFiles }] = useFileInput({
@@ -158,7 +157,7 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
                                 appBridge={appBridge}
                                 blockSettings={blockSettings}
                                 image={image}
-                                isDownloadable={isDownloadable}
+                                isAssetDownloadable={isAssetDownloadable}
                                 isEditing={isEditing}
                             />
                             {image ? (
@@ -217,7 +216,7 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
                                             blockSettings={blockSettings}
                                             isEditing={isEditing}
                                             image={image}
-                                            isDownloadable={isDownloadable}
+                                            isDownloadable={isAssetDownloadable}
                                             globalAssetViewerEnabled={assetViewerEnabled}
                                         />
                                     )}

--- a/packages/image-block/src/components/DownloadAndAttachments.tsx
+++ b/packages/image-block/src/components/DownloadAndAttachments.tsx
@@ -4,13 +4,14 @@ import { Attachments, DownloadButton, useAttachmentsContext } from '@frontify/gu
 import { getTotalImagePadding } from './helpers';
 import { AppBridgeBlock, Asset } from '@frontify/app-bridge';
 import { Settings } from '../types';
+import { isImageDownloadable } from '../helpers/isImageDownloadable';
 
 type DownloadAndAttachmentsProps = {
     appBridge: AppBridgeBlock;
     isEditing: boolean;
     image?: Asset;
     blockSettings: Settings;
-    isDownloadable: boolean;
+    isAssetDownloadable: boolean;
 };
 
 export const DownloadAndAttachments = ({
@@ -18,10 +19,11 @@ export const DownloadAndAttachments = ({
     isEditing,
     image,
     blockSettings,
-    isDownloadable,
+    isAssetDownloadable,
 }: DownloadAndAttachmentsProps) => {
     const { attachments, onAttachmentsAdd, onAttachmentDelete, onAttachmentReplace, onAttachmentsSorted } =
         useAttachmentsContext();
+    const isDownloadable = isImageDownloadable(isAssetDownloadable, image);
 
     return !isEditing ? (
         <div className="tw-absolute tw-top-2 tw-right-2 tw-z-50">

--- a/packages/image-block/src/helpers/isImageDownloadable.spec.ts
+++ b/packages/image-block/src/helpers/isImageDownloadable.spec.ts
@@ -1,20 +1,46 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { isImageDownloadable } from './isImageDownloadable';
-import { Security } from '@frontify/guideline-blocks-settings';
 import { AssetDummy } from '@frontify/app-bridge';
 
 describe('isImageDownloadable', () => {
-    it('return false if the image is download protected', () => {
-        expect(
-            isImageDownloadable(Security.Global, true, true, { ...AssetDummy.with(1), isDownloadProtected: true })
-        ).toEqual(false);
-    });
+    const assetBase = AssetDummy.with(1);
 
-    it('return true if the image is not download protected', () => {
-        expect(
-            isImageDownloadable(Security.Global, true, true, { ...AssetDummy.with(1), isDownloadProtected: false })
-        ).toEqual(true);
+    const cases = [
+        {
+            description: 'returns false if the image is download protected',
+            isDownloadableValue: true,
+            image: { ...assetBase, isDownloadProtected: true },
+            expected: false,
+        },
+        {
+            description: 'returns true if the image is not download protected',
+            isDownloadableValue: true,
+            image: { ...assetBase, isDownloadProtected: false },
+            expected: true,
+        },
+        {
+            description: 'returns false if isDownloadableValue is false',
+            isDownloadableValue: false,
+            image: { ...assetBase, isDownloadProtected: false },
+            expected: false,
+        },
+        {
+            description: 'returns false if image is protected and isDownloadableValue is false',
+            isDownloadableValue: false,
+            image: { ...assetBase, isDownloadProtected: true },
+            expected: false,
+        },
+        {
+            description: 'returns false if image is not provided',
+            isDownloadableValue: true,
+            image: undefined,
+            expected: false,
+        },
+    ];
+
+    test.each(cases)('$description', ({ isDownloadableValue, image, expected }) => {
+        expect(isImageDownloadable(isDownloadableValue, image)).toBe(expected);
     });
 });

--- a/packages/image-block/src/helpers/isImageDownloadable.ts
+++ b/packages/image-block/src/helpers/isImageDownloadable.ts
@@ -1,11 +1,7 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { Security, isDownloadable } from '@frontify/guideline-blocks-settings';
 import { Asset } from '@frontify/app-bridge';
 
-export const isImageDownloadable = (
-    security: Security,
-    downloadable: boolean,
-    assetDownloadEnabled: boolean,
-    image?: Asset
-) => image?.isDownloadProtected === false && isDownloadable(security, downloadable, assetDownloadEnabled);
+export const isImageDownloadable = (isDownloadableValue: boolean, image?: Asset): boolean => {
+    return !!image && !image.isDownloadProtected && isDownloadableValue;
+};


### PR DESCRIPTION
TASK-14053
----

Basic Handling for the 2 cases

For Download through the block we need to know if the asset is protected (basically what the helper: `isImageDownloadable` does)

For opening the asset viewer, the asset viewer only needs to know about the options of the block or guideline if the asset is downloadable and then cares on its own if the asset is protected.


CC: @urietberger 

----

### AI Summary:

This pull request involves several changes to the `ImageBlock` component and its related files to improve the handling of downloadable images. The key changes include updating the import statements, renaming variables for clarity, and refactoring the `isImageDownloadable` function and its tests.

### Import and Variable Updates:

* [`packages/image-block/src/ImageBlock.tsx`](diffhunk://#diff-17309e5c0933869ae6e1db21f3368d5a6a621335506c53ecc4685572df640f96R20): Added the `isDownloadable` import and removed the `isImageDownloadable` import. Renamed the `isDownloadable` variable to `isAssetDownloadable` for clarity. [[1]](diffhunk://#diff-17309e5c0933869ae6e1db21f3368d5a6a621335506c53ecc4685572df640f96R20) [[2]](diffhunk://#diff-17309e5c0933869ae6e1db21f3368d5a6a621335506c53ecc4685572df640f96L42) [[3]](diffhunk://#diff-17309e5c0933869ae6e1db21f3368d5a6a621335506c53ecc4685572df640f96L57-R60) [[4]](diffhunk://#diff-17309e5c0933869ae6e1db21f3368d5a6a621335506c53ecc4685572df640f96L161-R160) [[5]](diffhunk://#diff-17309e5c0933869ae6e1db21f3368d5a6a621335506c53ecc4685572df640f96L220-R219)
* [`packages/image-block/src/components/DownloadAndAttachments.tsx`](diffhunk://#diff-4cf021d4c91e0b97536da345f76501b407fb4ea84e8a86aeb1995892635b0e39R7-R26): Added the `isImageDownloadable` import and renamed the `isDownloadable` prop to `isAssetDownloadable`.

### Function and Test Refactoring:

* [`packages/image-block/src/helpers/isImageDownloadable.ts`](diffhunk://#diff-af0ad4c11bf9ce8aa89d8ab64e94d35a21e72a01b6622381442e1e5b150e6353L3-R7): Simplified the `isImageDownloadable` function to take only two parameters: `isDownloadableValue` and `image`.
* [`packages/image-block/src/helpers/isImageDownloadable.spec.ts`](diffhunk://#diff-47239db7dd82a14d3454ddd1895012a0a654eb8985510bd8b1e06d65f75dd5cfL3-R44): Refactored the tests for `isImageDownloadable` to use `test.each` for better readability and added multiple test cases.