### PR TITLE
feat: adjust do-and-dont schema

### DIFF
--- a/packages/dos-donts-block/manifest.json
+++ b/packages/dos-donts-block/manifest.json
@@ -3,6 +3,20 @@
     "settingsSchema": {
         "type": "object",
         "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "color": {
+                "type": ["null", "object"],
+                "required": ["red", "green", "blue"],
+                "additionalProperties": false,
+                "properties": {
+                    "red": { "type": "integer", "minimum": 0, "maximum": 255, "frontify-api-read": true },
+                    "green": { "type": "integer", "minimum": 0, "maximum": 255, "frontify-api-read": true },
+                    "blue": { "type": "integer", "minimum": 0, "maximum": 255, "frontify-api-read": true },
+                    "alpha": { "type": "number", "minimum": 0, "maximum": 1, "frontify-api-read": true },
+                    "name": { "type": "string", "frontify-api-read": true }
+                }
+            }
+        },
         "required": [
             "mode",
             "style",
@@ -82,49 +96,13 @@
 
             "hasCustomDoColor": { "type": "boolean", "frontify-api-read": true },
             "hasCustomDontColor": { "type": "boolean", "frontify-api-read": true },
-            "doColor": {
-                "type": ["null", "object"],
-                "required": ["red", "green", "blue"],
-                "additionalProperties": false,
-                "frontify-api-read": true,
-                "properties": {
-                    "red": { "type": "integer", "minimum": 0, "maximum": 255 },
-                    "green": { "type": "integer", "minimum": 0, "maximum": 255 },
-                    "blue": { "type": "integer", "minimum": 0, "maximum": 255 },
-                    "alpha": { "type": "number", "minimum": 0, "maximum": 1 },
-                    "name": { "type": "string" }
-                }
-            },
-            "dontColor": {
-                "type": ["null", "object"],
-                "required": ["red", "green", "blue"],
-                "additionalProperties": false,
-                "frontify-api-read": true,
-                "properties": {
-                    "red": { "type": "integer", "minimum": 0, "maximum": 255 },
-                    "green": { "type": "integer", "minimum": 0, "maximum": 255 },
-                    "blue": { "type": "integer", "minimum": 0, "maximum": 255 },
-                    "alpha": { "type": "number", "minimum": 0, "maximum": 1 },
-                    "name": { "type": "string" }
-                }
-            },
+            "doColor": { "$ref": "#/$defs/color" },
+            "dontColor": { "$ref": "#/$defs/color" },
 
             "hasBorder": { "type": "boolean", "frontify-api-read": true },
             "borderWidth": { "type": "string", "pattern": "^[0-9]+px$", "frontify-api-read": true },
             "borderStyle": { "type": "string", "enum": ["Solid", "Dashed", "Dotted"], "frontify-api-read": true },
-            "borderColor": {
-                "type": ["null", "object"],
-                "required": ["red", "green", "blue"],
-                "additionalProperties": false,
-                "frontify-api-read": true,
-                "properties": {
-                    "red": { "type": "integer", "minimum": 0, "maximum": 255 },
-                    "green": { "type": "integer", "minimum": 0, "maximum": 255 },
-                    "blue": { "type": "integer", "minimum": 0, "maximum": 255 },
-                    "alpha": { "type": "number", "minimum": 0, "maximum": 1 },
-                    "name": { "type": "string" }
-                }
-            },
+            "borderColor": { "$ref": "#/$defs/color" },
 
             "hasRadius": { "type": "boolean", "frontify-api-read": true },
             "radiusValue": { "type": "string", "pattern": "^[0-9]+px$", "frontify-api-read": true },
@@ -135,19 +113,7 @@
             },
 
             "hasBackground": { "type": "boolean", "frontify-api-read": true },
-            "backgroundColor": {
-                "type": ["null", "object"],
-                "required": ["red", "green", "blue"],
-                "additionalProperties": false,
-                "frontify-api-read": true,
-                "properties": {
-                    "red": { "type": "integer", "minimum": 0, "maximum": 255 },
-                    "green": { "type": "integer", "minimum": 0, "maximum": 255 },
-                    "blue": { "type": "integer", "minimum": 0, "maximum": 255 },
-                    "alpha": { "type": "number", "minimum": 0, "maximum": 1 },
-                    "name": { "type": "string" }
-                }
-            },
+            "backgroundColor": { "$ref": "#/$defs/color" },
 
             "items": {
                 "type": "array",
@@ -155,18 +121,12 @@
                     "type": "object",
                     "required": ["id", "type", "title", "body"],
                     "additionalProperties": false,
-                    "frontify-api-read": true,
                     "properties": {
                         "id": {
+                            "type": ["string", "integer"],
+                            "pattern": "^(id-[0-9]+|c[0-9a-z]{24}|[0-9]+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$",
                             "frontify-api-read": true,
-                            "frontify-translatable": true,
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "pattern": "^(id-[0-9]+|c[0-9a-z]{24}|[0-9]+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"
-                                },
-                                { "type": "integer" }
-                            ]
+                            "frontify-translatable": true
                         },
                         "type": {
                             "type": "string",


### PR DESCRIPTION
Adjust the schema to reflect the new backend.

- drop `oneOf` -> use multi type
- introduce $def for colors