### PR TITLE
fix(Image): improve aria label alt text

### DIFF
--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -162,6 +162,7 @@ export const ImageBlock = withAttachmentsProvider(({ appBridge }: BlockProps) =>
                                 appBridge={appBridge}
                                 blockSettings={blockSettings}
                                 image={image}
+                                altText={altText}
                                 isAssetDownloadable={isAssetDownloadable}
                                 isEditing={isEditing}
                             />

--- a/packages/image-block/src/components/DownloadAndAttachments.tsx
+++ b/packages/image-block/src/components/DownloadAndAttachments.tsx
@@ -12,6 +12,7 @@ type DownloadAndAttachmentsProps = {
     appBridge: AppBridgeBlock;
     isEditing: boolean;
     image?: Asset;
+    altText?: string;
     blockSettings: Settings;
     isAssetDownloadable: boolean;
 };
@@ -20,6 +21,7 @@ export const DownloadAndAttachments = ({
     appBridge,
     isEditing,
     image,
+    altText,
     blockSettings,
     isAssetDownloadable,
 }: DownloadAndAttachmentsProps) => {
@@ -41,7 +43,7 @@ export const DownloadAndAttachments = ({
         return null;
     }
 
-    const imageAriaLabel = image?.alternativeText ? `Download ${image.alternativeText}` : 'Download image';
+    const imageAriaLabel = altText ? `Download ${altText}` : 'Download image';
     const paddingStyle = getTotalImagePadding(blockSettings);
 
     return (


### PR DESCRIPTION
Using the same alt text as on the img tag so its fully clear for screen reader users