### PR TITLE
fix(CalloutBlock): adjust color computation logic

### DIFF
--- a/packages/callout-block/src/CalloutBlock.spec.ct.tsx
+++ b/packages/callout-block/src/CalloutBlock.spec.ct.tsx
@@ -163,7 +163,7 @@ describe('Callout Block', () => {
         mount(<CalloutBlockWithStubs />);
 
         cy.get(CalloutBlockSelector).should('have.css', 'background-color', 'rgba(246, 216, 56, 0.1)');
-        cy.get(HtmlContentSelector).should('have.css', 'color', 'rgb(108, 92, 5)');
+        cy.get(HtmlContentSelector).should('have.css', 'color', 'rgb(0, 0, 0)');
     });
 
     it('renders a callout block with the correct colors for type tip', () => {
@@ -223,10 +223,10 @@ describe('Callout Block', () => {
         mount(<CalloutBlockWithStubs />);
 
         cy.get(CalloutBlockSelector)
-            .should('have.css', '--f-theme-settings-heading1-color', 'rgb(108, 92, 5)')
-            .and('have.css', '--f-theme-settings-body-color', 'rgb(108, 92, 5)')
-            .and('have.css', '--f-theme-settings-link-color', 'rgb(108, 92, 5)')
-            .and('have.css', 'color', 'rgb(108, 92, 5)')
+            .should('have.css', '--f-theme-settings-heading1-color', 'black')
+            .and('have.css', '--f-theme-settings-body-color', 'black')
+            .and('have.css', '--f-theme-settings-link-color', 'black')
+            .and('have.css', 'color', 'rgb(0, 0, 0)')
             .and('have.css', 'background-color', 'rgba(246, 216, 56, 0.1)');
     });
 
@@ -251,6 +251,30 @@ describe('Callout Block', () => {
 
         cy.get(CalloutBlockSelector).should('have.css', 'background-color', 'rgba(50, 40, 145, 0.1)');
         cy.get(HtmlContentSelector).should('have.css', 'color', 'rgb(50, 40, 145)');
+    });
+
+    it('should turn text to white when a black accent sits on a black section background', () => {
+        cy.document().then((doc) => {
+            const style = doc.querySelector('#test-settings');
+            if (style) {
+                style.innerHTML =
+                    ':root {--f-theme-settings-accent-color-note-color: rgba(0, 0, 0, 1); --f-theme-settings-background-color: rgb(0, 0, 0);}';
+            }
+            return null;
+        });
+
+        const [CalloutBlockWithStubs] = withAppBridgeBlockStubs(CalloutBlock, {
+            blockSettings: {
+                textValue: 'This is a note',
+                type: Type.Note,
+                appearance: Appearance.Light,
+            },
+        });
+
+        mount(<CalloutBlockWithStubs />);
+
+        cy.get(CalloutBlockSelector).should('have.css', 'background-color', 'rgba(0, 0, 0, 0.1)');
+        cy.get(HtmlContentSelector).should('have.css', 'color', 'rgb(255, 255, 255)');
     });
 
     it('renders a callout block with strong appearance', () => {

--- a/packages/callout-block/src/helpers/color.ts
+++ b/packages/callout-block/src/helpers/color.ts
@@ -1,19 +1,10 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { THEME_PREFIX, getReadableColor, isDark, setAlpha } from '@frontify/guideline-blocks-settings';
+import { type Color, THEME_PREFIX, isDark, setAlpha, toColorObject } from '@frontify/guideline-blocks-settings';
 
 import { Appearance, Type } from '../types';
 
-const getTextColor = (appearance: Appearance, color: string, backgroundColor: string): string => {
-    const isDarkColor = isDark(color, 185);
-    const defaultTextColor = isDarkColor ? 'white' : 'black';
-
-    if (appearance === Appearance.Light) {
-        return isDarkColor ? color : getReadableColor(color, backgroundColor);
-    }
-
-    return defaultTextColor;
-};
+const MIN_READABLE_CONTRAST = 1.5;
 
 const getAccentColor = (type: Type, hostElement: HTMLDivElement | null): string => {
     const style = getComputedStyle(hostElement ?? document.body);
@@ -29,9 +20,55 @@ const getAccentColor = (type: Type, hostElement: HTMLDivElement | null): string 
     }
 };
 
+const getSchemeBackgroundColor = (hostElement: HTMLDivElement | null): string => {
+    const style = getComputedStyle(hostElement ?? document.body);
+    return style.getPropertyValue(`${THEME_PREFIX}background-color`).trim() || 'rgb(255, 255, 255)';
+};
+
+const getEffectiveBackgroundColor = (accentColor: string, schemeBackgroundColor: string): string => {
+    const accent = toColorObject(accentColor);
+    const scheme = toColorObject(schemeBackgroundColor);
+    const blendChannel = (channel: 'red' | 'green' | 'blue') =>
+        Math.round(accent[channel] * 0.1 + scheme[channel] * 0.9);
+    return `rgb(${blendChannel('red')}, ${blendChannel('green')}, ${blendChannel('blue')})`;
+};
+
+const getRelativeLuminance = ({ red, green, blue }: Color): number => {
+    const toLinear = (channel: number) => {
+        const value = channel / 255;
+        return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+    };
+    return 0.2126 * toLinear(red) + 0.7152 * toLinear(green) + 0.0722 * toLinear(blue);
+};
+
+const getContrastRatio = (firstColor: string, secondColor: string): number => {
+    const firstLuminance = getRelativeLuminance(toColorObject(firstColor));
+    const secondLuminance = getRelativeLuminance(toColorObject(secondColor));
+    const lighter = Math.max(firstLuminance, secondLuminance);
+    const darker = Math.min(firstLuminance, secondLuminance);
+    return (lighter + 0.05) / (darker + 0.05);
+};
+
+const getReadableTextColor = (accentColor: string, backgroundColor: string): string => {
+    if (getContrastRatio(accentColor, backgroundColor) >= MIN_READABLE_CONTRAST) {
+        return accentColor;
+    }
+
+    const whiteContrast = getContrastRatio('rgb(255, 255, 255)', backgroundColor);
+    const blackContrast = getContrastRatio('rgb(0, 0, 0)', backgroundColor);
+    return whiteContrast > blackContrast ? 'white' : 'black';
+};
+
 export const computeStyles = (type: Type, appearance: Appearance, hostElement: HTMLDivElement | null) => {
     const accentColor = getAccentColor(type, hostElement);
-    const backgroundColor = appearance === Appearance.Strong ? accentColor : setAlpha(0.1, accentColor);
-    const textColor = getTextColor(appearance, accentColor, backgroundColor);
+
+    if (appearance === Appearance.Strong) {
+        return { backgroundColor: accentColor, textColor: isDark(accentColor, 185) ? 'white' : 'black' };
+    }
+
+    const backgroundColor = setAlpha(0.1, accentColor);
+    const effectiveBackgroundColor = getEffectiveBackgroundColor(accentColor, getSchemeBackgroundColor(hostElement));
+    const textColor = getReadableTextColor(accentColor, effectiveBackgroundColor);
+
     return { backgroundColor, textColor };
 };


### PR DESCRIPTION
For **Light** appearance callouts, the text color now falls back to black or white when the accent color doesn't have enough contrast against the background it sits on.

**Strong** appearance is unchanged.

---

Minimal contrast ratio required: 1.5. This is intentionally not too high to keep existing blocks unchanged most of the time.

The calculation for computing the luminance and contrast ratio is a mix of research and AI.