### PR TITLE
feat(Scoping): use themeProvider for scoping

### DIFF
--- a/examples/asset-upload/postcss.config.js
+++ b/examples/asset-upload/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.example-asset-upload' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/examples/asset-upload/src/ExampleAssetUploadBlock.tsx
+++ b/examples/asset-upload/src/ExampleAssetUploadBlock.tsx
@@ -6,6 +6,8 @@ import { type BlockProps } from '@frontify/guideline-blocks-settings';
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type ReactElement, useEffect, useState } from 'react';
 
+import manifest from '../manifest.json';
+
 import { IMAGE_SETTING_ID } from './settings';
 
 export const ExampleAssetUploadBlock = ({ appBridge }: BlockProps): ReactElement => {
@@ -66,44 +68,42 @@ export const ExampleAssetUploadBlock = ({ appBridge }: BlockProps): ReactElement
     };
 
     return (
-        <div className="example-asset-upload">
-            <StyleProvider>
-                <div className="tw-flex tw-flex-col tw-gap-4">
-                    <div className="tw-flex tw-gap-4">
-                        <Button onPress={onOpenAssetChooser}>Open asset chooser</Button>
-                        <Button onPress={openFileDialog} disabled={loading}>
-                            {loading ? 'Uploading...' : 'Upload'}
-                        </Button>
-                    </div>
+        <StyleProvider appId={manifest.appId}>
+            <div className="tw-flex tw-flex-col tw-gap-4">
+                <div className="tw-flex tw-gap-4">
+                    <Button onPress={onOpenAssetChooser}>Open asset chooser</Button>
+                    <Button onPress={openFileDialog} disabled={loading}>
+                        {loading ? 'Uploading...' : 'Upload'}
+                    </Button>
+                </div>
 
-                    <div data-test-id="example-asset-upload-block">
-                        {blockAssets[IMAGE_SETTING_ID] ? (
-                            blockAssets[IMAGE_SETTING_ID].map((asset: Asset) => (
-                                <div key={asset.id}>
-                                    <img
-                                        src={asset.previewUrl}
-                                        alt={asset.title}
-                                        data-test-id="example-asset-upload-image"
-                                    />
-                                    <div className="tw-flex tw-flex-col tw-gap-4">
-                                        <strong>{asset.title}</strong>
-                                        <div className="tw-flex tw-gap-4">
-                                            {/* eslint-disable-next-line @eslint-react/static-components */}
-                                            <Link link={asset.previewUrl} text="Preview URL" />
-                                            {/* eslint-disable-next-line @eslint-react/static-components */}
-                                            <Link link={asset.genericUrl} text="Generic URL" />
-                                            {/* eslint-disable-next-line @eslint-react/static-components */}
-                                            {asset.originUrl && <Link link={asset.originUrl} text="Origin URL" />}
-                                        </div>
+                <div data-test-id="example-asset-upload-block">
+                    {blockAssets[IMAGE_SETTING_ID] ? (
+                        blockAssets[IMAGE_SETTING_ID].map((asset: Asset) => (
+                            <div key={asset.id}>
+                                <img
+                                    src={asset.previewUrl}
+                                    alt={asset.title}
+                                    data-test-id="example-asset-upload-image"
+                                />
+                                <div className="tw-flex tw-flex-col tw-gap-4">
+                                    <strong>{asset.title}</strong>
+                                    <div className="tw-flex tw-gap-4">
+                                        {/* eslint-disable-next-line @eslint-react/static-components */}
+                                        <Link link={asset.previewUrl} text="Preview URL" />
+                                        {/* eslint-disable-next-line @eslint-react/static-components */}
+                                        <Link link={asset.genericUrl} text="Generic URL" />
+                                        {/* eslint-disable-next-line @eslint-react/static-components */}
+                                        {asset.originUrl && <Link link={asset.originUrl} text="Origin URL" />}
                                     </div>
                                 </div>
-                            ))
-                        ) : (
-                            <p>No image set</p>
-                        )}
-                    </div>
+                            </div>
+                        ))
+                    ) : (
+                        <p>No image set</p>
+                    )}
                 </div>
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/animation-curve-block/postcss.config.js
+++ b/packages/animation-curve-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.animation-curve-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/animation-curve-block/src/AnimationCurveBlock.tsx
+++ b/packages/animation-curve-block/src/AnimationCurveBlock.tsx
@@ -8,6 +8,8 @@ import { type BlockProps, gutterSpacingStyleMap, useDndSensors } from '@frontify
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { useState } from 'react';
 
+import manifest from '../manifest.json';
+
 import { BlankSlate, Card, SortableCard } from './components';
 import { gridClasses } from './constants';
 import { type AnimationCurve, type AnimationCurvePatch, type Settings } from './types';
@@ -56,65 +58,63 @@ export const AnimationCurveBlock = ({ appBridge }: BlockProps) => {
     };
 
     return (
-        <div className="animation-curve-block tw-@container">
-            <StyleProvider>
-                <DndContext
-                    sensors={sensors}
-                    collisionDetection={closestCenter}
-                    onDragEnd={handleDragEnd}
-                    onDragStart={handleDragStart}
-                    modifiers={[restrictToParentElement]}
+        <StyleProvider appId={manifest.appId} className="tw-@container">
+            <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+                onDragStart={handleDragStart}
+                modifiers={[restrictToParentElement]}
+            >
+                <div
+                    data-test-id="animation-curve-block"
+                    className={`tw-grid tw-auto-rows-auto ${gridClasses[columns]}`}
+                    style={{
+                        gap,
+                    }}
                 >
-                    <div
-                        data-test-id="animation-curve-block"
-                        className={`tw-grid tw-auto-rows-auto ${gridClasses[columns]}`}
-                        style={{
-                            gap,
-                        }}
-                    >
-                        <SortableContext items={localItems} strategy={rectSortingStrategy}>
-                            {localItems?.map((animationCurve) => (
-                                <SortableCard
+                    <SortableContext items={localItems} strategy={rectSortingStrategy}>
+                        {localItems?.map((animationCurve) => (
+                            <SortableCard
+                                appBridge={appBridge}
+                                key={animationCurve.id}
+                                animationCurve={animationCurve}
+                                isEditing={isEditing}
+                                blockSettings={blockSettings}
+                                onDelete={deleteAnimationCurve}
+                                onUpdate={updateAnimationCurve}
+                                setCanvasHeight={setCanvasHeight}
+                            />
+                        ))}
+                        <DragOverlay>
+                            {activeItem && (
+                                <Card
                                     appBridge={appBridge}
-                                    key={animationCurve.id}
-                                    animationCurve={animationCurve}
+                                    key={activeItem.id}
+                                    animationCurve={activeItem}
                                     isEditing={isEditing}
+                                    isDragging
                                     blockSettings={blockSettings}
                                     onDelete={deleteAnimationCurve}
                                     onUpdate={updateAnimationCurve}
                                     setCanvasHeight={setCanvasHeight}
                                 />
-                            ))}
-                            <DragOverlay>
-                                {activeItem && (
-                                    <Card
-                                        appBridge={appBridge}
-                                        key={activeItem.id}
-                                        animationCurve={activeItem}
-                                        isEditing={isEditing}
-                                        isDragging
-                                        blockSettings={blockSettings}
-                                        onDelete={deleteAnimationCurve}
-                                        onUpdate={updateAnimationCurve}
-                                        setCanvasHeight={setCanvasHeight}
-                                    />
-                                )}
-                            </DragOverlay>
-                        </SortableContext>
-                        {isEditing && (
-                            <BlankSlate
-                                key={localItems.length}
-                                appBridge={appBridge}
-                                content={localItems}
-                                hasBorder={hasBorder}
-                                setLocalItems={setLocalItems}
-                                setBlockSettings={setBlockSettings}
-                                canvasHeight={canvasHeight}
-                            />
-                        )}
-                    </div>
-                </DndContext>
-            </StyleProvider>
-        </div>
+                            )}
+                        </DragOverlay>
+                    </SortableContext>
+                    {isEditing && (
+                        <BlankSlate
+                            key={localItems.length}
+                            appBridge={appBridge}
+                            content={localItems}
+                            hasBorder={hasBorder}
+                            setLocalItems={setLocalItems}
+                            setBlockSettings={setBlockSettings}
+                            canvasHeight={canvasHeight}
+                        />
+                    )}
+                </div>
+            </DndContext>
+        </StyleProvider>
     );
 };

--- a/packages/asset-kit-block/postcss.config.js
+++ b/packages/asset-kit-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.asset-kit-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -19,6 +19,8 @@ import {
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type ReactElement, useEffect, useRef, useState } from 'react';
 
+import manifest from '../manifest.json';
+
 import { AssetGrid, AssetSelection, DownloadMessage, InformationSection } from './components';
 import { blockStyle } from './helpers';
 import { ASSET_SETTINGS_ID } from './settings';
