### PR TITLE
feat(FigmaBlock): check for asset status to be finished before usage

### DIFF
--- a/packages/figma-block/src/FigmaBlock.tsx
+++ b/packages/figma-block/src/FigmaBlock.tsx
@@ -167,6 +167,9 @@ export const FigmaBlock = ({ appBridge }: BlockProps): ReactElement => {
                                     title={asset.title}
                                     url={asset.previewUrl}
                                     assetExternalUrl={safeExternalUrl}
+                                    assetId={asset.id}
+                                    assetStatus={asset.status}
+                                    appBridge={appBridge}
                                     hasLimitedOptions={hasLimitedOptions}
                                     height={isCustomHeight ? heightValue : heights[heightChoice]}
                                     hasBorder={hasBorder}

--- a/packages/figma-block/src/ImageStage.tsx
+++ b/packages/figma-block/src/ImageStage.tsx
@@ -4,9 +4,9 @@ import { joinClassNames, radiusStyleMap, toHex8String } from '@frontify/guidelin
 
 import { DrawFullScreenActionButton, DrawZoomInOutButtons } from './components';
 import { getBorderOfBlock } from './helpers';
+import { useImageStage } from './hooks/useImageStage';
 import { DEFAULT_HEIGHT } from './settings';
 import { type ImageStageProps } from './types';
-import { useImageStage } from './useImageStage';
 
 export const ImageStage = ({
     title,

--- a/packages/figma-block/src/components/FigmaImagePreview.tsx
+++ b/packages/figma-block/src/components/FigmaImagePreview.tsx
@@ -29,7 +29,7 @@ export const FigmaImagePreview = ({
     return (
         <div data-test-id="figma-image-preview" className="tw-flex tw-flex-col tw-justify-center">
             {isReady ? (
-                <ImageStage {...imageStageProps} url={imageStageProps.url} />
+                <ImageStage {...imageStageProps} />
             ) : (
                 <div className="tw-flex tw-items-center tw-justify-center tw-w-full tw-py-8">
                     <LoadingCircle />

--- a/packages/figma-block/src/components/FigmaImagePreview.tsx
+++ b/packages/figma-block/src/components/FigmaImagePreview.tsx
@@ -31,7 +31,7 @@ export const FigmaImagePreview = ({
             {isReady ? (
                 <ImageStage {...imageStageProps} />
             ) : (
-                <div 
+                <div
                     className="tw-flex tw-items-center tw-justify-center tw-w-full"
                     style={{ height: imageStageProps.height }}
                 >

--- a/packages/figma-block/src/components/FigmaImagePreview.tsx
+++ b/packages/figma-block/src/components/FigmaImagePreview.tsx
@@ -31,7 +31,10 @@ export const FigmaImagePreview = ({
             {isReady ? (
                 <ImageStage {...imageStageProps} />
             ) : (
-                <div className="tw-flex tw-items-center tw-justify-center tw-w-full tw-py-8">
+                <div 
+                    className="tw-flex tw-items-center tw-justify-center tw-w-full"
+                    style={{ height: imageStageProps.height }}
+                >
                     <LoadingCircle />
                 </div>
             )}

--- a/packages/figma-block/src/components/FigmaImagePreview.tsx
+++ b/packages/figma-block/src/components/FigmaImagePreview.tsx
@@ -1,29 +1,53 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { type AppBridgeBlock } from '@frontify/app-bridge';
+import { LoadingCircle } from '@frontify/fondue/components';
+
 import { ImageStage } from '../ImageStage';
+import { useAssetStatusPolling } from '../hooks/useAssetStatusPolling';
 import { type ImageStageProps } from '../types';
 import { extractUrlParameterFromUriQueries } from '../utilities';
 
 type FigmaImagePreviewProps = ImageStageProps & {
     assetExternalUrl: string;
     showFigmaLink: boolean;
+    assetId: number;
+    assetStatus: string;
+    appBridge: AppBridgeBlock;
 };
 
-export const FigmaImagePreview = ({ assetExternalUrl, showFigmaLink, ...imageStageProps }: FigmaImagePreviewProps) => (
-    <div data-test-id="figma-image-preview" className="tw-flex tw-flex-col tw-justify-center">
-        <ImageStage {...imageStageProps} />
+export const FigmaImagePreview = ({
+    assetExternalUrl,
+    showFigmaLink,
+    assetId,
+    assetStatus,
+    appBridge,
+    ...imageStageProps
+}: FigmaImagePreviewProps) => {
+    const { isReady } = useAssetStatusPolling(appBridge, assetId, assetStatus);
 
-        {showFigmaLink && (
-            <div className="tw-p-2 tw-text-sm">
-                <a
-                    href={extractUrlParameterFromUriQueries(assetExternalUrl)}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="tw-text-[#4a90e2]"
-                >
-                    {imageStageProps.title}
-                </a>
-            </div>
-        )}
-    </div>
-);
+    return (
+        <div data-test-id="figma-image-preview" className="tw-flex tw-flex-col tw-justify-center">
+            {isReady ? (
+                <ImageStage {...imageStageProps} url={imageStageProps.url} />
+            ) : (
+                <div className="tw-flex tw-items-center tw-justify-center tw-w-full tw-py-8">
+                    <LoadingCircle />
+                </div>
+            )}
+
+            {showFigmaLink && (
+                <div className="tw-p-2 tw-text-sm">
+                    <a
+                        href={extractUrlParameterFromUriQueries(assetExternalUrl)}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="tw-text-[#4a90e2]"
+                    >
+                        {imageStageProps.title}
+                    </a>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/packages/figma-block/src/hooks/useAssetStatusPolling.spec.ts
+++ b/packages/figma-block/src/hooks/useAssetStatusPolling.spec.ts
@@ -11,6 +11,7 @@ import { useAssetStatusPolling } from './useAssetStatusPolling';
 const ASSET_STATUS_FINISHED = 'FINISHED';
 const ASSET_STATUS_PROCESSING = 'PROCESSING';
 const POLLING_INTERVAL_MS = 3000;
+const MAX_POLL_ATTEMPTS = 20;
 const ASSET_ID_FIXTURE = 42;
 
 const createAppBridgeMock = (status: string) =>
@@ -182,6 +183,44 @@ describe('useAssetStatusPolling', () => {
 
             await advancePollingInterval();
             expect(result.current.isReady).toBe(true);
+        });
+
+        it('should set isReady: true when initialStatus prop updates to FINISHED from the parent', () => {
+            const appBridge = createAppBridgeMock(ASSET_STATUS_PROCESSING);
+            let currentStatus = ASSET_STATUS_PROCESSING;
+
+            const { result, rerender } = renderHook(() =>
+                useAssetStatusPolling(appBridge, ASSET_ID_FIXTURE, currentStatus)
+            );
+
+            expect(result.current.isReady).toBe(false);
+
+            currentStatus = ASSET_STATUS_FINISHED;
+            rerender();
+
+            expect(result.current.isReady).toBe(true);
+            expect(appBridge.getBlockAssets).not.toHaveBeenCalled();
+        });
+
+        it('should stop polling and log an error after reaching the max attempt limit', async () => {
+            const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const appBridge = createAppBridgeMock(ASSET_STATUS_PROCESSING);
+
+            const { result } = renderHook(() =>
+                useAssetStatusPolling(appBridge, ASSET_ID_FIXTURE, ASSET_STATUS_PROCESSING)
+            );
+
+            await advancePollingInterval(MAX_POLL_ATTEMPTS);
+
+            expect(appBridge.getBlockAssets).toHaveBeenCalledTimes(MAX_POLL_ATTEMPTS);
+            expect(result.current.isReady).toBe(false);
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                '[useAssetStatusPolling] Max poll attempts reached for asset',
+                ASSET_ID_FIXTURE
+            );
+
+            await advancePollingInterval(5);
+            expect(appBridge.getBlockAssets).toHaveBeenCalledTimes(MAX_POLL_ATTEMPTS);
         });
     });
 });

--- a/packages/figma-block/src/hooks/useAssetStatusPolling.spec.ts
+++ b/packages/figma-block/src/hooks/useAssetStatusPolling.spec.ts
@@ -1,0 +1,187 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type AppBridgeBlock } from '@frontify/app-bridge';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ASSET_ID } from '../settings';
+
+import { useAssetStatusPolling } from './useAssetStatusPolling';
+
+const ASSET_STATUS_FINISHED = 'FINISHED';
+const ASSET_STATUS_PROCESSING = 'PROCESSING';
+const POLLING_INTERVAL_MS = 3000;
+const ASSET_ID_FIXTURE = 42;
+
+const createAppBridgeMock = (status: string) =>
+    ({
+        getBlockAssets: vi.fn().mockResolvedValue({
+            [ASSET_ID]: [{ id: ASSET_ID_FIXTURE, status }],
+        }),
+    }) as unknown as AppBridgeBlock;
+
+const advancePollingInterval = async (times = 1) => {
+    await act(async () => {
+        await vi.advanceTimersByTimeAsync(POLLING_INTERVAL_MS * times);
+    });
+};
+
+describe('useAssetStatusPolling', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    describe('when initialStatus is FINISHED', () => {
+        it('should return isReady: true immediately', () => {
+            const appBridge = createAppBridgeMock(ASSET_STATUS_PROCESSING);
+
+            const { result } = renderHook(() =>
+                useAssetStatusPolling(appBridge, ASSET_ID_FIXTURE, ASSET_STATUS_FINISHED)
+            );
+
+            expect(result.current.isReady).toBe(true);
+        });
+
+        it('should not start polling', async () => {
+            const appBridge = createAppBridgeMock(ASSET_STATUS_PROCESSING);
+
+            renderHook(() => useAssetStatusPolling(appBridge, ASSET_ID_FIXTURE, ASSET_STATUS_FINISHED));
+
+            await advancePollingInterval(3);
+
+            expect(appBridge.getBlockAssets).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('when initialStatus is not FINISHED', () => {
+        it('should return isReady: false initially', () => {
+            const appBridge = createAppBridgeMock(ASSET_STATUS_PROCESSING);
+
+            const { result } = renderHook(() =>
+                useAssetStatusPolling(appBridge, ASSET_ID_FIXTURE, ASSET_STATUS_PROCESSING)
+            );
+
+            expect(result.current.isReady).toBe(false);
+        });
+
+        it('should start polling and set isReady: true when the asset reaches FINISHED', async () => {
+            const appBridge = createAppBridgeMock(ASSET_STATUS_FINISHED);
+
+            const { result } = renderHook(() =>
+                useAssetStatusPolling(appBridge, ASSET_ID_FIXTURE, ASSET_STATUS_PROCESSING)
+            );
+
+            expect(result.current.isReady).toBe(false);
+
+            await advancePollingInterval();
+
+            expect(appBridge.getBlockAssets).toHaveBeenCalledTimes(1);
+            expect(result.current.isReady).toBe(true);
+        });
+
+        it('should keep polling until status becomes FINISHED', async () => {
+            const appBridge = {
+                getBlockAssets: vi
+                    .fn()
+                    .mockResolvedValueOnce({ [ASSET_ID]: [{ id: ASSET_ID_FIXTURE, status: ASSET_STATUS_PROCESSING }] })
+                    .mockResolvedValueOnce({ [ASSET_ID]: [{ id: ASSET_ID_FIXTURE, status: ASSET_STATUS_PROCESSING }] })
+                    .mockResolvedValue({ [ASSET_ID]: [{ id: ASSET_ID_FIXTURE, status: ASSET_STATUS_FINISHED }] }),
+            } as unknown as AppBridgeBlock;
+
+            const { result } = renderHook(() =>
+                useAssetStatusPolling(appBridge, ASSET_ID_FIXTURE, ASSET_STATUS_PROCESSING)
+            );
+
+            await advancePollingInterval(2);
+            expect(result.current.isReady).toBe(false);
+            expect(appBridge.getBlockAssets).toHaveBeenCalledTimes(2);
+
+            await advancePollingInterval();
+            expect(result.current.isReady).toBe(true);
+            expect(appBridge.getBlockAssets).toHaveBeenCalledTimes(3);
+        });
+
+        it('should stop polling after status becomes FINISHED', async () => {
+            const appBridge = createAppBridgeMock(ASSET_STATUS_FINISHED);
+
+            renderHook(() => useAssetStatusPolling(appBridge, ASSET_ID_FIXTURE, ASSET_STATUS_PROCESSING));
+
+            await advancePollingInterval();
+            expect(appBridge.getBlockAssets).toHaveBeenCalledTimes(1);
+
+            await advancePollingInterval(5);
+            expect(appBridge.getBlockAssets).toHaveBeenCalledTimes(1);
+        });
+
+        it('should clear the interval on unmount', () => {
+            const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+            const appBridge = createAppBridgeMock(ASSET_STATUS_PROCESSING);
+
+            const { unmount } = renderHook(() =>
+                useAssetStatusPolling(appBridge, ASSET_ID_FIXTURE, ASSET_STATUS_PROCESSING)
+            );
+
+            unmount();
+
+            expect(clearIntervalSpy).toHaveBeenCalled();
+        });
+
+        it('should remain not ready when the asset is not found in the returned assets', async () => {
+            const appBridge = {
+                getBlockAssets: vi.fn().mockResolvedValue({ [ASSET_ID]: [{ id: 999, status: ASSET_STATUS_FINISHED }] }),
+            } as unknown as AppBridgeBlock;
+
+            const { result } = renderHook(() =>
+                useAssetStatusPolling(appBridge, ASSET_ID_FIXTURE, ASSET_STATUS_PROCESSING)
+            );
+
+            await advancePollingInterval();
+
+            expect(result.current.isReady).toBe(false);
+        });
+
+        it('should remain not ready when the key is absent from block assets', async () => {
+            const appBridge = {
+                getBlockAssets: vi.fn().mockResolvedValue({}),
+            } as unknown as AppBridgeBlock;
+
+            const { result } = renderHook(() =>
+                useAssetStatusPolling(appBridge, ASSET_ID_FIXTURE, ASSET_STATUS_PROCESSING)
+            );
+
+            await advancePollingInterval();
+
+            expect(result.current.isReady).toBe(false);
+        });
+
+        it('should log an error and continue polling when getBlockAssets throws', async () => {
+            const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const error = new Error('Network error');
+            const appBridge = {
+                getBlockAssets: vi
+                    .fn()
+                    .mockRejectedValueOnce(error)
+                    .mockResolvedValue({ [ASSET_ID]: [{ id: ASSET_ID_FIXTURE, status: ASSET_STATUS_FINISHED }] }),
+            } as unknown as AppBridgeBlock;
+
+            const { result } = renderHook(() =>
+                useAssetStatusPolling(appBridge, ASSET_ID_FIXTURE, ASSET_STATUS_PROCESSING)
+            );
+
+            await advancePollingInterval();
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                '[useAssetStatusPolling] Failed to fetch block assets:',
+                error
+            );
+            expect(result.current.isReady).toBe(false);
+
+            await advancePollingInterval();
+            expect(result.current.isReady).toBe(true);
+        });
+    });
+});

--- a/packages/figma-block/src/hooks/useAssetStatusPolling.ts
+++ b/packages/figma-block/src/hooks/useAssetStatusPolling.ts
@@ -13,16 +13,18 @@ type UseAssetStatusPollingReturn = {
     isReady: boolean;
 };
 
+const isFinished = (status: string | undefined) => status && status === ASSET_STATUS_FINISHED;
+
 export const useAssetStatusPolling = (
     appBridge: AppBridgeBlock,
     assetId: number,
     initialStatus: string
 ): UseAssetStatusPollingReturn => {
     const [pollingDetectedFinished, setPollingDetectedFinished] = useState(false);
-    const isReady = initialStatus === ASSET_STATUS_FINISHED || pollingDetectedFinished;
+    const isReady = isFinished(initialStatus) || pollingDetectedFinished;
 
     useEffect(() => {
-        if (initialStatus === ASSET_STATUS_FINISHED) {
+        if (isFinished(initialStatus)) {
             return;
         }
 
@@ -36,7 +38,7 @@ export const useAssetStatusPolling = (
                 const assets = blockAssets[ASSET_ID] ?? [];
                 const asset = assets.find((a) => a.id === assetId);
 
-                if (asset?.status === ASSET_STATUS_FINISHED) {
+                if (isFinished(asset?.status)) {
                     setPollingDetectedFinished(true);
                     clearInterval(intervalId);
                     return;

--- a/packages/figma-block/src/hooks/useAssetStatusPolling.ts
+++ b/packages/figma-block/src/hooks/useAssetStatusPolling.ts
@@ -28,7 +28,7 @@ export const useAssetStatusPolling = (
             return;
         }
 
-        let intervalId: number;
+        let intervalId: ReturnType<typeof setInterval>;
         let attempts = 0;
 
         const poll = async () => {

--- a/packages/figma-block/src/hooks/useAssetStatusPolling.ts
+++ b/packages/figma-block/src/hooks/useAssetStatusPolling.ts
@@ -7,6 +7,7 @@ import { ASSET_ID } from '../settings';
 
 const ASSET_STATUS_FINISHED = 'FINISHED';
 const POLLING_INTERVAL_MS = 3000;
+const MAX_POLL_ATTEMPTS = 20;
 
 type UseAssetStatusPollingReturn = {
     isReady: boolean;
@@ -17,28 +18,36 @@ export const useAssetStatusPolling = (
     assetId: number,
     initialStatus: string
 ): UseAssetStatusPollingReturn => {
-    const isInitiallyFinished = initialStatus === ASSET_STATUS_FINISHED;
-    const [isReady, setIsReady] = useState(isInitiallyFinished);
+    const [pollingDetectedFinished, setPollingDetectedFinished] = useState(false);
+    const isReady = initialStatus === ASSET_STATUS_FINISHED || pollingDetectedFinished;
 
     useEffect(() => {
-        if (isInitiallyFinished) {
+        if (initialStatus === ASSET_STATUS_FINISHED) {
             return;
         }
 
         let intervalId: number;
+        let attempts = 0;
 
         const poll = async () => {
+            attempts++;
             try {
                 const blockAssets = await appBridge.getBlockAssets();
                 const assets = blockAssets[ASSET_ID] ?? [];
                 const asset = assets.find((a) => a.id === assetId);
 
                 if (asset?.status === ASSET_STATUS_FINISHED) {
-                    setIsReady(true);
+                    setPollingDetectedFinished(true);
                     clearInterval(intervalId);
+                    return;
                 }
             } catch (error) {
                 console.error('[useAssetStatusPolling] Failed to fetch block assets:', error);
+            }
+
+            if (attempts >= MAX_POLL_ATTEMPTS) {
+                console.error('[useAssetStatusPolling] Max poll attempts reached for asset', assetId);
+                clearInterval(intervalId);
             }
         };
 
@@ -47,7 +56,7 @@ export const useAssetStatusPolling = (
         }, POLLING_INTERVAL_MS);
 
         return () => clearInterval(intervalId);
-    }, [appBridge, assetId, isInitiallyFinished]);
+    }, [appBridge, assetId, initialStatus]);
 
     return { isReady };
 };

--- a/packages/figma-block/src/hooks/useAssetStatusPolling.ts
+++ b/packages/figma-block/src/hooks/useAssetStatusPolling.ts
@@ -49,7 +49,5 @@ export const useAssetStatusPolling = (
         return () => clearInterval(intervalId);
     }, [appBridge, assetId, isInitiallyFinished]);
 
-    return {
-        isReady,
-    };
+    return { isReady };
 };

--- a/packages/figma-block/src/hooks/useAssetStatusPolling.ts
+++ b/packages/figma-block/src/hooks/useAssetStatusPolling.ts
@@ -1,0 +1,55 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type AppBridgeBlock } from '@frontify/app-bridge';
+import { useEffect, useState } from 'react';
+
+import { ASSET_ID } from '../settings';
+
+const ASSET_STATUS_FINISHED = 'FINISHED';
+const POLLING_INTERVAL_MS = 3000;
+
+type UseAssetStatusPollingReturn = {
+    isReady: boolean;
+};
+
+export const useAssetStatusPolling = (
+    appBridge: AppBridgeBlock,
+    assetId: number,
+    initialStatus: string
+): UseAssetStatusPollingReturn => {
+    const isInitiallyFinished = initialStatus === ASSET_STATUS_FINISHED;
+    const [isReady, setIsReady] = useState(isInitiallyFinished);
+
+    useEffect(() => {
+        if (isInitiallyFinished) {
+            return;
+        }
+
+        let intervalId: number;
+
+        const poll = async () => {
+            try {
+                const blockAssets = await appBridge.getBlockAssets();
+                const assets = blockAssets[ASSET_ID] ?? [];
+                const asset = assets.find((a) => a.id === assetId);
+
+                if (asset?.status === ASSET_STATUS_FINISHED) {
+                    setIsReady(true);
+                    clearInterval(intervalId);
+                }
+            } catch (error) {
+                console.error('[useAssetStatusPolling] Failed to fetch block assets:', error);
+            }
+        };
+
+        intervalId = setInterval(() => {
+            poll().catch(console.error);
+        }, POLLING_INTERVAL_MS);
+
+        return () => clearInterval(intervalId);
+    }, [appBridge, assetId, isInitiallyFinished]);
+
+    return {
+        isReady,
+    };
+};

--- a/packages/figma-block/src/hooks/useAssetStatusPolling.ts
+++ b/packages/figma-block/src/hooks/useAssetStatusPolling.ts
@@ -13,7 +13,7 @@ type UseAssetStatusPollingReturn = {
     isReady: boolean;
 };
 
-const isFinished = (status: string | undefined) => status && status === ASSET_STATUS_FINISHED;
+const isFinished = (status: string | undefined): boolean => status === ASSET_STATUS_FINISHED;
 
 export const useAssetStatusPolling = (
     appBridge: AppBridgeBlock,

--- a/packages/figma-block/src/hooks/useAssetStatusPolling.ts
+++ b/packages/figma-block/src/hooks/useAssetStatusPolling.ts
@@ -53,8 +53,8 @@ export const useAssetStatusPolling = (
             }
         };
 
-        intervalId = setInterval(() => {
-            poll().catch(console.error);
+        intervalId = setInterval(async () => {
+            await poll();
         }, POLLING_INTERVAL_MS);
 
         return () => clearInterval(intervalId);

--- a/packages/figma-block/src/hooks/useImageStage.ts
+++ b/packages/figma-block/src/hooks/useImageStage.ts
@@ -9,9 +9,9 @@ import {
     ImageElement,
     ImageStage,
     VectorContainerOperator,
-} from './components';
-import { getHeightOfBlock } from './helpers';
-import { type UseImageStageProps, Zoom } from './types';
+} from '../components';
+import { getHeightOfBlock } from '../helpers';
+import { type UseImageStageProps, Zoom } from '../types';
 
 export const useImageStage = ({ height, hasLimitedOptions, isMobile }: UseImageStageProps) => {
     const [isFullScreen, setIsFullScreen] = useState<boolean>(false);


### PR DESCRIPTION
## The problem we're trying to solve:

When the asset status is not FINISHED and we're trying to use the `previewUrl` we're putting a lot of strain on the worker that deals with the assets.

## Solution
We're going to check if the `asset.status` is `FINISHED` before using the `previewUrl`.

Technical details:
* create a custom react hook `useAssetStatusPolling` that will be used in `FigmaImagePreview` to communicate if the asset is ready
* the hook does the checking of the status and polls for updates if the status is not FINISHED
* we show a loading circle if the asset is not ready


