### PR TITLE
chore(lint): disable sort-keys on manifest.json

### DIFF
--- a/examples/asset-upload/eslint.config.mjs
+++ b/examples/asset-upload/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/animation-curve-block/eslint.config.mjs
+++ b/packages/animation-curve-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/asset-kit-block/eslint.config.mjs
+++ b/packages/asset-kit-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/audio-block/eslint.config.mjs
+++ b/packages/audio-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/callout-block/eslint.config.mjs
+++ b/packages/callout-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/code-snippet-block/eslint.config.mjs
+++ b/packages/code-snippet-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/compare-slider-block/eslint.config.mjs
+++ b/packages/compare-slider-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/divider-block/eslint.config.mjs
+++ b/packages/divider-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/dos-donts-block/eslint.config.mjs
+++ b/packages/dos-donts-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/figma-block/eslint.config.mjs
+++ b/packages/figma-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/glyphs-block/eslint.config.mjs
+++ b/packages/glyphs-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/gradient-block/eslint.config.mjs
+++ b/packages/gradient-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/image-block/eslint.config.mjs
+++ b/packages/image-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/quote-block/eslint.config.mjs
+++ b/packages/quote-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/shared/eslint.config.mjs
+++ b/packages/shared/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/sketchfab-block/eslint.config.mjs
+++ b/packages/sketchfab-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/storybook-block/eslint.config.mjs
+++ b/packages/storybook-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/template-block/eslint.config.mjs
+++ b/packages/template-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/text-block/eslint.config.mjs
+++ b/packages/text-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/thumbnail-grid-block/eslint.config.mjs
+++ b/packages/thumbnail-grid-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );

--- a/packages/ui-pattern-block/eslint.config.mjs
+++ b/packages/ui-pattern-block/eslint.config.mjs
@@ -42,5 +42,11 @@ export default defineConfig(
                 },
             ],
         },
+    },
+    {
+        files: ['**/manifest.json'],
+        rules: {
+            'jsonc/sort-keys': 'off',
+        },
     }
 );


### PR DESCRIPTION
As it's hurting the readability of the `manifest.json`, I will deactivate the rule on it