@@ -89,91 +91,89 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement | null =>
     }
 
     return (
-        <div className="asset-kit-block">
-            <StyleProvider>
-                <div
-                    data-test-id="asset-kit-block"
-                    className={joinClassNames([
-                        'tw-w-full tw-space-y-8',
-                        (hasBorder_blocks || hasBackgroundBlocks) && 'tw-p-5 sm:tw-p-8',
-                    ])}
-                    style={{
-                        ...blockStyle(blockSettings),
-                    }}
-                >
-                    <div className="sm:tw-flex tw-gap-8 tw-space-y-3 md:tw-space-y-0">
-                        <InformationSection
-                            description={description}
-                            isEditing={isEditing}
-                            setBlockSettings={setBlockSettings}
-                            title={title}
-                            appBridge={appBridge}
-                        />
-                        <div className="tw-flex-none">
-                            <button
-                                type="button"
-                                data-test-id="asset-kit-block-download-button"
-                                className="[&>div]:!tw-@container-normal"
-                                disabled={isButtonDisabled}
-                                onClick={isEditing ? undefined : startDownload}
-                                onMouseEnter={() => setButtonHover(true)}
-                                onMouseLeave={() => setButtonHover(false)}
-                                style={{
-                                    ...BlockStyles.buttonPrimary,
-                                    ...(buttonHover ? BlockStyles.buttonPrimary?.hover : null),
-                                    ...(isButtonDisabled ? { opacity: 0.5 } : null),
-                                    overflow: 'visible',
-                                }}
-                            >
-                                <RichTextEditor
-                                    id={`asset-kit-block-download-button-text-${appBridge.context('blockId').get()}`}
-                                    value={
-                                        hasRichTextValue(buttonText)
-                                            ? buttonText
-                                            : convertToRteValue('p', 'Download package')
-                                    }
-                                    isEditing={isEditing}
-                                    plugins={new PluginComposer({ noToolbar: true }).setPlugin()}
-                                    onTextChange={(buttonText) => setBlockSettings({ buttonText })}
-                                />
-                                <span
-                                    data-test-id="asset-kit-block-screen-reader"
-                                    ref={screenReaderRef}
-                                    role="status"
-                                    className="tw-absolute -tw-left-[10000px] tw-top-auto tw-w-1 tw-h-1 tw-overflow-hidden"
-                                />
-                            </button>
-                        </div>
-                    </div>
-
-                    {![AssetBulkDownloadState.Init, AssetBulkDownloadState.Ready].includes(status) && (
-                        <DownloadMessage blockStyle={blockStyle(blockSettings)} status={status} />
-                    )}
-
-                    <div>
-                        <AssetGrid
-                            appBridge={appBridge}
-                            currentAssets={currentAssets}
-                            deleteAssetIdsFromKey={deleteAssetIdsFromKey}
-                            updateAssetIdsFromKey={updateAssetIdsFromKey}
-                            isEditing={isEditing}
-                            showThumbnails={showThumbnails}
-                            showCount={showCount}
-                            countColor={assetCountColor === 'override' ? countCustomColor : undefined}
-                        />
-
-                        {isEditing && (
-                            <AssetSelection
-                                appBridge={appBridge}
-                                isUploadingAssets={isUploadingAssets}
-                                setIsUploadingAssets={setIsUploadingAssets}
-                                addAssetIdsToKey={addAssetIdsToKey}
-                                currentAssets={currentAssets}
+        <StyleProvider appId={manifest.appId}>
+            <div
+                data-test-id="asset-kit-block"
+                className={joinClassNames([
+                    'tw-w-full tw-space-y-8',
+                    (hasBorder_blocks || hasBackgroundBlocks) && 'tw-p-5 sm:tw-p-8',
+                ])}
+                style={{
+                    ...blockStyle(blockSettings),
+                }}
+            >
+                <div className="sm:tw-flex tw-gap-8 tw-space-y-3 md:tw-space-y-0">
+                    <InformationSection
+                        description={description}
+                        isEditing={isEditing}
+                        setBlockSettings={setBlockSettings}
+                        title={title}
+                        appBridge={appBridge}
+                    />
+                    <div className="tw-flex-none">
+                        <button
+                            type="button"
+                            data-test-id="asset-kit-block-download-button"
+                            className="[&>div]:!tw-@container-normal"
+                            disabled={isButtonDisabled}
+                            onClick={isEditing ? undefined : startDownload}
+                            onMouseEnter={() => setButtonHover(true)}
+                            onMouseLeave={() => setButtonHover(false)}
+                            style={{
+                                ...BlockStyles.buttonPrimary,
+                                ...(buttonHover ? BlockStyles.buttonPrimary?.hover : null),
+                                ...(isButtonDisabled ? { opacity: 0.5 } : null),
+                                overflow: 'visible',
+                            }}
+                        >
+                            <RichTextEditor
+                                id={`asset-kit-block-download-button-text-${appBridge.context('blockId').get()}`}
+                                value={
+                                    hasRichTextValue(buttonText)
+                                        ? buttonText
+                                        : convertToRteValue('p', 'Download package')
+                                }
+                                isEditing={isEditing}
+                                plugins={new PluginComposer({ noToolbar: true }).setPlugin()}
+                                onTextChange={(buttonText) => setBlockSettings({ buttonText })}
                             />
-                        )}
+                            <span
+                                data-test-id="asset-kit-block-screen-reader"
+                                ref={screenReaderRef}
+                                role="status"
+                                className="tw-absolute -tw-left-[10000px] tw-top-auto tw-w-1 tw-h-1 tw-overflow-hidden"
+                            />
+                        </button>
                     </div>
                 </div>
-            </StyleProvider>
-        </div>
+
+                {![AssetBulkDownloadState.Init, AssetBulkDownloadState.Ready].includes(status) && (
+                    <DownloadMessage blockStyle={blockStyle(blockSettings)} status={status} />
+                )}
+
+                <div>
+                    <AssetGrid
+                        appBridge={appBridge}
+                        currentAssets={currentAssets}
+                        deleteAssetIdsFromKey={deleteAssetIdsFromKey}
+                        updateAssetIdsFromKey={updateAssetIdsFromKey}
+                        isEditing={isEditing}
+                        showThumbnails={showThumbnails}
+                        showCount={showCount}
+                        countColor={assetCountColor === 'override' ? countCustomColor : undefined}
+                    />
+
+                    {isEditing && (
+                        <AssetSelection
+                            appBridge={appBridge}
+                            isUploadingAssets={isUploadingAssets}
+                            setIsUploadingAssets={setIsUploadingAssets}
+                            addAssetIdsToKey={addAssetIdsToKey}
+                            currentAssets={currentAssets}
+                        />
+                    )}
+                </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/audio-block/postcss.config.js
+++ b/packages/audio-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.audio-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/audio-block/src/AudioBlock.tsx
+++ b/packages/audio-block/src/AudioBlock.tsx
@@ -26,6 +26,8 @@ import {
 import { DownloadButton, generateRandomId, StyleProvider } from '@frontify/guideline-blocks-shared';
 import { useEffect, useState } from 'react';
 
+import manifest from '../manifest.json';
+
 import { AudioPlayer, BlockAttachments, UploadPlaceholder } from './components';
 import { getDescriptionPlugins, titlePlugins } from './helpers/plugins';
 import { ATTACHMENTS_ASSET_ID, AUDIO_ID } from './settings';
@@ -123,81 +125,77 @@ export const AudioBlock = ({ appBridge }: BlockProps) => {
             assetId={ATTACHMENTS_ASSET_ID}
             appBridge={appBridge}
         >
-            <div className="audio-block">
-                <StyleProvider>
-                    <div
-                        data-test-id="audio-block"
-                        className={joinClassNames([
-                            'tw-flex tw-gap-3',
-                            blockSettings.positioning === TextPosition.Below ? 'tw-flex-col' : 'tw-flex-col-reverse',
-                        ])}
-                    >
-                        {audio ? (
-                            <AudioPlayer
-                                audio={audio}
-                                isEditing={isEditing}
-                                isLoading={isLoading}
-                                openFileDialog={openFileDialog}
-                                openAssetChooser={onOpenAssetChooser}
-                                onRemoveAsset={onRemoveAsset}
+            <StyleProvider appId={manifest.appId}>
+                <div
+                    data-test-id="audio-block"
+                    className={joinClassNames([
+                        'tw-flex tw-gap-3',
+                        blockSettings.positioning === TextPosition.Below ? 'tw-flex-col' : 'tw-flex-col-reverse',
+                    ])}
+                >
+                    {audio ? (
+                        <AudioPlayer
+                            audio={audio}
+                            isEditing={isEditing}
+                            isLoading={isLoading}
+                            openFileDialog={openFileDialog}
+                            openAssetChooser={onOpenAssetChooser}
+                            onRemoveAsset={onRemoveAsset}
+                        />
+                    ) : (
+                        isEditing && (
+                            <UploadPlaceholder
+                                onUploadClick={openFileDialog}
+                                onAssetChooseClick={onOpenAssetChooser}
+                                onFilesDrop={onFilesDrop}
+                                loading={isLoading}
                             />
-                        ) : (
-                            isEditing && (
-                                <UploadPlaceholder
-                                    onUploadClick={openFileDialog}
-                                    onAssetChooseClick={onOpenAssetChooser}
-                                    onFilesDrop={onFilesDrop}
-                                    loading={isLoading}
+                        )
+                    )}
+                    <div className="tw-flex tw-gap-4 tw-justify-between tw-w-full tw-relative">
+                        <div className="tw-flex-1">
+                            <div data-test-id="block-title">
+                                <RichTextEditor
+                                    key={titleKey}
+                                    id={`${blockId}-title`}
+                                    plugins={titlePlugins}
+                                    isEditing={isEditing}
+                                    onTextChange={onTitleChange}
+                                    value={titleValue}
+                                    placeholder="Asset name"
+                                    showSerializedText={hasRichTextValue(titleValue)}
                                 />
-                            )
-                        )}
-                        <div className="tw-flex tw-gap-4 tw-justify-between tw-w-full tw-relative">
-                            <div className="tw-flex-1">
-                                <div data-test-id="block-title">
-                                    <RichTextEditor
-                                        key={titleKey}
-                                        id={`${blockId}-title`}
-                                        plugins={titlePlugins}
-                                        isEditing={isEditing}
-                                        onTextChange={onTitleChange}
-                                        value={titleValue}
-                                        placeholder="Asset name"
-                                        showSerializedText={hasRichTextValue(titleValue)}
-                                    />
-                                </div>
-
-                                <div data-test-id="block-description">
-                                    <RichTextEditor
-                                        id={`${blockId}-description`}
-                                        plugins={getDescriptionPlugins(appBridge)}
-                                        isEditing={isEditing}
-                                        onTextChange={onDescriptionChange}
-                                        value={descriptionValue}
-                                        placeholder="Add a description here"
-                                        showSerializedText={hasRichTextValue(descriptionValue)}
-                                    />
-                                </div>
                             </div>
-                            {audio && !isEditing && (
-                                <div className="tw-flex tw-gap-2 tw-leading-normal" data-test-id="view-mode-addons">
-                                    {isDownloadable(
-                                        blockSettings.security,
-                                        blockSettings.downloadable,
-                                        assetDownloadEnabled
-                                    ) && (
-                                        <DownloadButton
-                                            onDownload={() =>
-                                                appBridge.dispatch({ name: 'downloadAsset', payload: audio })
-                                            }
-                                        />
-                                    )}
-                                    <BlockAttachments appBridge={appBridge} />
-                                </div>
-                            )}
+
+                            <div data-test-id="block-description">
+                                <RichTextEditor
+                                    id={`${blockId}-description`}
+                                    plugins={getDescriptionPlugins(appBridge)}
+                                    isEditing={isEditing}
+                                    onTextChange={onDescriptionChange}
+                                    value={descriptionValue}
+                                    placeholder="Add a description here"
+                                    showSerializedText={hasRichTextValue(descriptionValue)}
+                                />
+                            </div>
                         </div>
+                        {audio && !isEditing && (
+                            <div className="tw-flex tw-gap-2 tw-leading-normal" data-test-id="view-mode-addons">
+                                {isDownloadable(
+                                    blockSettings.security,
+                                    blockSettings.downloadable,
+                                    assetDownloadEnabled
+                                ) && (
+                                    <DownloadButton
+                                        onDownload={() => appBridge.dispatch({ name: 'downloadAsset', payload: audio })}
+                                    />
+                                )}
+                                <BlockAttachments appBridge={appBridge} />
+                            </div>
+                        )}
                     </div>
-                </StyleProvider>
-            </div>
+                </div>
+            </StyleProvider>
         </AttachmentOperationsProvider>
     );
 };

--- a/packages/callout-block/postcss.config.js
+++ b/packages/callout-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.callout-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/callout-block/src/CalloutBlock.tsx
+++ b/packages/callout-block/src/CalloutBlock.tsx
@@ -13,6 +13,8 @@ import {
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type CSSProperties, type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import manifest from '../manifest.json';
+
 import { CalloutIcon } from './components/CalloutIcon';
 import { computeStyles } from './helpers/color';
 import { isThemeEnabled } from './helpers/theme';
@@ -157,39 +159,37 @@ export const CalloutBlock = ({ appBridge }: BlockProps): ReactElement => {
     const iconType = blockSettings.iconSwitch ? Icon.Custom : blockSettings.iconType;
 
     return (
-        <div ref={hostElement} className="callout-block">
-            <StyleProvider>
-                <div
-                    data-test-id="callout-block"
-                    style={{
-                        ...overwrittenThemeSettings,
-                        backgroundColor,
-                        ...customPaddingStyle,
-                        ...customCornerRadiusStyle,
-                    }}
-                    className={containerDivClassNames}
-                >
-                    <div data-test-id="callout-content" className={textDivClassNames}>
-                        {iconType !== Icon.None && (
-                            <CalloutIcon
-                                isActive={hasRichTextValue(blockSettings.textValue)}
-                                iconType={iconType}
-                                customIcon={customIcon}
-                                color={textColor}
-                                type={type}
-                            />
-                        )}
-                        <RichTextEditor
-                            id={String(appBridge.context('blockId').get())}
-                            isEditing={isEditing}
-                            onTextChange={handleTextChange}
-                            placeholder="Type your text here"
-                            value={blockSettings.textValue}
-                            plugins={plugins}
+        <StyleProvider ref={hostElement} appId={manifest.appId}>
+            <div
+                data-test-id="callout-block"
+                style={{
+                    ...overwrittenThemeSettings,
+                    backgroundColor,
+                    ...customPaddingStyle,
+                    ...customCornerRadiusStyle,
+                }}
+                className={containerDivClassNames}
+            >
+                <div data-test-id="callout-content" className={textDivClassNames}>
+                    {iconType !== Icon.None && (
+                        <CalloutIcon
+                            isActive={hasRichTextValue(blockSettings.textValue)}
+                            iconType={iconType}
+                            customIcon={customIcon}
+                            color={textColor}
+                            type={type}
                         />
-                    </div>
+                    )}
+                    <RichTextEditor
+                        id={String(appBridge.context('blockId').get())}
+                        isEditing={isEditing}
+                        onTextChange={handleTextChange}
+                        placeholder="Type your text here"
+                        value={blockSettings.textValue}
+                        plugins={plugins}
+                    />
                 </div>
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/code-snippet-block/postcss.config.js
+++ b/packages/code-snippet-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.code-snippet-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/code-snippet-block/src/CodeSnippetBlock.tsx
+++ b/packages/code-snippet-block/src/CodeSnippetBlock.tsx
@@ -12,6 +12,8 @@ import CodeMirror from '@uiw/react-codemirror';
 import debounce from 'lodash-es/debounce';
 import { type FC, useEffect, useMemo, useState } from 'react';
 
+import manifest from '../manifest.json';
+
 import { DEFAULT_BORDER_COLOR } from './constants';
 import { headerThemes } from './headerThemes';
 import { useCodeMirrorExtensions } from './hooks/useCodeMirrorExtensions';
@@ -88,124 +90,122 @@ export const CodeSnippetBlock: FC<BlockProps> = ({ appBridge }) => {
     };
 
     return (
-        <div className="code-snippet-block">
-            <StyleProvider>
-                <div
-                    data-test-id="code-snippet-block"
-                    className="tw-overflow-hidden"
-                    style={{
-                        fontFamily: 'Menlo, Courier, monospace',
-                        fontSize: '12px',
-                        border: hasBorder
-                            ? `${borderStyle} ${borderWidth} ${toRgbaString(borderColor || DEFAULT_BORDER_COLOR)}`
-                            : 'none',
-                        borderRadius: customCornerRadiusStyle.borderRadius,
-                    }}
-                >
-                    <div className={merge(['tw-relative tw-group/copy', !isEditing && 'CodeMirror-readonly'])}>
-                        {withHeading && (
-                            <div
-                                data-test-id="code-snippet-header"
-                                className="tw-py-2 tw-px-3 tw-bg-black-5 tw-border-b tw-border-black-10 tw-text-small tw-flex tw-justify-between tw-items-center"
-                                style={{ ...getStyle(), letterSpacing: 'normal' }}
-                            >
-                                {isEditing ? (
-                                    <div
-                                        id={labelId}
-                                        className="tw-max-w-[150px]"
-                                        style={
-                                            {
-                                                '--base-color': getStyle().backgroundColor,
-                                                '--text-color': getStyle().color,
-                                                '--line-color-xx-strong': setAlpha(0.8, getStyle().color),
-                                            } as React.CSSProperties
-                                        }
+        <StyleProvider appId={manifest.appId}>
+            <div
+                data-test-id="code-snippet-block"
+                className="tw-overflow-hidden"
+                style={{
+                    fontFamily: 'Menlo, Courier, monospace',
+                    fontSize: '12px',
+                    border: hasBorder
+                        ? `${borderStyle} ${borderWidth} ${toRgbaString(borderColor || DEFAULT_BORDER_COLOR)}`
+                        : 'none',
+                    borderRadius: customCornerRadiusStyle.borderRadius,
+                }}
+            >
+                <div className={merge(['tw-relative tw-group/copy', !isEditing && 'CodeMirror-readonly'])}>
+                    {withHeading && (
+                        <div
+                            data-test-id="code-snippet-header"
+                            className="tw-py-2 tw-px-3 tw-bg-black-5 tw-border-b tw-border-black-10 tw-text-small tw-flex tw-justify-between tw-items-center"
+                            style={{ ...getStyle(), letterSpacing: 'normal' }}
+                        >
+                            {isEditing ? (
+                                <div
+                                    id={labelId}
+                                    className="tw-max-w-[150px]"
+                                    style={
+                                        {
+                                            '--base-color': getStyle().backgroundColor,
+                                            '--text-color': getStyle().color,
+                                            '--line-color-xx-strong': setAlpha(0.8, getStyle().color),
+                                        } as React.CSSProperties
+                                    }
+                                >
+                                    <Select
+                                        value={selectedLanguage}
+                                        onSelect={(value) => handleLanguageChange(value as Language)}
                                     >
-                                        <Select
-                                            value={selectedLanguage}
-                                            onSelect={(value) => handleLanguageChange(value as Language)}
+                                        {Object.entries(languageNameMap).map(([value, label]) => (
+                                            <Select.Item value={value} key={value}>
+                                                {label}
+                                            </Select.Item>
+                                        ))}
+                                    </Select>
+                                </div>
+                            ) : (
+                                <span id={labelId}>{languageNameMap[selectedLanguage]}</span>
+                            )}
+                            <button
+                                type="button"
+                                data-test-id="header-copy-button"
+                                className="tw-items-center tw-justify-end tw-gap-1 tw-flex"
+                                style={{
+                                    ...getStyle(),
+                                    color: blockSettings.theme === 'default' ? '#000000' : getStyle().color,
+                                }}
+                                onClick={handleCopy}
+                            >
+                                {getCopyButtonText()}
+                            </button>
+                        </div>
+                    )}
+                    <CodeMirror
+                        theme={getTheme()}
+                        value={contentValue}
+                        extensions={extensions}
+                        onChange={handleChange}
+                        readOnly={!isEditing}
+                        basicSetup={{
+                            lineNumbers: withRowNumbers,
+                            searchKeymap: false,
+                            highlightActiveLineGutter: false,
+                            highlightActiveLine: false,
+                            lintKeymap: false,
+                            autocompletion: false,
+                            syntaxHighlighting: true,
+                        }}
+                        onCreateEditor={(view) =>
+                            view.dom.querySelector('.cm-content')?.setAttribute('aria-labelledby', labelId)
+                        }
+                        placeholder={isEditing ? '< please add snippet here >' : ''}
+                    />
+                    {!withHeading && (
+                        <div className="tw-absolute tw-p-1 tw-dark tw-top-0 tw-right-0 tw-hidden group-hover/copy:tw-block">
+                            {blockSettings.content && (blockSettings.content.match(/\n/g) || []).length > 1 ? (
+                                <Tooltip.Root
+                                    open={isCopyTooltipOpen}
+                                    onOpenChange={setIsCopyTooltipOpen}
+                                    enterDelay={0}
+                                >
+                                    <Tooltip.Trigger>
+                                        <button
+                                            type="button"
+                                            data-test-id="copy-button"
+                                            className="tw-p-2 tw-rounded-md"
+                                            style={getStyle()}
+                                            onClick={handleCopy}
                                         >
-                                            {Object.entries(languageNameMap).map(([value, label]) => (
-                                                <Select.Item value={value} key={value}>
-                                                    {label}
-                                                </Select.Item>
-                                            ))}
-                                        </Select>
-                                    </div>
-                                ) : (
-                                    <span id={labelId}>{languageNameMap[selectedLanguage]}</span>
-                                )}
+                                            {isCopied ? <IconCheckMark /> : <IconClipboard />}
+                                        </button>
+                                    </Tooltip.Trigger>
+                                    <Tooltip.Content>{isCopied ? 'Copied' : 'Copy to clipboard'}</Tooltip.Content>
+                                </Tooltip.Root>
+                            ) : (
                                 <button
                                     type="button"
-                                    data-test-id="header-copy-button"
-                                    className="tw-items-center tw-justify-end tw-gap-1 tw-flex"
-                                    style={{
-                                        ...getStyle(),
-                                        color: blockSettings.theme === 'default' ? '#000000' : getStyle().color,
-                                    }}
+                                    className="tw-flex tw-items-center tw-justify-end tw-gap-1 tw-pr-2 tw-rounded-md"
+                                    style={getStyle()}
                                     onClick={handleCopy}
+                                    aria-live="assertive"
                                 >
                                     {getCopyButtonText()}
                                 </button>
-                            </div>
-                        )}
-                        <CodeMirror
-                            theme={getTheme()}
-                            value={contentValue}
-                            extensions={extensions}
-                            onChange={handleChange}
-                            readOnly={!isEditing}
-                            basicSetup={{
-                                lineNumbers: withRowNumbers,
-                                searchKeymap: false,
-                                highlightActiveLineGutter: false,
-                                highlightActiveLine: false,
-                                lintKeymap: false,
-                                autocompletion: false,
-                                syntaxHighlighting: true,
-                            }}
-                            onCreateEditor={(view) =>
-                                view.dom.querySelector('.cm-content')?.setAttribute('aria-labelledby', labelId)
-                            }
-                            placeholder={isEditing ? '< please add snippet here >' : ''}
-                        />
-                        {!withHeading && (
-                            <div className="tw-absolute tw-p-1 tw-dark tw-top-0 tw-right-0 tw-hidden group-hover/copy:tw-block">
-                                {blockSettings.content && (blockSettings.content.match(/\n/g) || []).length > 1 ? (
-                                    <Tooltip.Root
-                                        open={isCopyTooltipOpen}
-                                        onOpenChange={setIsCopyTooltipOpen}
-                                        enterDelay={0}
-                                    >
-                                        <Tooltip.Trigger>
-                                            <button
-                                                type="button"
-                                                data-test-id="copy-button"
-                                                className="tw-p-2 tw-rounded-md"
-                                                style={getStyle()}
-                                                onClick={handleCopy}
-                                            >
-                                                {isCopied ? <IconCheckMark /> : <IconClipboard />}
-                                            </button>
-                                        </Tooltip.Trigger>
-                                        <Tooltip.Content>{isCopied ? 'Copied' : 'Copy to clipboard'}</Tooltip.Content>
-                                    </Tooltip.Root>
-                                ) : (
-                                    <button
-                                        type="button"
-                                        className="tw-flex tw-items-center tw-justify-end tw-gap-1 tw-pr-2 tw-rounded-md"
-                                        style={getStyle()}
-                                        onClick={handleCopy}
-                                        aria-live="assertive"
-                                    >
-                                        {getCopyButtonText()}
-                                    </button>
-                                )}
-                            </div>
-                        )}
-                    </div>
+                            )}
+                        </div>
+                    )}
                 </div>
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/compare-slider-block/postcss.config.js
+++ b/packages/compare-slider-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.compare-slider-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/compare-slider-block/src/CompareSliderBlock.tsx
+++ b/packages/compare-slider-block/src/CompareSliderBlock.tsx
@@ -15,6 +15,8 @@ import { ResponsiveImage, StyleProvider, useImageContainer } from '@frontify/gui
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ReactCompareSlider } from 'react-compare-slider';
 
+import manifest from '../manifest.json';
+
 import {
     EditorOverlay,
     Label,
@@ -372,62 +374,60 @@ export const CompareSliderBlock = ({ appBridge }: BlockProps) => {
         );
     }
     return (
-        <div className="compare-slider-block">
-            <StyleProvider>
-                <div
-                    data-test-id="compare-slider-block"
-                    ref={setContainerRef}
-                    className="tw-w-full tw-flex tw-relative"
-                    style={{ aspectRatio }}
-                >
-                    {isFirstAssetLoaded && isSecondAssetLoaded && (
-                        <>
-                            <div
-                                data-test-id="compare-slider-block-slider"
-                                className="tw-w-full tw-overflow-hidden tw-relative [&_.handle]:focus-within:tw-ring-4 [&_.handle]:focus-within:tw-ring-offset-2"
-                                style={{
-                                    ...getBorderStyle(),
-                                    borderRadius: getBorderRadius(),
-                                }}
-                            >
-                                <ReactCompareSlider
-                                    position={currentSliderPosition}
-                                    className="tw-size-full"
-                                    onPositionChange={setCurrentSliderPosition}
-                                    itemOne={renderSliderItem(SliderImageSlot.First)}
-                                    itemTwo={renderSliderItem(SliderImageSlot.Second)}
-                                    handle={
-                                        <SliderLine
-                                            alignment={alignment}
-                                            handle={handle}
-                                            sliderColor={sliderColor || DEFAULT_LINE_COLOR}
-                                            sliderStyle={sliderStyle}
-                                            sliderWidth={sliderWidth}
-                                        />
-                                    }
-                                    portrait={alignment === Alignment.Vertical}
-                                    onlyHandleDraggable
-                                />
-                            </div>
-                            {isEditing && (
-                                <EditorOverlay
-                                    alignment={alignment}
-                                    openAssetChooser={onOpenAssetChooser}
-                                    startFileDialogUpload={startFileDialogUpload}
-                                    firstAsset={firstAsset}
-                                    secondAsset={secondAsset}
-                                    borderStyle={{ ...getBorderStyle(), borderColor: 'transparent' }}
-                                    renderLabel={renderLabel}
-                                    handleAssetDelete={handleAssetDelete}
-                                    firstAlt={firstAssetAlt}
-                                    secondAlt={secondAssetAlt}
-                                    updateImageAlt={updateImageAlt}
-                                />
-                            )}
-                        </>
-                    )}
-                </div>
-            </StyleProvider>
-        </div>
+        <StyleProvider appId={manifest.appId}>
+            <div
+                data-test-id="compare-slider-block"
+                ref={setContainerRef}
+                className="tw-w-full tw-flex tw-relative"
+                style={{ aspectRatio }}
+            >
+                {isFirstAssetLoaded && isSecondAssetLoaded && (
+                    <>
+                        <div
+                            data-test-id="compare-slider-block-slider"
+                            className="tw-w-full tw-overflow-hidden tw-relative [&_.handle]:focus-within:tw-ring-4 [&_.handle]:focus-within:tw-ring-offset-2"
+                            style={{
+                                ...getBorderStyle(),
+                                borderRadius: getBorderRadius(),
+                            }}
+                        >
+                            <ReactCompareSlider
+                                position={currentSliderPosition}
+                                className="tw-size-full"
+                                onPositionChange={setCurrentSliderPosition}
+                                itemOne={renderSliderItem(SliderImageSlot.First)}
+                                itemTwo={renderSliderItem(SliderImageSlot.Second)}
+                                handle={
+                                    <SliderLine
+                                        alignment={alignment}
+                                        handle={handle}
+                                        sliderColor={sliderColor || DEFAULT_LINE_COLOR}
+                                        sliderStyle={sliderStyle}
+                                        sliderWidth={sliderWidth}
+                                    />
+                                }
+                                portrait={alignment === Alignment.Vertical}
+                                onlyHandleDraggable
+                            />
+                        </div>
+                        {isEditing && (
+                            <EditorOverlay
+                                alignment={alignment}
+                                openAssetChooser={onOpenAssetChooser}
+                                startFileDialogUpload={startFileDialogUpload}
+                                firstAsset={firstAsset}
+                                secondAsset={secondAsset}
+                                borderStyle={{ ...getBorderStyle(), borderColor: 'transparent' }}
+                                renderLabel={renderLabel}
+                                handleAssetDelete={handleAssetDelete}
+                                firstAlt={firstAssetAlt}
+                                secondAlt={secondAssetAlt}
+                                updateImageAlt={updateImageAlt}
+                            />
+                        )}
+                    </>
+                )}
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/divider-block/postcss.config.js
+++ b/packages/divider-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.divider-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/divider-block/src/DividerBlock.tsx
+++ b/packages/divider-block/src/DividerBlock.tsx
@@ -4,6 +4,8 @@ import { useBlockSettings } from '@frontify/app-bridge';
 import { type BlockProps, joinClassNames, toRgbaString } from '@frontify/guideline-blocks-settings';
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 
+import manifest from '../manifest.json';
+
 import {
     ALIGNMENT_DEFAULT_VALUE,
     COLOR_DEFAULT_RGBA_VALUE,
@@ -23,46 +25,44 @@ export const DividerBlock = ({ appBridge }: BlockProps) => {
     const [blockSettings] = useBlockSettings<Settings>(appBridge);
 
     return (
-        <div className="divider-block">
-            <StyleProvider>
+        <StyleProvider appId={manifest.appId}>
+            <div
+                data-test-id="divider-block"
+                className={joinClassNames([
+                    'tw-flex',
+                    css.dividerBlock,
+                    dividerAlignmentClasses[blockSettings.alignment ?? ALIGNMENT_DEFAULT_VALUE],
+                ])}
+            >
                 <div
-                    data-test-id="divider-block"
-                    className={joinClassNames([
-                        'tw-flex',
-                        css.dividerBlock,
-                        dividerAlignmentClasses[blockSettings.alignment ?? ALIGNMENT_DEFAULT_VALUE],
-                    ])}
+                    data-test-id="divider-wrapper"
+                    className="tw-flex tw-items-center tw-transition-all"
+                    style={{
+                        width: blockSettings.isWidthCustom ? blockSettings.widthCustom : blockSettings.widthSimple,
+                        height: blockSettings.isHeightCustom
+                            ? blockSettings.heightCustom
+                            : dividerHeightValues[blockSettings.heightSimple ?? HEIGHT_DEFAULT_VALUE],
+                    }}
                 >
-                    <div
-                        data-test-id="divider-wrapper"
-                        className="tw-flex tw-items-center tw-transition-all"
+                    <hr
+                        data-test-id="divider-line"
+                        className={joinClassNames([
+                            'tw-border-t tw-m-0 tw-w-full',
+                            dividerStyleClasses[
+                                blockSettings.isLine === DividerStyle.Solid
+                                    ? (blockSettings.style ?? STYLE_DEFAULT_VALUE)
+                                    : DividerStyle.NoLine
+                            ],
+                        ])}
                         style={{
-                            width: blockSettings.isWidthCustom ? blockSettings.widthCustom : blockSettings.widthSimple,
-                            height: blockSettings.isHeightCustom
-                                ? blockSettings.heightCustom
-                                : dividerHeightValues[blockSettings.heightSimple ?? HEIGHT_DEFAULT_VALUE],
+                            borderTopWidth: blockSettings.thickness,
+                            borderTopColor: blockSettings.color
+                                ? toRgbaString(blockSettings.color)
+                                : toRgbaString(COLOR_DEFAULT_RGBA_VALUE),
                         }}
-                    >
-                        <hr
-                            data-test-id="divider-line"
-                            className={joinClassNames([
-                                'tw-border-t tw-m-0 tw-w-full',
-                                dividerStyleClasses[
-                                    blockSettings.isLine === DividerStyle.Solid
-                                        ? (blockSettings.style ?? STYLE_DEFAULT_VALUE)
-                                        : DividerStyle.NoLine
-                                ],
-                            ])}
-                            style={{
-                                borderTopWidth: blockSettings.thickness,
-                                borderTopColor: blockSettings.color
-                                    ? toRgbaString(blockSettings.color)
-                                    : toRgbaString(COLOR_DEFAULT_RGBA_VALUE),
-                            }}
-                        />
-                    </div>
+                    />
                 </div>
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/dos-donts-block/postcss.config.js
+++ b/packages/dos-donts-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.dos-donts-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/dos-donts-block/src/DosDontsBlock.tsx
+++ b/packages/dos-donts-block/src/DosDontsBlock.tsx
@@ -26,6 +26,8 @@ import { generateRandomId, StyleProvider } from '@frontify/guideline-blocks-shar
 import throttle from 'lodash-es/throttle';
 import { type FC, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
+import manifest from '../manifest.json';
+
 import { AssetsContext, AssetsProvider } from './AssetsProvider';
 import { DoDontItem, SortableDoDontItem } from './DoDontItem';
 import { CONTAINER_SMALL_LIMIT, DONT_ICON_ASSET_KEY, DO_ICON_ASSET_KEY } from './const';
@@ -394,112 +396,110 @@ export const DosDontsBlock: FC<BlockProps> = ({ appBridge }) => {
     const activeItem = localItems.find((x) => x.id === activeId);
 
     return (
-        <div ref={containerRef} className="dos-donts-block tw-@container">
-            <StyleProvider>
-                <DndContext
-                    sensors={sensors}
-                    collisionDetection={closestCenter}
-                    onDragStart={handleDragStart}
-                    onDragEnd={handleDragEnd}
-                    modifiers={[restrictToParentElement]}
-                >
-                    <SortableContext items={localItems} strategy={rectSortingStrategy}>
-                        <div
-                            data-test-id="dos-donts-block"
-                            ref={wrapperRef}
-                            className={joinClassNames(['tw-grid', gridClassName])}
-                            style={{
-                                columnGap,
-                                rowGap,
-                            }}
-                        >
-                            {localItems.map((item) => (
-                                <SortableDoDontItem key={item.id} {...getDoDontItemProps(item)} />
-                            ))}
-                        </div>
-                    </SortableContext>
-                    {activeItem ? (
-                        <DragOverlay>
-                            <DoDontItem key={activeItem.id} isDragging {...getDoDontItemProps(activeItem)} />
-                        </DragOverlay>
-                    ) : null}
-                </DndContext>
-                {isEditing && (
-                    <div className="tw-w-full tw-flex tw-gap-3 tw-mt-9 tw-flex-wrap">
-                        {mode === BlockMode.TEXT_AND_IMAGE && (
-                            <div className="tw-flex tw-flex-wrap tw-w-full tw-gap-3 tw-justify-center">
-                                <BlockInjectButton
-                                    label="Add images"
-                                    secondaryLabel="Or drop them here"
-                                    icon={<IconPlus size={20} />}
-                                    onUploadClick={openFileDialog}
-                                    onAssetChooseClick={onOpenAssetChooser}
-                                    onDrop={setSelectedFiles}
-                                    isLoading={isUploadLoading}
-                                />
-                            </div>
-                        )}
-                        <div
-                            data-test-id="dos-donts-block-add-buttons"
-                            className="tw-flex tw-w-full tw-flex-col @sm:tw-flex-row"
-                        >
-                            <BlockInjectButton
-                                verticalLayout={isContainerSmall}
-                                label="Add do"
-                                withMenu={false}
-                                icon={<IconCheckMarkCircle size={20} />}
-                                onClick={() => addItem(DoDontType.Do)}
-                            />
-                            <BlockInjectButton
-                                verticalLayout={isContainerSmall}
-                                label="Add don't"
-                                withMenu={false}
-                                icon={<IconCrossCircle size={20} />}
-                                onClick={() => addItem(DoDontType.Dont)}
-                            />
-                        </div>
+        <StyleProvider ref={containerRef} appId={manifest.appId} className="tw-@container">
+            <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragStart={handleDragStart}
+                onDragEnd={handleDragEnd}
+                modifiers={[restrictToParentElement]}
+            >
+                <SortableContext items={localItems} strategy={rectSortingStrategy}>
+                    <div
+                        data-test-id="dos-donts-block"
+                        ref={wrapperRef}
+                        className={joinClassNames(['tw-grid', gridClassName])}
+                        style={{
+                            columnGap,
+                            rowGap,
+                        }}
+                    >
+                        {localItems.map((item) => (
+                            <SortableDoDontItem key={item.id} {...getDoDontItemProps(item)} />
+                        ))}
                     </div>
-                )}
-                <Dialog.Root
-                    open={(!!selectedAssets?.[0] || !!selectedFiles) && !selectedType}
-                    onOpenChange={(isOpen) => {
-                        if (!isOpen) {
-                            closeDialog();
-                        }
-                    }}
-                >
-                    <Dialog.Content padding="comfortable" showUnderlay>
-                        <Dialog.SideContent>
-                            <div className="tw-h-full sm:tw-max-w-60 tw-overflow-hidden">
-                                <FrontifyPattern
-                                    scale={PatternScale.XXL}
-                                    pattern={PatternDesign.Typography}
-                                    foregroundColor={PatternTheme.Green}
-                                />
-                            </div>
-                        </Dialog.SideContent>
-                        <Dialog.Header>
-                            <span className="tw-font-bold">What should be the type of those images?</span>
-                        </Dialog.Header>
-                        <Dialog.Body>
-                            <div>You can always change the type later on each item.</div>
-                        </Dialog.Body>
-                        <Dialog.Footer>
-                            <div className="tw-flex tw-gap-3 tw-flex-wrap">
-                                <Button onPress={closeDialog} emphasis="weak">
-                                    Cancel
-                                </Button>
-                                <Button onPress={() => setSelectedType(DoDontType.Do)} emphasis="default">
-                                    <IconCheckMarkCircle size={20} /> Add as Do
-                                </Button>
-                                <Button onPress={() => setSelectedType(DoDontType.Dont)} emphasis="default">
-                                    <IconCrossCircle size={20} /> Add as Don&apos;t
-                                </Button>
-                            </div>
-                        </Dialog.Footer>
-                    </Dialog.Content>
-                </Dialog.Root>
-            </StyleProvider>
-        </div>
+                </SortableContext>
+                {activeItem ? (
+                    <DragOverlay>
+                        <DoDontItem key={activeItem.id} isDragging {...getDoDontItemProps(activeItem)} />
+                    </DragOverlay>
+                ) : null}
+            </DndContext>
+            {isEditing && (
+                <div className="tw-w-full tw-flex tw-gap-3 tw-mt-9 tw-flex-wrap">
+                    {mode === BlockMode.TEXT_AND_IMAGE && (
+                        <div className="tw-flex tw-flex-wrap tw-w-full tw-gap-3 tw-justify-center">
+                            <BlockInjectButton
+                                label="Add images"
+                                secondaryLabel="Or drop them here"
+                                icon={<IconPlus size={20} />}
+                                onUploadClick={openFileDialog}
+                                onAssetChooseClick={onOpenAssetChooser}
+                                onDrop={setSelectedFiles}
+                                isLoading={isUploadLoading}
+                            />
+                        </div>
+                    )}
+                    <div
+                        data-test-id="dos-donts-block-add-buttons"
+                        className="tw-flex tw-w-full tw-flex-col @sm:tw-flex-row"
+                    >
+                        <BlockInjectButton
+                            verticalLayout={isContainerSmall}
+                            label="Add do"
+                            withMenu={false}
+                            icon={<IconCheckMarkCircle size={20} />}
+                            onClick={() => addItem(DoDontType.Do)}
+                        />
+                        <BlockInjectButton
+                            verticalLayout={isContainerSmall}
+                            label="Add don't"
+                            withMenu={false}
+                            icon={<IconCrossCircle size={20} />}
+                            onClick={() => addItem(DoDontType.Dont)}
+                        />
+                    </div>
+                </div>
+            )}
+            <Dialog.Root
+                open={(!!selectedAssets?.[0] || !!selectedFiles) && !selectedType}
+                onOpenChange={(isOpen) => {
+                    if (!isOpen) {
+                        closeDialog();
+                    }
+                }}
+            >
+                <Dialog.Content padding="comfortable" showUnderlay>
+                    <Dialog.SideContent>
+                        <div className="tw-h-full sm:tw-max-w-60 tw-overflow-hidden">
+                            <FrontifyPattern
+                                scale={PatternScale.XXL}
+                                pattern={PatternDesign.Typography}
+                                foregroundColor={PatternTheme.Green}
+                            />
+                        </div>
+                    </Dialog.SideContent>
+                    <Dialog.Header>
+                        <span className="tw-font-bold">What should be the type of those images?</span>
+                    </Dialog.Header>
+                    <Dialog.Body>
+                        <div>You can always change the type later on each item.</div>
+                    </Dialog.Body>
+                    <Dialog.Footer>
+                        <div className="tw-flex tw-gap-3 tw-flex-wrap">
+                            <Button onPress={closeDialog} emphasis="weak">
+                                Cancel
+                            </Button>
+                            <Button onPress={() => setSelectedType(DoDontType.Do)} emphasis="default">
+                                <IconCheckMarkCircle size={20} /> Add as Do
+                            </Button>
+                            <Button onPress={() => setSelectedType(DoDontType.Dont)} emphasis="default">
+                                <IconCrossCircle size={20} /> Add as Don&apos;t
+                            </Button>
+                        </div>
+                    </Dialog.Footer>
+                </Dialog.Content>
+            </Dialog.Root>
+        </StyleProvider>
     );
 };

--- a/packages/figma-block/postcss.config.js
+++ b/packages/figma-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.figma-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/figma-block/src/FigmaBlock.tsx
+++ b/packages/figma-block/src/FigmaBlock.tsx
@@ -13,6 +13,8 @@ import { type BlockProps } from '@frontify/guideline-blocks-settings';
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type ReactElement, useEffect, useMemo, useRef, useState } from 'react';
 
+import manifest from '../manifest.json';
+
 import { FigmaEmptyBlock } from './FigmaEmptyBlock';
 import ReferenceErrorMessage from './ReferenceErrorMessage';
 import { FigmaImagePreview } from './components/FigmaImagePreview';
@@ -98,63 +100,61 @@ export const FigmaBlock = ({ appBridge }: BlockProps): ReactElement => {
     };
 
     return (
-        <div ref={ref} data-test-id="figma-block" className="figma-block">
-            <StyleProvider>
-                {referenceUrl ? (
-                    <ReferenceErrorMessage originalUrl={referenceUrl} />
-                ) : (
-                    <>
-                        {isInEditMode && !asset && <FigmaEmptyBlock onOpenAssetChooser={onOpenAssetChooser} />}
+        <StyleProvider ref={ref} data-test-id="figma-block" appId={manifest.appId}>
+            {referenceUrl ? (
+                <ReferenceErrorMessage originalUrl={referenceUrl} />
+            ) : (
+                <>
+                    {isInEditMode && !asset && <FigmaEmptyBlock onOpenAssetChooser={onOpenAssetChooser} />}
 
-                        {asset &&
-                            (isLivePreview ? (
-                                <FigmaLivePreview
-                                    assetExternalUrl={safeExternalUrl}
-                                    allowFullScreen={allowFullScreen}
-                                    isMobile={isMobile}
-                                    onOpenFullScreen={() => setShowFigmaLiveModal(true)}
-                                    hasBorder={hasBorder}
-                                    borderStyle={borderStyle}
-                                    borderWidth={borderWidth}
-                                    borderColor={borderColor}
-                                    height={isCustomHeight ? heightValue : heights[heightChoice]}
-                                />
-                            ) : (
-                                <FigmaImagePreview
-                                    title={asset.title}
-                                    url={asset.previewUrl}
-                                    assetExternalUrl={safeExternalUrl ?? ''}
-                                    assetId={asset.id}
-                                    assetStatus={asset.status}
-                                    appBridge={appBridge}
-                                    hasLimitedOptions={hasLimitedOptions}
-                                    height={isCustomHeight ? heightValue : heights[heightChoice]}
-                                    hasBorder={hasBorder}
-                                    borderStyle={borderStyle}
-                                    borderColor={borderColor}
-                                    borderWidth={borderWidth}
-                                    isMobile={isMobile}
-                                    hasBackground={hasBackground}
-                                    backgroundColor={backgroundColor}
-                                    hasRadius={hasRadius}
-                                    radiusValue={radiusValue}
-                                    radiusChoice={radiusChoice}
-                                    allowFullScreen={allowFullScreen}
-                                    allowZooming={allowZooming}
-                                    showFigmaLink={showFigmaLink}
-                                />
-                            ))}
-
-                        {showFigmaLiveModal && asset && (
-                            <FigmaLiveModal
+                    {asset &&
+                        (isLivePreview ? (
+                            <FigmaLivePreview
                                 assetExternalUrl={safeExternalUrl}
-                                title={asset.title}
-                                onClose={() => setShowFigmaLiveModal(false)}
+                                allowFullScreen={allowFullScreen}
+                                isMobile={isMobile}
+                                onOpenFullScreen={() => setShowFigmaLiveModal(true)}
+                                hasBorder={hasBorder}
+                                borderStyle={borderStyle}
+                                borderWidth={borderWidth}
+                                borderColor={borderColor}
+                                height={isCustomHeight ? heightValue : heights[heightChoice]}
                             />
-                        )}
-                    </>
-                )}
-            </StyleProvider>
-        </div>
+                        ) : (
+                            <FigmaImagePreview
+                                title={asset.title}
+                                url={asset.previewUrl}
+                                assetExternalUrl={safeExternalUrl ?? ''}
+                                assetId={asset.id}
+                                assetStatus={asset.status}
+                                appBridge={appBridge}
+                                hasLimitedOptions={hasLimitedOptions}
+                                height={isCustomHeight ? heightValue : heights[heightChoice]}
+                                hasBorder={hasBorder}
+                                borderStyle={borderStyle}
+                                borderColor={borderColor}
+                                borderWidth={borderWidth}
+                                isMobile={isMobile}
+                                hasBackground={hasBackground}
+                                backgroundColor={backgroundColor}
+                                hasRadius={hasRadius}
+                                radiusValue={radiusValue}
+                                radiusChoice={radiusChoice}
+                                allowFullScreen={allowFullScreen}
+                                allowZooming={allowZooming}
+                                showFigmaLink={showFigmaLink}
+                            />
+                        ))}
+
+                    {showFigmaLiveModal && asset && (
+                        <FigmaLiveModal
+                            assetExternalUrl={safeExternalUrl}
+                            title={asset.title}
+                            onClose={() => setShowFigmaLiveModal(false)}
+                        />
+                    )}
+                </>
+            )}
+        </StyleProvider>
     );
 };

--- a/packages/glyphs-block/postcss.config.js
+++ b/packages/glyphs-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.glyphs-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/glyphs-block/src/GlyphsBlock.tsx
+++ b/packages/glyphs-block/src/GlyphsBlock.tsx
@@ -5,6 +5,8 @@ import { toRgbaString } from '@frontify/guideline-blocks-settings';
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type ReactElement } from 'react';
 
+import manifest from '../manifest.json';
+
 import { getRadiusValue } from './helpers';
 import { BLACK_COLOR, DEFAULT_CHARS, WHITE_COLOR } from './settings';
 import { type BlockProps, type Settings } from './types';
@@ -69,25 +71,23 @@ export const GlyphsBlock = ({ appBridge }: BlockProps): ReactElement => {
     });
 
     return (
-        <div className="glyps-block">
-            <StyleProvider>
-                <ul
-                    data-test-id="glyphs-block"
-                    className="tw-grid tw-grid-cols-6"
-                    style={{
-                        fontWeight: blockSettings.fontWeight,
-                        fontSize: blockSettings.fontSize,
-                        fontFamily: fontFamily || 'inherit',
-                        color: toRgbaString(fontColor || BLACK_COLOR),
-                        ...(hasBorder && {
-                            gap: borderWidth,
-                            padding: borderWidth,
-                        }),
-                    }}
-                >
-                    {items}
-                </ul>
-            </StyleProvider>
-        </div>
+        <StyleProvider appId={manifest.appId}>
+            <ul
+                data-test-id="glyphs-block"
+                className="tw-grid tw-grid-cols-6"
+                style={{
+                    fontWeight: blockSettings.fontWeight,
+                    fontSize: blockSettings.fontSize,
+                    fontFamily: fontFamily || 'inherit',
+                    color: toRgbaString(fontColor || BLACK_COLOR),
+                    ...(hasBorder && {
+                        gap: borderWidth,
+                        padding: borderWidth,
+                    }),
+                }}
+            >
+                {items}
+            </ul>
+        </StyleProvider>
     );
 };

--- a/packages/gradient-block/postcss.config.js
+++ b/packages/gradient-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.gradient-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/gradient-block/src/GradientBlock.tsx
+++ b/packages/gradient-block/src/GradientBlock.tsx
@@ -7,6 +7,8 @@ import { type BlockProps, mapAppBridgeColorPalettesToFonduePalettes } from '@fro
 import { CssValueDisplay, StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type MouseEvent, type ReactElement, useEffect, useRef, useState } from 'react';
 
+import manifest from '../manifest.json';
+
 import { AddColorButton, ColorFlyout, ColorTooltip, SquareBadgesRow } from './components';
 import { DEFAULT_GRADIENT_COLORS, DEFAULT_HEIGHT_VALUE, DEFAULT_ORIENTATION_VALUE } from './constants';
 import { parseGradientColorsToCss, toHex6or8String } from './helpers';
@@ -78,73 +80,71 @@ export const GradientBlock = ({ appBridge }: BlockProps): ReactElement => {
     const cssValue = parseGradientColorsToCss(gradientColors, gradientOrientation);
 
     return (
-        <div data-test-id="gradient-block" className="gradient-block" ref={gradientBlockRef}>
-            <StyleProvider>
-                <div className="tw-border tw-border-line-strong tw-rounded-medium tw-p-0.5">
-                    <div
-                        data-test-id="gradient-block-display"
-                        className="tw-w-full tw-h-4 tw-rounded-medium"
-                        style={{
-                            height: gradientBlockHeight,
-                            background: cssValue,
-                        }}
-                    />
-                </div>
-                {isEditing ? (
-                    <div>
-                        <div className="tw-relative">
-                            <div
-                                data-test-id="gradient-block-divider"
-                                onMouseMove={handleMouseMove}
-                                onMouseLeave={() => setShowAddButton(false)}
-                            >
-                                <Divider />
-                                {}
-                                {showAddButton && gradientBlockRef.current && (
-                                    <AddColorButton
-                                        blockWidth={gradientBlockRef.current.clientWidth}
-                                        positionLeft={addButtonPositionLeft}
-                                        setShowColorModal={setShowColorModal}
-                                        setCurrentlyEditingPosition={setCurrentlyEditingPosition}
-                                    />
-                                )}
-                            </div>
+        <StyleProvider data-test-id="gradient-block" ref={gradientBlockRef} appId={manifest.appId}>
+            <div className="tw-border tw-border-line-strong tw-rounded-medium tw-p-0.5">
+                <div
+                    data-test-id="gradient-block-display"
+                    className="tw-w-full tw-h-4 tw-rounded-medium"
+                    style={{
+                        height: gradientBlockHeight,
+                        background: cssValue,
+                    }}
+                />
+            </div>
+            {isEditing ? (
+                <div>
+                    <div className="tw-relative">
+                        <div
+                            data-test-id="gradient-block-divider"
+                            onMouseMove={handleMouseMove}
+                            onMouseLeave={() => setShowAddButton(false)}
+                        >
+                            <Divider />
+                            {}
+                            {showAddButton && gradientBlockRef.current && (
+                                <AddColorButton
+                                    blockWidth={gradientBlockRef.current.clientWidth}
+                                    positionLeft={addButtonPositionLeft}
+                                    setShowColorModal={setShowColorModal}
+                                    setCurrentlyEditingPosition={setCurrentlyEditingPosition}
+                                />
+                            )}
                         </div>
-                        {showColorModal && gradientColors !== undefined && (
-                            <ColorFlyout
-                                colorPalettes={colorPickerPalettes}
-                                currentlyEditingPosition={currentlyEditingPosition}
-                                gradientColors={gradientColors}
-                                showColorModal={showColorModal}
-                                setColors={setGradientColors}
-                                setShowColorModal={setShowColorModal}
-                            />
-                        )}
-
-                        {gradientColors?.map((gradientColor) => (
-                            <ColorTooltip
-                                key={toHex6or8String(gradientColor.color) + gradientColor.position}
-                                gradientColor={gradientColor}
-                                gradientColors={gradientColors}
-                                showColorModal={showColorModal}
-                                setColors={setGradientColors}
-                                setShowColorModal={setShowColorModal}
-                                setCurrentlyEditingPosition={setCurrentlyEditingPosition}
-                            />
-                        ))}
                     </div>
-                ) : (
-                    gradientBlockRef.current &&
-                    gradientColors && (
-                        <SquareBadgesRow
-                            blockWidth={gradientBlockRef.current.clientWidth}
+                    {showColorModal && gradientColors !== undefined && (
+                        <ColorFlyout
+                            colorPalettes={colorPickerPalettes}
+                            currentlyEditingPosition={currentlyEditingPosition}
                             gradientColors={gradientColors}
-                            gradientOrientation={gradientOrientation}
+                            showColorModal={showColorModal}
+                            setColors={setGradientColors}
+                            setShowColorModal={setShowColorModal}
                         />
-                    )
-                )}
-                {displayCss && <CssValueDisplay cssValue={cssValue} placeholder="<add colors to generate CSS code>" />}
-            </StyleProvider>
-        </div>
+                    )}
+
+                    {gradientColors?.map((gradientColor) => (
+                        <ColorTooltip
+                            key={toHex6or8String(gradientColor.color) + gradientColor.position}
+                            gradientColor={gradientColor}
+                            gradientColors={gradientColors}
+                            showColorModal={showColorModal}
+                            setColors={setGradientColors}
+                            setShowColorModal={setShowColorModal}
+                            setCurrentlyEditingPosition={setCurrentlyEditingPosition}
+                        />
+                    ))}
+                </div>
+            ) : (
+                gradientBlockRef.current &&
+                gradientColors && (
+                    <SquareBadgesRow
+                        blockWidth={gradientBlockRef.current.clientWidth}
+                        gradientColors={gradientColors}
+                        gradientOrientation={gradientOrientation}
+                    />
+                )
+            )}
+            {displayCss && <CssValueDisplay cssValue={cssValue} placeholder="<add colors to generate CSS code>" />}
+        </StyleProvider>
     );
 };

--- a/packages/image-block/postcss.config.js
+++ b/packages/image-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.image-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -28,6 +28,8 @@ import {
 import { StyleProvider, generateRandomId, getEditAltTextToolbarButton } from '@frontify/guideline-blocks-shared';
 import { useEffect, useState } from 'react';
 
+import manifest from '../manifest.json';
+
 import { DownloadAndAttachments } from './components/DownloadAndAttachments';
 import { Image } from './components/Image';
 import { ImageCaption } from './components/ImageCaption';
@@ -165,124 +167,122 @@ export const ImageBlock = ({ appBridge }: BlockProps) => {
             assetId={ATTACHMENTS_ASSET_ID}
             appBridge={appBridge}
         >
-            <div className="image-block">
-                <StyleProvider>
-                    <div className="tw-@container">
+            <StyleProvider appId={manifest.appId}>
+                <div className="tw-@container">
+                    <div
+                        data-test-id="image-block"
+                        className={`tw-flex tw-h-auto ${mapCaptionPositionClasses[positioning]}`}
+                    >
                         <div
-                            data-test-id="image-block"
-                            className={`tw-flex tw-h-auto ${mapCaptionPositionClasses[positioning]}`}
+                            className={merge([
+                                'tw-relative',
+                                attachmentCount > 0 && 'tw-min-h-11',
+                                [CaptionPosition.Above, CaptionPosition.Below].includes(positioning)
+                                    ? 'tw-w-full'
+                                    : imageRatioValues[ratio],
+                            ])}
                         >
-                            <div
-                                className={merge([
-                                    'tw-relative',
-                                    attachmentCount > 0 && 'tw-min-h-11',
-                                    [CaptionPosition.Above, CaptionPosition.Below].includes(positioning)
-                                        ? 'tw-w-full'
-                                        : imageRatioValues[ratio],
-                                ])}
-                            >
-                                <DownloadAndAttachments
-                                    appBridge={appBridge}
-                                    blockSettings={blockSettings}
-                                    image={image}
-                                    ariaLabel={ariaLabel}
-                                    isAssetDownloadable={isAssetDownloadable}
-                                    isEditing={isEditing}
-                                />
-                                {image ? (
-                                    <BlockItemWrapper
-                                        shouldHideWrapper={!isEditing}
-                                        showAttachments
-                                        toolbarItems={[
-                                            image
-                                                ? getEditAltTextToolbarButton({
-                                                      localAltText,
-                                                      setLocalAltText,
-                                                      blockSettings,
-                                                      setBlockSettings,
-                                                  })
-                                                : undefined,
-                                            {
-                                                type: 'button',
-                                                icon: <IconTrashBin size={16} />,
-                                                onClick: onRemoveAsset,
-                                                tooltip: 'Delete',
-                                            },
-                                            {
-                                                type: 'menu',
-                                                items: [
-                                                    [
-                                                        {
-                                                            title: 'Replace with upload',
-                                                            icon: <IconArrowCircleUp size={20} />,
-                                                            onClick: openFileDialog,
-                                                        },
-                                                        {
-                                                            title: 'Replace with asset',
-                                                            icon: <IconImageStack size={20} />,
-                                                            onClick: onOpenAssetChooser,
-                                                        },
-                                                    ],
-                                                    [
-                                                        {
-                                                            title: 'Delete',
-                                                            icon: <IconTrashBin size={20} />,
-                                                            style: 'danger',
-                                                            onClick: onRemoveAsset,
-                                                        },
-                                                    ],
-                                                ],
-                                            },
-                                        ]}
-                                    >
-                                        {isLoading ? (
-                                            <div className="tw-flex tw-items-center tw-justify-center tw-h-64">
-                                                <LoadingCircle />
-                                            </div>
-                                        ) : (
-                                            <Image
-                                                appBridge={appBridge}
-                                                blockSettings={blockSettings}
-                                                isEditing={isEditing}
-                                                image={image}
-                                                isDownloadable={isAssetDownloadable}
-                                                isAssetViewerEnabled={isAssetViewerEnabled}
-                                            />
-                                        )}
-                                    </BlockItemWrapper>
-                                ) : (
-                                    isEditing && (
-                                        <BlockItemWrapper
-                                            shouldHideWrapper={attachmentCount === 0}
-                                            showAttachments
-                                            toolbarItems={[]}
-                                        >
-                                            <UploadPlaceholder
-                                                loading={isLoading}
-                                                onUploadClick={openFileDialog}
-                                                onFilesDrop={onFilesDrop}
-                                                onAssetChooseClick={onOpenAssetChooser}
-                                            />
-                                        </BlockItemWrapper>
-                                    )
-                                )}
-                            </div>
-
-                            <ImageCaption
-                                titleKey={titleKey}
-                                blockId={blockId}
-                                isEditing={isEditing}
-                                description={description}
-                                name={name}
-                                positioning={positioning}
+                            <DownloadAndAttachments
                                 appBridge={appBridge}
-                                ratio={ratio}
-                                setBlockSettings={setBlockSettings}
+                                blockSettings={blockSettings}
+                                image={image}
+                                ariaLabel={ariaLabel}
+                                isAssetDownloadable={isAssetDownloadable}
+                                isEditing={isEditing}
                             />
+                            {image ? (
+                                <BlockItemWrapper
+                                    shouldHideWrapper={!isEditing}
+                                    showAttachments
+                                    toolbarItems={[
+                                        image
+                                            ? getEditAltTextToolbarButton({
+                                                  localAltText,
+                                                  setLocalAltText,
+                                                  blockSettings,
+                                                  setBlockSettings,
+                                              })
+                                            : undefined,
+                                        {
+                                            type: 'button',
+                                            icon: <IconTrashBin size={16} />,
+                                            onClick: onRemoveAsset,
+                                            tooltip: 'Delete',
+                                        },
+                                        {
+                                            type: 'menu',
+                                            items: [
+                                                [
+                                                    {
+                                                        title: 'Replace with upload',
+                                                        icon: <IconArrowCircleUp size={20} />,
+                                                        onClick: openFileDialog,
+                                                    },
+                                                    {
+                                                        title: 'Replace with asset',
+                                                        icon: <IconImageStack size={20} />,
+                                                        onClick: onOpenAssetChooser,
+                                                    },
+                                                ],
+                                                [
+                                                    {
+                                                        title: 'Delete',
+                                                        icon: <IconTrashBin size={20} />,
+                                                        style: 'danger',
+                                                        onClick: onRemoveAsset,
+                                                    },
+                                                ],
+                                            ],
+                                        },
+                                    ]}
+                                >
+                                    {isLoading ? (
+                                        <div className="tw-flex tw-items-center tw-justify-center tw-h-64">
+                                            <LoadingCircle />
+                                        </div>
+                                    ) : (
+                                        <Image
+                                            appBridge={appBridge}
+                                            blockSettings={blockSettings}
+                                            isEditing={isEditing}
+                                            image={image}
+                                            isDownloadable={isAssetDownloadable}
+                                            isAssetViewerEnabled={isAssetViewerEnabled}
+                                        />
+                                    )}
+                                </BlockItemWrapper>
+                            ) : (
+                                isEditing && (
+                                    <BlockItemWrapper
+                                        shouldHideWrapper={attachmentCount === 0}
+                                        showAttachments
+                                        toolbarItems={[]}
+                                    >
+                                        <UploadPlaceholder
+                                            loading={isLoading}
+                                            onUploadClick={openFileDialog}
+                                            onFilesDrop={onFilesDrop}
+                                            onAssetChooseClick={onOpenAssetChooser}
+                                        />
+                                    </BlockItemWrapper>
+                                )
+                            )}
                         </div>
+
+                        <ImageCaption
+                            titleKey={titleKey}
+                            blockId={blockId}
+                            isEditing={isEditing}
+                            description={description}
+                            name={name}
+                            positioning={positioning}
+                            appBridge={appBridge}
+                            ratio={ratio}
+                            setBlockSettings={setBlockSettings}
+                        />
                     </div>
-                </StyleProvider>
-            </div>
+                </div>
+            </StyleProvider>
         </AttachmentOperationsProvider>
     );
 };

--- a/packages/quote-block/postcss.config.js
+++ b/packages/quote-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.quote-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/quote-block/src/QuoteBlock.tsx
+++ b/packages/quote-block/src/QuoteBlock.tsx
@@ -24,6 +24,8 @@ import {
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type FC, useEffect } from 'react';
 
+import manifest from '../manifest.json';
+
 import { QuoteBlockIcon } from './QuoteBlockIcon';
 import { CUSTOM_QUOTE_STYLE_LEFT_ID, CUSTOM_QUOTE_STYLE_RIGHT_ID, DEFAULT_COLOR_VALUE } from './settings';
 import {
@@ -116,79 +118,77 @@ export const QuoteBlock: FC<BlockProps> = ({ appBridge }) => {
     };
 
     return (
-        <div className="quote-block">
-            <StyleProvider>
-                <div data-test-id="quote-block" className={isEditing ? '' : 'tw-text-primary'}>
-                    <div className={getWrapperClasses()}>
-                        {isQuotationMarkType && (
-                            <QuoteBlockIcon
-                                color={iconColor}
-                                isCustomSize={blockSettings.isCustomSize}
-                                sizeValue={sizeValue}
-                                sizeChoice={blockSettings.sizeChoice}
-                                customIcon={customLeftIcon}
-                                quoteStyle={
-                                    blockSettings.isCustomQuoteStyleLeft
-                                        ? QuoteStyle.Custom
-                                        : (blockSettings.quoteStyleLeft ?? QuoteStyle.DoubleUp)
-                                }
-                            />
-                        )}
-
-                        <figure
-                            data-test-id="quote-block-author"
-                            className={
-                                isFullWidth && isQuotationMarkType
-                                    ? 'tw-flex-1 tw-w-full tw-overflow-hidden'
-                                    : 'tw-min-w-[1rem]'
+        <StyleProvider appId={manifest.appId}>
+            <div data-test-id="quote-block" className={isEditing ? '' : 'tw-text-primary'}>
+                <div className={getWrapperClasses()}>
+                    {isQuotationMarkType && (
+                        <QuoteBlockIcon
+                            color={iconColor}
+                            isCustomSize={blockSettings.isCustomSize}
+                            sizeValue={sizeValue}
+                            sizeChoice={blockSettings.sizeChoice}
+                            customIcon={customLeftIcon}
+                            quoteStyle={
+                                blockSettings.isCustomQuoteStyleLeft
+                                    ? QuoteStyle.Custom
+                                    : (blockSettings.quoteStyleLeft ?? QuoteStyle.DoubleUp)
                             }
+                        />
+                    )}
+
+                    <figure
+                        data-test-id="quote-block-author"
+                        className={
+                            isFullWidth && isQuotationMarkType
+                                ? 'tw-flex-1 tw-w-full tw-overflow-hidden'
+                                : 'tw-min-w-[1rem]'
+                        }
+                    >
+                        <blockquote
+                            style={isQuotationMarkType ? {} : borderStyles}
+                            className={merge([
+                                isQuotationMarkType ? '' : accentLineClassName,
+                                textAlignmentClassNames[textAlignment],
+                                '[&>div]:!tw-@container-normal',
+                            ])}
                         >
-                            <blockquote
-                                style={isQuotationMarkType ? {} : borderStyles}
-                                className={merge([
-                                    isQuotationMarkType ? '' : accentLineClassName,
-                                    textAlignmentClassNames[textAlignment],
-                                    '[&>div]:!tw-@container-normal',
-                                ])}
-                            >
-                                <RichTextEditor
-                                    id={String(appBridge.context('blockId').get())}
-                                    placeholder={isEditing ? 'Add your quote text here' : undefined}
-                                    value={blockSettings.content ?? convertToRteValue(TextStyles.quote)}
-                                    onTextChange={onChangeContent}
-                                    plugins={customPlugins}
-                                    isEditing={isEditing}
-                                />
-                            </blockquote>
-                            {showAuthor && (
-                                <figcaption
-                                    className="tw-text-right tw-break-all"
-                                    style={{
-                                        color: BlockStyles[TextStyles.p].color,
-                                    }}
-                                >
-                                    {`- ${blockSettings.authorName}`}
-                                </figcaption>
-                            )}
-                        </figure>
-                        {isQuotationMarkType && (
-                            <QuoteBlockIcon
-                                color={iconColor}
-                                isCustomSize={blockSettings.isCustomSize}
-                                sizeValue={sizeValue}
-                                sizeChoice={blockSettings.sizeChoice}
-                                customIcon={customRightIcon}
-                                quoteStyle={
-                                    blockSettings.isCustomQuoteStyleRight
-                                        ? QuoteStyle.Custom
-                                        : (blockSettings.quoteStyleRight ?? QuoteStyle.None)
-                                }
-                                position="bottom"
+                            <RichTextEditor
+                                id={String(appBridge.context('blockId').get())}
+                                placeholder={isEditing ? 'Add your quote text here' : undefined}
+                                value={blockSettings.content ?? convertToRteValue(TextStyles.quote)}
+                                onTextChange={onChangeContent}
+                                plugins={customPlugins}
+                                isEditing={isEditing}
                             />
+                        </blockquote>
+                        {showAuthor && (
+                            <figcaption
+                                className="tw-text-right tw-break-all"
+                                style={{
+                                    color: BlockStyles[TextStyles.p].color,
+                                }}
+                            >
+                                {`- ${blockSettings.authorName}`}
+                            </figcaption>
                         )}
-                    </div>
+                    </figure>
+                    {isQuotationMarkType && (
+                        <QuoteBlockIcon
+                            color={iconColor}
+                            isCustomSize={blockSettings.isCustomSize}
+                            sizeValue={sizeValue}
+                            sizeChoice={blockSettings.sizeChoice}
+                            customIcon={customRightIcon}
+                            quoteStyle={
+                                blockSettings.isCustomQuoteStyleRight
+                                    ? QuoteStyle.Custom
+                                    : (blockSettings.quoteStyleRight ?? QuoteStyle.None)
+                            }
+                            position="bottom"
+                        />
+                    )}
                 </div>
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/shared/src/components/StyleProvider/StyleProvider.tsx
+++ b/packages/shared/src/components/StyleProvider/StyleProvider.tsx
@@ -3,10 +3,25 @@
 import { ThemeProvider } from '@frontify/fondue/components';
 // eslint-disable-next-line no-restricted-syntax
 import * as React from 'react';
-import { type ReactNode } from 'react';
+import { type ComponentPropsWithoutRef, forwardRef, type ReactNode } from 'react';
 
 import './styles.css';
 
-export const StyleProvider = ({ children }: { children: ReactNode }) => {
-    return <ThemeProvider theme="light">{children}</ThemeProvider>;
+type StyleProviderProps = ComponentPropsWithoutRef<'div'> & {
+    appId: string;
+    children: ReactNode;
 };
+
+export const StyleProvider = forwardRef<HTMLDivElement, StyleProviderProps>(
+    ({ appId, className, children, ...rest }, ref) => (
+        <div ref={ref} className={[appId, className].filter(Boolean).join(' ')} {...rest}>
+            {/* Passing `appId` as ThemeProvider's className propagates the scope class to portaled
+                content (Dropdown, Tooltip, Dialog), so the block's scoped styles reach overlays too. */}
+            <ThemeProvider theme="light" className={appId}>
+                {children}
+            </ThemeProvider>
+        </div>
+    )
+);
+
+StyleProvider.displayName = 'StyleProvider';

--- a/packages/sketchfab-block/postcss.config.js
+++ b/packages/sketchfab-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.sketchfab-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/sketchfab-block/src/SketchfabBlock.tsx
+++ b/packages/sketchfab-block/src/SketchfabBlock.tsx
@@ -8,6 +8,8 @@ import { type BlockProps, joinClassNames, toHex8String } from '@frontify/guideli
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type FC, useEffect, useState } from 'react';
 
+import manifest from '../manifest.json';
+
 import { SKETCHFAB_RULE_ERROR, generateIframeUrl, generateSketchfabEmbedUrl, getIframeBorderStyles } from './helpers';
 import { URL_INPUT_PLACEHOLDER } from './settings';
 import { type Settings, SketchfabAccount, SketchfabNavigation, SketchfabTheme, heights, radiusClassMap } from './types';
@@ -146,69 +148,67 @@ export const SketchfabBlock: FC<BlockProps> = ({ appBridge }) => {
     }, [blockSettings]);
 
     return (
-        <div className="sketchfab-block">
-            <StyleProvider>
-                <div data-test-id="sketchfab-block" className="tw-relative">
-                    {iframeUrl && (
-                        <div>
-                            <iframe
-                                className={joinClassNames(['tw-w-full', !hasRadius && radiusClassMap[radiusChoice]])}
-                                style={{
-                                    ...(hasBorder ? getIframeBorderStyles(borderStyle, borderWidth, borderColor) : {}),
-                                    borderRadius: hasRadius ? radiusValue : '',
-                                }}
-                                height={isCustomHeight ? customHeight : heights[height]}
-                                src={iframeUrl.toString()}
-                                frameBorder="0"
-                                data-test-id="sketchfab-iframe"
-                                title="3D model from Sketchfab"
-                                sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-presentation"
-                            />
-                        </div>
-                    )}
-                    {isEditing && !iframeUrl && (
-                        <div
-                            className="tw-flex tw-flex-col tw-items-center tw-bg-black-5 tw-p-20 tw-gap-8 tw-body-medium"
-                            data-test-id="sketchfab-empty-block-edit"
-                        >
-                            <Text color="weak">Enter a URL to your 3D model from Sketchfab.</Text>
-                            <div className="tw-text-secondary tw-flex tw-items-start tw-gap-3 tw-w-full tw-justify-center">
-                                <div className="tw-flex-none tw-mt-[2px]">
-                                    <IconLinkBox size={32} />
-                                </div>
-                                <div className="tw-w-full tw-max-w-sm">
-                                    <FormControl
-                                        helper={inputError ? { text: SKETCHFAB_RULE_ERROR } : undefined}
-                                        style={inputError ? FormControlStyle.Danger : FormControlStyle.Primary}
-                                    >
-                                        <TextInput
-                                            value={localUrl}
-                                            onChange={(event) => setLocalUrl(event.target.value)}
-                                            onKeyDown={(event) => {
-                                                if (event.key === 'Enter') {
-                                                    saveLink();
-                                                }
-                                            }}
-                                            placeholder={URL_INPUT_PLACEHOLDER}
-                                        />
-                                    </FormControl>
-                                </div>
-                                <Button onPress={saveLink}>Confirm</Button>
-                            </div>
-                        </div>
-                    )}
-                    {!isEditing && !iframeUrl && (
-                        <div
-                            className="tw-flex tw-items-center tw-justify-center tw-bg-black-5 tw-p-20"
-                            data-test-id="sketchfab-empty-block-view"
-                        >
-                            <Text color="weak">
+        <StyleProvider appId={manifest.appId}>
+            <div data-test-id="sketchfab-block" className="tw-relative">
+                {iframeUrl && (
+                    <div>
+                        <iframe
+                            className={joinClassNames(['tw-w-full', !hasRadius && radiusClassMap[radiusChoice]])}
+                            style={{
+                                ...(hasBorder ? getIframeBorderStyles(borderStyle, borderWidth, borderColor) : {}),
+                                borderRadius: hasRadius ? radiusValue : '',
+                            }}
+                            height={isCustomHeight ? customHeight : heights[height]}
+                            src={iframeUrl.toString()}
+                            frameBorder="0"
+                            data-test-id="sketchfab-iframe"
+                            title="3D model from Sketchfab"
+                            sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-presentation"
+                        />
+                    </div>
+                )}
+                {isEditing && !iframeUrl && (
+                    <div
+                        className="tw-flex tw-flex-col tw-items-center tw-bg-black-5 tw-p-20 tw-gap-8 tw-body-medium"
+                        data-test-id="sketchfab-empty-block-edit"
+                    >
+                        <Text color="weak">Enter a URL to your 3D model from Sketchfab.</Text>
+                        <div className="tw-text-secondary tw-flex tw-items-start tw-gap-3 tw-w-full tw-justify-center">
+                            <div className="tw-flex-none tw-mt-[2px]">
                                 <IconLinkBox size={32} />
-                            </Text>
+                            </div>
+                            <div className="tw-w-full tw-max-w-sm">
+                                <FormControl
+                                    helper={inputError ? { text: SKETCHFAB_RULE_ERROR } : undefined}
+                                    style={inputError ? FormControlStyle.Danger : FormControlStyle.Primary}
+                                >
+                                    <TextInput
+                                        value={localUrl}
+                                        onChange={(event) => setLocalUrl(event.target.value)}
+                                        onKeyDown={(event) => {
+                                            if (event.key === 'Enter') {
+                                                saveLink();
+                                            }
+                                        }}
+                                        placeholder={URL_INPUT_PLACEHOLDER}
+                                    />
+                                </FormControl>
+                            </div>
+                            <Button onPress={saveLink}>Confirm</Button>
                         </div>
-                    )}
-                </div>
-            </StyleProvider>
-        </div>
+                    </div>
+                )}
+                {!isEditing && !iframeUrl && (
+                    <div
+                        className="tw-flex tw-items-center tw-justify-center tw-bg-black-5 tw-p-20"
+                        data-test-id="sketchfab-empty-block-view"
+                    >
+                        <Text color="weak">
+                            <IconLinkBox size={32} />
+                        </Text>
+                    </div>
+                )}
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/storybook-block/postcss.config.js
+++ b/packages/storybook-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.storybook-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/storybook-block/src/StorybookBlock.tsx
+++ b/packages/storybook-block/src/StorybookBlock.tsx
@@ -8,6 +8,8 @@ import { type BlockProps, radiusStyleMap, toRgbaString } from '@frontify/guideli
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type FC, useCallback, useEffect, useState } from 'react';
 
+import manifest from '../manifest.json';
+
 import { Resizeable } from './components/Resizable';
 import { BORDER_COLOR_DEFAULT_VALUE, ERROR_MSG, URL_INPUT_PLACEHOLDER } from './settings';
 import {
@@ -108,60 +110,56 @@ export const StorybookBlock: FC<BlockProps> = ({ appBridge }) => {
     );
 
     return (
-        <div className="storybook-block">
-            <StyleProvider>
-                <div data-test-id="storybook-block" className="tw-relative">
-                    {iframe ? (
-                        isEditing ? (
-                            <Resizeable saveHeight={saveHeight} initialHeight={activeHeight}>
-                                <div>{iframe}</div>
-                            </Resizeable>
-                        ) : (
-                            <div style={{ height: activeHeight }}>{iframe}</div>
-                        )
-                    ) : isEditing ? (
+        <StyleProvider appId={manifest.appId}>
+            <div data-test-id="storybook-block" className="tw-relative">
+                {iframe ? (
+                    isEditing ? (
                         <Resizeable saveHeight={saveHeight} initialHeight={activeHeight}>
-                            <div
-                                className="tw-flex tw-justify-center tw-items-center tw-bg-black-5 tw-p-20 tw-text-black-40 tw-space-x-2 tw-resize-y tw-body-medium"
-                                data-test-id="storybook-empty-wrapper"
-                            >
-                                <IconStorybook size={32} />
-                                <div
-                                    className={`tw-w-full tw-max-w-sm ${!isValidStorybookUrl(submittedUrl) && 'tw-pt-6'}`}
-                                >
-                                    <FormControl
-                                        helper={!isValidStorybookUrl(submittedUrl) ? { text: ERROR_MSG } : undefined}
-                                        style={
-                                            !isValidStorybookUrl(submittedUrl)
-                                                ? FormControlStyle.Danger
-                                                : FormControlStyle.Primary
-                                        }
-                                    >
-                                        <TextInput
-                                            value={input}
-                                            onChange={(event) => setInput(event.target.value)}
-                                            onKeyDown={(event) => {
-                                                if (event.key === 'Enter') {
-                                                    saveInputLink();
-                                                }
-                                            }}
-                                            placeholder={URL_INPUT_PLACEHOLDER}
-                                        />
-                                    </FormControl>
-                                </div>
-                                <Button onPress={saveInputLink}>Confirm</Button>
-                            </div>
+                            <div>{iframe}</div>
                         </Resizeable>
                     ) : (
+                        <div style={{ height: activeHeight }}>{iframe}</div>
+                    )
+                ) : isEditing ? (
+                    <Resizeable saveHeight={saveHeight} initialHeight={activeHeight}>
                         <div
-                            className="tw-flex tw-items-center tw-justify-center tw-bg-black-5"
-                            style={{ height: activeHeight }}
+                            className="tw-flex tw-justify-center tw-items-center tw-bg-black-5 tw-p-20 tw-text-black-40 tw-space-x-2 tw-resize-y tw-body-medium"
+                            data-test-id="storybook-empty-wrapper"
                         >
-                            No Storybook-URL defined.
+                            <IconStorybook size={32} />
+                            <div className={`tw-w-full tw-max-w-sm ${!isValidStorybookUrl(submittedUrl) && 'tw-pt-6'}`}>
+                                <FormControl
+                                    helper={!isValidStorybookUrl(submittedUrl) ? { text: ERROR_MSG } : undefined}
+                                    style={
+                                        !isValidStorybookUrl(submittedUrl)
+                                            ? FormControlStyle.Danger
+                                            : FormControlStyle.Primary
+                                    }
+                                >
+                                    <TextInput
+                                        value={input}
+                                        onChange={(event) => setInput(event.target.value)}
+                                        onKeyDown={(event) => {
+                                            if (event.key === 'Enter') {
+                                                saveInputLink();
+                                            }
+                                        }}
+                                        placeholder={URL_INPUT_PLACEHOLDER}
+                                    />
+                                </FormControl>
+                            </div>
+                            <Button onPress={saveInputLink}>Confirm</Button>
                         </div>
-                    )}
-                </div>
-            </StyleProvider>
-        </div>
+                    </Resizeable>
+                ) : (
+                    <div
+                        className="tw-flex tw-items-center tw-justify-center tw-bg-black-5"
+                        style={{ height: activeHeight }}
+                    >
+                        No Storybook-URL defined.
+                    </div>
+                )}
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/template-block/postcss.config.js
+++ b/packages/template-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.template-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/template-block/src/TemplateBlock.tsx
+++ b/packages/template-block/src/TemplateBlock.tsx
@@ -6,6 +6,8 @@ import { type BlockProps } from '@frontify/guideline-blocks-settings';
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type ReactElement } from 'react';
 
+import manifest from '../manifest.json';
+
 import { AlertError } from './components/AlertError';
 import { CtaButton } from './components/CtaButton';
 import { TemplatePreview } from './components/TemplatePreview';
@@ -69,78 +71,76 @@ export const TemplateBlock = ({ appBridge }: BlockProps): ReactElement => {
     }
 
     return (
-        <div data-test-id="container" className="template-block tw-@container">
-            <StyleProvider>
-                <div data-test-id="card" style={cardStyles}>
-                    {isEditing && lastErrorMessage !== '' && <AlertError errorMessage={lastErrorMessage} />}
+        <StyleProvider data-test-id="container" appId={manifest.appId} className="tw-@container">
+            <div data-test-id="card" style={cardStyles}>
+                {isEditing && lastErrorMessage !== '' && <AlertError errorMessage={lastErrorMessage} />}
 
-                    <div data-test-id="content" className={contentClasses}>
-                        {hasPreview && (
-                            <TemplatePreview
+                <div data-test-id="content" className={contentClasses}>
+                    {hasPreview && (
+                        <TemplatePreview
+                            appBridge={appBridge}
+                            blockSettings={blockSettings}
+                            template={selectedTemplate}
+                            previewCustom={previewCustom}
+                            previewClasses={previewClasses}
+                            updateBlockSettings={updateBlockSettings}
+                            onOpenTemplateChooser={handleOpenTemplateChooser}
+                            handleNewPublication={handleNewPublication}
+                            handleDeleteCustomPreview={handleDeleteCustomPreview}
+                        />
+                    )}
+
+                    <div data-test-id="text-cta-wrapper" className={textCtaWrapperClasses}>
+                        <div data-test-id="text" className={textClasses}>
+                            <TemplateText
                                 appBridge={appBridge}
-                                blockSettings={blockSettings}
-                                template={selectedTemplate}
-                                previewCustom={previewCustom}
-                                previewClasses={previewClasses}
                                 updateBlockSettings={updateBlockSettings}
-                                onOpenTemplateChooser={handleOpenTemplateChooser}
-                                handleNewPublication={handleNewPublication}
-                                handleDeleteCustomPreview={handleDeleteCustomPreview}
+                                title={title}
+                                description={description}
+                                pageCount={
+                                    blockSettings.hasPageCount !== false
+                                        ? (selectedTemplate?.pages.length ?? 0)
+                                        : undefined
+                                }
+                                isEditing={isEditing}
+                                hasTitleOnly={hasTitleOnly}
+                                templateTextKey={templateTextKey}
                             />
-                        )}
-
-                        <div data-test-id="text-cta-wrapper" className={textCtaWrapperClasses}>
-                            <div data-test-id="text" className={textClasses}>
-                                <TemplateText
-                                    appBridge={appBridge}
-                                    updateBlockSettings={updateBlockSettings}
-                                    title={title}
-                                    description={description}
-                                    pageCount={
-                                        blockSettings.hasPageCount !== false
-                                            ? (selectedTemplate?.pages.length ?? 0)
-                                            : undefined
-                                    }
-                                    isEditing={isEditing}
-                                    hasTitleOnly={hasTitleOnly}
-                                    templateTextKey={templateTextKey}
-                                />
-                            </div>
-                            <div data-test-id="cta" className={ctaClasses}>
-                                <CtaButton
-                                    blockSettings={blockSettings}
-                                    isEditing={isEditing}
-                                    isDisabled={!selectedTemplate}
-                                    updateBlockSettings={updateBlockSettings}
-                                    handleNewPublication={handleNewPublication}
-                                />
-                            </div>
+                        </div>
+                        <div data-test-id="cta" className={ctaClasses}>
+                            <CtaButton
+                                blockSettings={blockSettings}
+                                isEditing={isEditing}
+                                isDisabled={!selectedTemplate}
+                                updateBlockSettings={updateBlockSettings}
+                                handleNewPublication={handleNewPublication}
+                            />
                         </div>
                     </div>
-
-                    {isEditing && !hasPreview && (
-                        <div
-                            data-test-id="cta-editing-no-preview"
-                            className="tw-flex tw-justify-between tw-items-center tw-mt-4 tw-p-3 tw-pl-4 tw-bg-black-0 tw-border tw-border-container-secondary tw-rounded-medium tw-flex-col @sm:tw-flex-row"
-                        >
-                            <div>
-                                <Text size="large" color="weak">
-                                    {'Connected template: '}
-                                </Text>
-                                <Text size="large">{selectedTemplate?.name ?? 'None'}</Text>
-                            </div>
-
-                            <Button
-                                className="tw-line-clamp-2"
-                                emphasis={selectedTemplate ? 'default' : 'strong'}
-                                onPress={handleOpenTemplateChooser}
-                            >
-                                {selectedTemplate ? 'Replace template' : 'Choose existing template'}
-                            </Button>
-                        </div>
-                    )}
                 </div>
-            </StyleProvider>
-        </div>
+
+                {isEditing && !hasPreview && (
+                    <div
+                        data-test-id="cta-editing-no-preview"
+                        className="tw-flex tw-justify-between tw-items-center tw-mt-4 tw-p-3 tw-pl-4 tw-bg-black-0 tw-border tw-border-container-secondary tw-rounded-medium tw-flex-col @sm:tw-flex-row"
+                    >
+                        <div>
+                            <Text size="large" color="weak">
+                                {'Connected template: '}
+                            </Text>
+                            <Text size="large">{selectedTemplate?.name ?? 'None'}</Text>
+                        </div>
+
+                        <Button
+                            className="tw-line-clamp-2"
+                            emphasis={selectedTemplate ? 'default' : 'strong'}
+                            onPress={handleOpenTemplateChooser}
+                        >
+                            {selectedTemplate ? 'Replace template' : 'Choose existing template'}
+                        </Button>
+                    </div>
+                )}
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/text-block/postcss.config.js
+++ b/packages/text-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.text-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/text-block/src/TextBlock.tsx
+++ b/packages/text-block/src/TextBlock.tsx
@@ -6,6 +6,8 @@ import { type BlockProps, RichTextEditor } from '@frontify/guideline-blocks-sett
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type ReactElement, useCallback, useMemo } from 'react';
 
+import manifest from '../manifest.json';
+
 import { getPlugins } from './getPlugins';
 import { PLACEHOLDER } from './settings';
 import { type Settings, spacingValues } from './types';
@@ -21,19 +23,21 @@ export const TextBlock = ({ appBridge }: BlockProps): ReactElement => {
     const handleTextChange = useCallback((content: string) => setBlockSettings({ content }), [setBlockSettings]);
 
     return (
-        <div data-test-id="text-block-wrapper" className={merge(['text-block', isEditing && 'tw-min-h-9'])}>
-            <StyleProvider>
-                <RichTextEditor
-                    id={String(appBridge.context('blockId').get())}
-                    isEditing={isEditing}
-                    value={content}
-                    columns={parseInt(columnNumber)}
-                    gap={gap}
-                    plugins={plugins}
-                    placeholder={PLACEHOLDER}
-                    onTextChange={handleTextChange}
-                />
-            </StyleProvider>
-        </div>
+        <StyleProvider
+            data-test-id="text-block-wrapper"
+            appId={manifest.appId}
+            className={merge([isEditing && 'tw-min-h-9'])}
+        >
+            <RichTextEditor
+                id={String(appBridge.context('blockId').get())}
+                isEditing={isEditing}
+                value={content}
+                columns={parseInt(columnNumber)}
+                gap={gap}
+                plugins={plugins}
+                placeholder={PLACEHOLDER}
+                onTextChange={handleTextChange}
+            />
+        </StyleProvider>
     );
 };

--- a/packages/thumbnail-grid-block/postcss.config.js
+++ b/packages/thumbnail-grid-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.thumbnail-grid-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/thumbnail-grid-block/src/ThumbnailGridBlock.tsx
+++ b/packages/thumbnail-grid-block/src/ThumbnailGridBlock.tsx
@@ -15,6 +15,8 @@ import { type BlockProps, Security, gutterSpacingStyleMap, useDndSensors } from 
 import { generateRandomId, StyleProvider } from '@frontify/guideline-blocks-shared';
 import { useCallback, useEffect, useState } from 'react';
 
+import manifest from '../manifest.json';
+
 import { Grid, Item, SortableItem } from './components/';
 import { getThumbnailStyles } from './helper';
 import { type Settings, type Thumbnail } from './types';
@@ -180,48 +182,46 @@ export const ThumbnailGridBlock = ({ appBridge }: BlockProps) => {
     };
 
     return (
-        <div className="thumbnail-grid-block">
-            <StyleProvider>
-                <DndContext
-                    sensors={sensors}
-                    collisionDetection={closestCenter}
-                    onDragEnd={handleDragEnd}
-                    onDragStart={handleDragStart}
-                    modifiers={[restrictToParentElement]}
-                >
-                    <SortableContext items={itemsState} strategy={rectSortingStrategy}>
-                        <div className="tw-@container tw-translate-x-0 tw-isolate">
-                            <Grid columnCount={blockSettings.columnCount} gap={gap}>
-                                {itemsState.map((item, i) => (
-                                    <SortableItem
-                                        key={item.id}
-                                        item={item}
-                                        isAssetViewerEnabled={isAssetViewerEnabled}
-                                        image={blockAssets?.[item.id]?.[0]}
-                                        isLoading={getIsItemUploading(item.id)}
-                                        showDeleteButton={i !== itemsState.length - 1}
-                                        openAssetInAssetViewer={openAssetInAssetViewer}
-                                        {...thumbnailProps}
-                                    />
-                                ))}
-                            </Grid>
-                        </div>
-                        <DragOverlay>
-                            {draggedItem && (
-                                <Item
-                                    key={draggedItem.id}
-                                    item={draggedItem}
-                                    image={blockAssets?.[draggedItem.id]?.[0]}
-                                    isLoading={getIsItemUploading(draggedItem.id)}
-                                    isDragging
-                                    showDeleteButton={itemsState[itemsState.length - 1]?.id !== draggedItem.id}
+        <StyleProvider appId={manifest.appId}>
+            <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+                onDragStart={handleDragStart}
+                modifiers={[restrictToParentElement]}
+            >
+                <SortableContext items={itemsState} strategy={rectSortingStrategy}>
+                    <div className="tw-@container tw-translate-x-0 tw-isolate">
+                        <Grid columnCount={blockSettings.columnCount} gap={gap}>
+                            {itemsState.map((item, i) => (
+                                <SortableItem
+                                    key={item.id}
+                                    item={item}
+                                    isAssetViewerEnabled={isAssetViewerEnabled}
+                                    image={blockAssets?.[item.id]?.[0]}
+                                    isLoading={getIsItemUploading(item.id)}
+                                    showDeleteButton={i !== itemsState.length - 1}
+                                    openAssetInAssetViewer={openAssetInAssetViewer}
                                     {...thumbnailProps}
                                 />
-                            )}
-                        </DragOverlay>
-                    </SortableContext>
-                </DndContext>
-            </StyleProvider>
-        </div>
+                            ))}
+                        </Grid>
+                    </div>
+                    <DragOverlay>
+                        {draggedItem && (
+                            <Item
+                                key={draggedItem.id}
+                                item={draggedItem}
+                                image={blockAssets?.[draggedItem.id]?.[0]}
+                                isLoading={getIsItemUploading(draggedItem.id)}
+                                isDragging
+                                showDeleteButton={itemsState[itemsState.length - 1]?.id !== draggedItem.id}
+                                {...thumbnailProps}
+                            />
+                        )}
+                    </DragOverlay>
+                </SortableContext>
+            </DndContext>
+        </StyleProvider>
     );
 };

--- a/packages/ui-pattern-block/postcss.config.js
+++ b/packages/ui-pattern-block/postcss.config.js
@@ -4,6 +4,6 @@ module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.ui-pattern-block' }),
+        require('../../postcss/scope')({ scope: `.${require('./manifest.json').appId}` }),
     ],
 };

--- a/packages/ui-pattern-block/src/UIPatternBlock.tsx
+++ b/packages/ui-pattern-block/src/UIPatternBlock.tsx
@@ -17,6 +17,8 @@ import {
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type ReactElement, useMemo, useRef, useState } from 'react';
 
+import manifest from '../manifest.json';
+
 import { Captions, CodeEditor, ExternalDependencies, NPMDependencies, ResponsivePreview } from './components';
 import { AttachmentsButton } from './components/AttachmentsButton';
 import {
@@ -185,119 +187,115 @@ export const UIPatternBlock = withAttachmentsProvider(({ appBridge }: BlockProps
     const borderRadius = hasBorder ? getRadiusValue(hasRadius, radiusValue, radiusChoice) : 0;
 
     return (
-        <div key={sandpackTemplate} data-test-id="ui-pattern-block" className="ui-pattern-block">
-            <StyleProvider>
+        <StyleProvider key={sandpackTemplate} data-test-id="ui-pattern-block" appId={manifest.appId}>
+            <div
+                className={joinClassNames([
+                    'tw-flex tw-gap-3',
+                    labelPosition === TextAlignment.Top ? 'tw-flex-col' : 'tw-flex-col-reverse',
+                ])}
+            >
+                <div className="tw-flex tw-justify-between tw-gap-3 tw-items-start">
+                    <Captions
+                        appBridge={appBridge}
+                        title={title}
+                        description={description}
+                        onTitleChange={(newValue) => setBlockSettings({ title: newValue })}
+                        onDescriptionChange={(newValue) => setBlockSettings({ description: newValue })}
+                        isEditing={isEditing}
+                    />
+                    <AttachmentsButton appBridge={appBridge} />
+                </div>
+
                 <div
+                    data-test-id="ui-pattern-block-wrapper"
+                    style={{
+                        ...(hasBorder &&
+                            getBorderStyles(borderStyle, borderWidth, borderColor || BORDER_COLOR_DEFAULT_VALUE)),
+                        borderRadius,
+                    }}
                     className={joinClassNames([
-                        'tw-flex tw-gap-3',
-                        labelPosition === TextAlignment.Top ? 'tw-flex-col' : 'tw-flex-col-reverse',
+                        'tw-rounded-medium tw-bg-white tw-overflow-hidden tw-group',
+                        // Used to hide border-bottom of last elements in component from also applying a border (eg. Accordion.tsx).
+                        hasBorder && 'bordered',
                     ])}
                 >
-                    <div className="tw-flex tw-justify-between tw-gap-3 tw-items-start">
-                        <Captions
-                            appBridge={appBridge}
-                            title={title}
-                            description={description}
-                            onTitleChange={(newValue) => setBlockSettings({ title: newValue })}
-                            onDescriptionChange={(newValue) => setBlockSettings({ description: newValue })}
-                            isEditing={isEditing}
-                        />
-                        <AttachmentsButton appBridge={appBridge} />
-                    </div>
-
-                    <div
-                        data-test-id="ui-pattern-block-wrapper"
-                        style={{
-                            ...(hasBorder &&
-                                getBorderStyles(borderStyle, borderWidth, borderColor || BORDER_COLOR_DEFAULT_VALUE)),
-                            borderRadius,
+                    <SandpackProvider
+                        files={templateFiles}
+                        template={sandpackTemplate}
+                        customSetup={parsedNpmDependencies}
+                        theme={sandpackThemeValues[sandpackTheme]}
+                        key={sandpackRestartInitiators.map((i) => i.toString()).join('')}
+                        options={{
+                            classes: EDITOR_CLASSES,
+                            activeFile: initialActiveFile[sandpackTemplate],
+                            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                            externalResources: [cssToInject, ...parsedExternalDependencies],
                         }}
-                        className={joinClassNames([
-                            'tw-rounded-medium tw-bg-white tw-overflow-hidden tw-group',
-                            // Used to hide border-bottom of last elements in component from also applying a border (eg. Accordion.tsx).
-                            hasBorder && 'bordered',
-                        ])}
                     >
-                        <SandpackProvider
-                            files={templateFiles}
-                            template={sandpackTemplate}
-                            customSetup={parsedNpmDependencies}
-                            theme={sandpackThemeValues[sandpackTheme]}
-                            key={sandpackRestartInitiators.map((i) => i.toString()).join('')}
-                            options={{
-                                classes: EDITOR_CLASSES,
-                                activeFile: initialActiveFile[sandpackTemplate],
-                                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                                externalResources: [cssToInject, ...parsedExternalDependencies],
-                            }}
-                        >
-                            <SandpackLayout className="tw-flex tw-flex-col">
-                                {isResponsivePreviewOpen && (
-                                    <ResponsivePreview onClose={() => setIsResponsivePreviewOpen(false)} />
-                                )}
-                                <SandpackPreview
-                                    ref={previewRef}
-                                    style={{
-                                        height: getHeightStyle(isCustomHeight, customHeightValue, heightChoice),
-                                        padding: getPaddingStyle(hasCustomPadding, paddingCustom, paddingChoice),
-                                        ...(hasBackground && {
-                                            ...getBackgroundColorStyles(
-                                                backgroundColor || BACKGROUND_COLOR_DEFAULT_VALUE
-                                            ),
-                                            backgroundImage: 'none',
-                                        }),
-                                    }}
-                                    showRefreshButton={false}
-                                    showOpenInCodeSandbox={false}
-                                    className="tw-rounded-none tw-shadow-none tw-ml-0 tw-bg-white [&>div>iframe]:!tw-max-h-none"
+                        <SandpackLayout className="tw-flex tw-flex-col">
+                            {isResponsivePreviewOpen && (
+                                <ResponsivePreview onClose={() => setIsResponsivePreviewOpen(false)} />
+                            )}
+                            <SandpackPreview
+                                ref={previewRef}
+                                style={{
+                                    height: getHeightStyle(isCustomHeight, customHeightValue, heightChoice),
+                                    padding: getPaddingStyle(hasCustomPadding, paddingCustom, paddingChoice),
+                                    ...(hasBackground && {
+                                        ...getBackgroundColorStyles(backgroundColor || BACKGROUND_COLOR_DEFAULT_VALUE),
+                                        backgroundImage: 'none',
+                                    }),
+                                }}
+                                showRefreshButton={false}
+                                showOpenInCodeSandbox={false}
+                                className="tw-rounded-none tw-shadow-none tw-ml-0 tw-bg-white [&>div>iframe]:!tw-max-h-none"
+                            />
+                            {(isEditing || showCode) && (
+                                <CodeEditor
+                                    key={`editor_${isEditing.toString()}`}
+                                    isCodeEditable={isEditing || isCodeEditable}
+                                    showResetButton={showResetButton}
+                                    showSandboxLink={showSandboxLink}
+                                    showResponsivePreview={showResponsivePreview}
+                                    onResponsivePreviewOpen={() => setIsResponsivePreviewOpen(true)}
+                                    onCodeChange={onCodeChange}
+                                    onResetFilesToDefault={onResetFiles}
+                                    onResetRun={onResetRun}
+                                    hasCodeChanges={!isEditing && hasCodeChanges}
+                                    template={sandpackTemplate}
+                                    shouldCollapseCodeByDefault={!isEditing && shouldCollapseCodeByDefault}
+                                    preprocessor={preprocessor}
                                 />
-                                {(isEditing || showCode) && (
-                                    <CodeEditor
-                                        key={`editor_${isEditing.toString()}`}
-                                        isCodeEditable={isEditing || isCodeEditable}
-                                        showResetButton={showResetButton}
-                                        showSandboxLink={showSandboxLink}
-                                        showResponsivePreview={showResponsivePreview}
-                                        onResponsivePreviewOpen={() => setIsResponsivePreviewOpen(true)}
-                                        onCodeChange={onCodeChange}
-                                        onResetFilesToDefault={onResetFiles}
-                                        onResetRun={onResetRun}
-                                        hasCodeChanges={!isEditing && hasCodeChanges}
-                                        template={sandpackTemplate}
-                                        shouldCollapseCodeByDefault={!isEditing && shouldCollapseCodeByDefault}
-                                        preprocessor={preprocessor}
-                                    />
-                                )}
-                            </SandpackLayout>
-                        </SandpackProvider>
+                            )}
+                        </SandpackLayout>
+                    </SandpackProvider>
 
-                        {(isEditing || showNpmDependencies) && sandpackTemplate !== SandpackTemplate.Static && (
-                            <NPMDependencies
-                                key={`npm_${isEditing.toString()}`}
-                                npmDependencies={npmDependencies}
-                                shouldCollapseByDefault={!isEditing && shouldCollapseDependenciesByDefault}
-                                onNpmDependenciesChanged={(newDependencies) =>
-                                    onDependenciesChanged(newDependencies, 'npm')
-                                }
-                                borderRadius={showExternalDependencies ? undefined : borderRadius}
-                                readOnly={!isEditing}
-                            />
-                        )}
-                        {(isEditing || showExternalDependencies) && sandpackTemplate !== SandpackTemplate.Static && (
-                            <ExternalDependencies
-                                key={`external_${isEditing.toString()}`}
-                                externalDependencies={externalDependencies}
-                                shouldCollapseByDefault={!isEditing && shouldCollapseDependenciesByDefault}
-                                onExternalDependenciesChanged={(newDependencies) =>
-                                    onDependenciesChanged(newDependencies, 'external')
-                                }
-                                borderRadius={borderRadius}
-                                readOnly={!isEditing}
-                            />
-                        )}
-                    </div>
+                    {(isEditing || showNpmDependencies) && sandpackTemplate !== SandpackTemplate.Static && (
+                        <NPMDependencies
+                            key={`npm_${isEditing.toString()}`}
+                            npmDependencies={npmDependencies}
+                            shouldCollapseByDefault={!isEditing && shouldCollapseDependenciesByDefault}
+                            onNpmDependenciesChanged={(newDependencies) =>
+                                onDependenciesChanged(newDependencies, 'npm')
+                            }
+                            borderRadius={showExternalDependencies ? undefined : borderRadius}
+                            readOnly={!isEditing}
+                        />
+                    )}
+                    {(isEditing || showExternalDependencies) && sandpackTemplate !== SandpackTemplate.Static && (
+                        <ExternalDependencies
+                            key={`external_${isEditing.toString()}`}
+                            externalDependencies={externalDependencies}
+                            shouldCollapseByDefault={!isEditing && shouldCollapseDependenciesByDefault}
+                            onExternalDependenciesChanged={(newDependencies) =>
+                                onDependenciesChanged(newDependencies, 'external')
+                            }
+                            borderRadius={borderRadius}
+                            readOnly={!isEditing}
+                        />
+                    )}
                 </div>
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 }, ATTACHMENTS_ASSET_ID);

--- a/postcss/scope.js
+++ b/postcss/scope.js
@@ -43,19 +43,13 @@ const getScopedSelector = (selector, scope) => {
         return scope;
     }
 
-    // Prefix all rules with .selector that match the condition
+    // Prefix all rules with .selector that match the condition. Portaled content
+    // (Dropdown, Tooltip, Dialog, …) carries the scope class via Fondue's ThemeProvider
+    // className propagation, so a plain `${scope} ${selector}` prefix reaches it too.
     if (selector.includes("tw-") || tagSelectorRegex.test(selector)) {
-        return `${scope} ${selector}${getModalExtensions(selector)}`;
+        return `${scope} ${selector}`;
     }
 
     // Return the original rule
     return selector;
-};
-
-const getModalExtensions = (selector) => {
-    if (!selector.includes(".")) {
-        return "";
-    }
-
-    return `, body > [role='toolbar'] ${selector}, body [data-overlay-container] ${selector}, body [role='dialog'] ${selector}, body [data-is-underlay="true"] ${selector}`;
 };


### PR DESCRIPTION
## feat(scoping): scope block CSS by marketplace app id via StyleProvider

### Why

Every block scopes its generated CSS so it doesn't leak into the surrounding guideline. Until now that scope was kept in sync **by hand** in two disconnected places per block:

1. a manual `<div className="x-block">` wrapper in the component, and
2. a hard-coded `scope: '.x-block'` in `postcss.config.js`.

This is fragile — `glyphs-block` proved it by rendering `className="glyps-block"` (typo) while scoping to `.glyphs-block`, so its scoped styles never matched the element. The class names were also arbitrary and not tied to anything canonical.

This PR makes the **marketplace app id** (`appId` from each block's `manifest.json`) the single source of truth for scoping, used by both the runtime class and the PostCSS build scope, and centralizes the wrapper in `StyleProvider`.

### What changed

- **`StyleProvider` now owns the scope element.** It renders the wrapping `<div>`, applies the `appId` as its `className`, and forwards `ref` + arbitrary DOM props (`data-test-id`, `key`, extra classes). It also passes `appId` to Fondue's `ThemeProvider` `className`, which **propagates the scope class to portaled content** (Dropdown, Tooltip, Dialog), so overlays rendered at `body` level are scoped natively.
- **PostCSS scope is derived from the manifest.** Each block's `postcss.config.js` now uses `` scope: `.${require('./manifest.json').appId}` `` instead of a hard-coded class.
- **Simplified `postcss/scope.js`.** Removed the `getModalExtensions` hack (the hardcoded `body [data-overlay-container]` / `[role='dialog']` / `[data-is-underlay]` / `[role='toolbar']` selectors) — Fondue's `ThemeProvider` propagation now covers portals, so a plain `${scope} ${selector}` prefix suffices.
- **20 components updated** (19 blocks + the asset-upload example): the manual `<div className="x-block">` wrapper is replaced by `<StyleProvider appId={manifest.appId} …>` with preserved props.
- **Fixes `glyphs-block`** styling bug for free (the `glyps-block` typo class is gone).

### Result

Generated CSS is now isolated per block, e.g. for `gradient-block`:

```css
.clexy16s300010pw1gf0c4bne .tw-flex { display: flex }
```

Since each block has a unique `appId`, blocks no longer interfere with each other.

### Verification

- ✅ `pnpm typecheck`, `pnpm lint`, `pnpm prettier` — all clean
- ✅ `pnpm test:unit` — 243 passed
- ✅ Confirmed via the real PostCSS pipeline that rules are scoped to `.<appId>` with no overlay extensions
- ✅  `pnpm test:components` (Cypress) not run — couldn't launch in the dev sandbox; please ensure CI runs it

### Things to fix

- [ ] RTE is currently not scoped and only works by "accident" (as it still uses old fondue components which are not relying on the themeProvider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
