### PR TITLE
fix(CompareSliderBlock): add focus ring to handle

### DIFF
--- a/packages/compare-slider-block/src/CompareSliderBlock.tsx
+++ b/packages/compare-slider-block/src/CompareSliderBlock.tsx
@@ -371,7 +371,7 @@ export const CompareSliderBlock = ({ appBridge }: BlockProps) => {
                         <>
                             <div
                                 data-test-id="compare-slider-block-slider"
-                                className="tw-w-full tw-overflow-hidden tw-relative"
+                                className="tw-w-full tw-overflow-hidden tw-relative  [&_.handle]:focus-within:tw-ring-4 [&_.handle]:focus-within:tw-ring-offset-2"
                                 style={{
                                     ...getBorderStyle(),
                                     borderRadius: getBorderRadius(),

--- a/packages/compare-slider-block/src/components/SliderLine/SliderLine.tsx
+++ b/packages/compare-slider-block/src/components/SliderLine/SliderLine.tsx
@@ -93,7 +93,8 @@ export const SliderLine = ({ handle, alignment, sliderColor, sliderStyle, slider
     return (
         <div
             className={joinClassNames([
-                ' tw-flex tw-justify-center tw-items-center tw-absolute',
+                'handle',
+                'tw-flex tw-justify-center tw-items-center tw-absolute tw-ring-blue',
                 alignment === Alignment.Horizontal
                     ? 'tw-top-0 tw-h-full tw-w-3 -tw-translate-x-1/2 tw-cursor-ew-resize'
                     : 'tw-left-0 tw-w-full tw-h-3 -tw-translate-y-1/2 tw-cursor-ns-resize',


### PR DESCRIPTION
bit of a workaround because the original button that is focused is inside the 3rd party package and not customisable.