### PR TITLE
refactor: improve types for settings that are always present

### DIFF
--- a/packages/image-block/src/helpers/getDownloadAriaLabel.ts
+++ b/packages/image-block/src/helpers/getDownloadAriaLabel.ts
@@ -2,7 +2,7 @@
 
 export const getDownloadAriaLabel = (
     hasAssetViewer: boolean,
-    hasLink?: boolean,
+    hasLink: boolean,
     altText?: string,
     title?: string
 ): string => {

--- a/packages/image-block/src/types.ts
+++ b/packages/image-block/src/types.ts
@@ -6,7 +6,7 @@ import { type Security } from '@frontify/guideline-blocks-settings';
 export type Link = { link: { link: string }; openInNewTab: boolean };
 
 export type Settings = {
-    hasLink?: boolean;
+    hasLink: boolean;
     linkObject?: Link;
     name?: string;
     altText?: string;
@@ -16,8 +16,8 @@ export type Settings = {
     borderStyle: BorderStyle;
     borderWidth: string;
     downloadable: boolean;
-    assetViewerEnabled?: boolean;
-    hasBackground?: boolean;
+    assetViewerEnabled: boolean;
+    hasBackground: boolean;
     hasBorder: boolean;
     hasCustomPadding: boolean;
     paddingChoice: Padding;


### PR DESCRIPTION
CU-869ctj5hg

Some improvements of cases, where settings are always given, once the new schema is deployed.