### PR TITLE
refactor: treat columnNumber as a string

### DIFF
--- a/packages/text-block/src/TextBlock.tsx
+++ b/packages/text-block/src/TextBlock.tsx
@@ -16,7 +16,7 @@ export const TextBlock = ({ appBridge }: BlockProps): ReactElement => {
     const { content, columnNumber, columnGutterSimple, columnGutterCustom, isColumnGutterCustom } = blockSettings;
     const gap = isColumnGutterCustom ? columnGutterCustom : spacingValues[columnGutterSimple];
 
-    const plugins = useMemo(() => getPlugins(appBridge, columnNumber, gap), [appBridge, columnNumber, gap]);
+    const plugins = useMemo(() => getPlugins(appBridge, parseInt(columnNumber), gap), [appBridge, columnNumber, gap]);
 
     const handleTextChange = useCallback((content: string) => setBlockSettings({ content }), [setBlockSettings]);
 
@@ -27,7 +27,7 @@ export const TextBlock = ({ appBridge }: BlockProps): ReactElement => {
                     id={String(appBridge.context('blockId').get())}
                     isEditing={isEditing}
                     value={content}
-                    columns={columnNumber}
+                    columns={parseInt(columnNumber)}
                     gap={gap}
                     plugins={plugins}
                     placeholder={PLACEHOLDER}

--- a/packages/text-block/src/settings.ts
+++ b/packages/text-block/src/settings.ts
@@ -13,22 +13,22 @@ export const settings = defineSettings({
             id: COLUMN_NR_ID,
             type: 'segmentedControls',
             label: 'Columns',
-            defaultValue: 1,
+            defaultValue: '1',
             choices: [
                 {
-                    value: 1,
+                    value: '1',
                     label: '1',
                 },
                 {
-                    value: 2,
+                    value: '2',
                     label: '2',
                 },
                 {
-                    value: 3,
+                    value: '3',
                     label: '3',
                 },
                 {
-                    value: 4,
+                    value: '4',
                     label: '4',
                 },
             ],

--- a/packages/text-block/src/types.ts
+++ b/packages/text-block/src/types.ts
@@ -5,7 +5,7 @@ import { GutterSpacing } from '@frontify/guideline-blocks-settings';
 export type Settings = {
     columnGutterCustom: string;
     columnGutterSimple: GutterSpacing;
-    columnNumber: number;
+    columnNumber: string;
     isColumnGutterCustom: boolean;
     content?: string;
 };


### PR DESCRIPTION
CU-869ctj5ec

`columnNumber` is used in a segmented control, which means it needs to be treated as a string.