### PR TITLE
fix(CompareSlider): hides when not in view

### DIFF
--- a/packages/compare-slider-block/src/CompareSliderBlock.tsx
+++ b/packages/compare-slider-block/src/CompareSliderBlock.tsx
@@ -253,7 +253,7 @@ export const CompareSliderBlock = ({ appBridge }: BlockProps) => {
                         alt={slot === SliderImageSlot.First ? firstAssetAlt || '' : secondAssetAlt || ''}
                         containerWidth={containerWidth}
                         className="tw-w-full tw-object-cover"
-                        testId={slot === SliderImageSlot.First ? 'first-slider-image' : 'second-slider-image'}
+                        testId={`slider-item-${slot}`}
                     />
                 </div>
 


### PR DESCRIPTION
TASK-15573

Uses now the `<ResponsiveImage` for better handling at all, as a plus it fixes the bug