### PR TITLE
fix: append px to divider thickness

### DIFF
--- a/packages/divider-block/src/settings.ts
+++ b/packages/divider-block/src/settings.ts
@@ -224,6 +224,7 @@ export const settings = defineSettings({
                     placeholder: 'e.g. 3px',
                     clearable: false,
                     rules: [numericalOrPixelRule, minimumNumericalOrPixelOrAutoRule(1)],
+                    onChange: (bundle) => appendUnit(bundle, THICKNESS_ID),
                 },
                 {
                     id: 'color',


### PR DESCRIPTION
When entering a number (without px) into the divider block, "px" is not appended automatically, causing this [error](https://sentryapp.appsupport.frontify.dev/organizations/frontify/issues/981608/?project=48)