### PR TITLE
fix: allow translation of link

### DIFF
--- a/packages/image-block/manifest.json
+++ b/packages/image-block/manifest.json
@@ -62,6 +62,9 @@
                     "link": {
                         "type": ["object", "null"],
                         "required": ["link"],
+                        "frontify-translatable": true,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true,
                         "properties": {
                             "link": {
                                 "type": "string",


### PR DESCRIPTION
Fixes this [problem](https://sentryapp.appsupport.frontify.dev/organizations/frontify/issues/982920/?project=48)