### PR TITLE
fix: default background alphalevel

### DIFF
--- a/packages/template-block/src/settings.ts
+++ b/packages/template-block/src/settings.ts
@@ -30,7 +30,7 @@ import {
 } from './types';
 import { TEMPLATE_BLOCK_SETTING_ID } from './constants';
 
-export const DEFAULT_BACKGROUND_COLOR = { red: 255, green: 255, blue: 255, alpha: 1 };
+export const DEFAULT_BACKGROUND_COLOR = { red: 255, green: 255, blue: 255, alpha: 0 };
 export const DEFAULT_BORDER_COLOR = { red: 234, green: 235, blue: 235, alpha: 1 };
 
 export const settings = defineSettings({


### PR DESCRIPTION
The alpha level should be at 0 when it's the default background