### PR TITLE
feat: add useDndSensor in the shared package

### DIFF
--- a/packages/animation-curve-block/src/AnimationCurveBlock.tsx
+++ b/packages/animation-curve-block/src/AnimationCurveBlock.tsx
@@ -4,8 +4,8 @@ import { DndContext, type DragEndEvent, DragOverlay, type DragStartEvent, closes
 import { restrictToParentElement } from '@dnd-kit/modifiers';
 import { SortableContext, arrayMove, rectSortingStrategy } from '@dnd-kit/sortable';
 import { useBlockSettings, useEditorState } from '@frontify/app-bridge';
-import { type BlockProps, gutterSpacingStyleMap, useDndSensors } from '@frontify/guideline-blocks-settings';
-import { StyleProvider } from '@frontify/guideline-blocks-shared';
+import { type BlockProps, gutterSpacingStyleMap } from '@frontify/guideline-blocks-settings';
+import { StyleProvider, useDndSensors } from '@frontify/guideline-blocks-shared';
 import { useState } from 'react';
 
 import { BlankSlate, Card, SortableCard } from './components';

--- a/packages/dos-donts-block/src/DosDontsBlock.tsx
+++ b/packages/dos-donts-block/src/DosDontsBlock.tsx
@@ -20,9 +20,8 @@ import {
     type BlockProps,
     FileExtensionSets,
     joinClassNames,
-    useDndSensors,
 } from '@frontify/guideline-blocks-settings';
-import { generateRandomId, StyleProvider } from '@frontify/guideline-blocks-shared';
+import { generateRandomId, StyleProvider, useDndSensors } from '@frontify/guideline-blocks-shared';
 import throttle from 'lodash-es/throttle';
 import { type FC, useCallback, useContext, useEffect, useRef, useState } from 'react';
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,6 +16,7 @@
     },
     "dependencies": {
         "@codemirror/lang-css": "^6.3.1",
+        "@dnd-kit/core": "^6.3.1",
         "@frontify/app-bridge": "^4.0.0-alpha.64",
         "@frontify/fondue": "13.7.0",
         "@frontify/guideline-blocks-settings": "2.1.15",

--- a/packages/shared/src/hooks/useDndSensors.spec.ts
+++ b/packages/shared/src/hooks/useDndSensors.spec.ts
@@ -1,0 +1,41 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type KeyboardSensorOptions } from '@dnd-kit/core';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useDndSensors } from './useDndSensors';
+
+/**
+ * @vitest-environment happy-dom
+ */
+describe('useDndSensors', () => {
+    it('should create a PointerSensor and a KeyboardSensor with a coordinate getter function and custom keyboardCodes', () => {
+        const { result } = renderHook(() => useDndSensors());
+        expect(result.current.length).toBe(2);
+        expect(result.current[0].sensor.name).toBe('PointerSensor');
+        expect(result.current[1].sensor.name).toBe('KeyboardSensor');
+        expect(typeof (result.current[1].options as KeyboardSensorOptions).coordinateGetter).toBe('function');
+        expect((result.current[1].options as KeyboardSensorOptions).keyboardCodes).toEqual({
+            start: ['Space', 'Enter'],
+            cancel: [],
+            end: ['Space', 'Enter', 'Escape'],
+        });
+    });
+
+    it('should create a PointerSensor and a KeyboardSensor with a coordinate getter with columnGap', () => {
+        const { result } = renderHook(() => useDndSensors(100));
+        expect(result.current.length).toBe(2);
+        expect(result.current[0].sensor.name).toBe('PointerSensor');
+        expect(result.current[1].sensor.name).toBe('KeyboardSensor');
+        expect(typeof (result.current[1].options as KeyboardSensorOptions).coordinateGetter).toBe('function');
+    });
+
+    it('should create a PointerSensor and a KeyboardSensor with a coordinate getter with columnGap and rowGap', () => {
+        const { result } = renderHook(() => useDndSensors(100, 150));
+        expect(result.current.length).toBe(2);
+        expect(result.current[0].sensor.name).toBe('PointerSensor');
+        expect(result.current[1].sensor.name).toBe('KeyboardSensor');
+        expect(typeof (result.current[1].options as KeyboardSensorOptions).coordinateGetter).toBe('function');
+    });
+});

--- a/packages/shared/src/hooks/useDndSensors.ts
+++ b/packages/shared/src/hooks/useDndSensors.ts
@@ -1,0 +1,26 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { useMemo } from 'react';
+
+import { customCoordinatesGetterFactory } from '../utils/customCoordinatesGetterFactory';
+
+const keyboardCodes = {
+    start: ['Space', 'Enter'],
+    cancel: [],
+    end: ['Space', 'Enter', 'Escape'],
+};
+
+export const useDndSensors = (columnGap = 0, rowGap = 0) => {
+    const keyboardSensorOptions = useMemo(() => {
+        const customCoordinatesGetter = customCoordinatesGetterFactory(columnGap, rowGap);
+        return {
+            coordinateGetter: customCoordinatesGetter,
+            keyboardCodes,
+        };
+    }, [columnGap, rowGap]);
+
+    const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor, keyboardSensorOptions));
+
+    return sensors;
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,3 +10,4 @@ export { ImageFormat } from './types';
 
 export { useImageContainer } from './hooks/useImageContainer';
 export { generateRandomId } from './utils/generateRandomId';
+export { useDndSensors } from './hooks/useDndSensors';

--- a/packages/shared/src/utils/customCoordinatesGetterFactory.spec.ts
+++ b/packages/shared/src/utils/customCoordinatesGetterFactory.spec.ts
@@ -1,0 +1,70 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { KeyboardCode, type KeyboardCoordinateGetter, type SensorContext } from '@dnd-kit/core';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { customCoordinatesGetterFactory } from './customCoordinatesGetterFactory';
+
+/**
+ * @vitest-environment happy-dom
+ */
+describe('customCoordinatesGetterFactory', () => {
+    const initialCoordinates = { x: 0, y: 0 };
+    const context = {
+        activeNode: {
+            offsetWidth: 100,
+            offsetHeight: 200,
+        },
+    } as SensorContext;
+
+    const active = 'mock-active-id';
+    let customCoordinatesGetter: KeyboardCoordinateGetter;
+    beforeEach(() => {
+        customCoordinatesGetter = customCoordinatesGetterFactory(10, 20);
+    });
+
+    it('should respond to ArrowRight', () => {
+        const result = customCoordinatesGetter(new KeyboardEvent(KeyboardCode.Right, { code: KeyboardCode.Right }), {
+            active,
+            currentCoordinates: initialCoordinates,
+            context,
+        });
+        expect(result).toEqual({ x: 110, y: 0 });
+    });
+
+    it('should respond to ArrowLeft', () => {
+        const result = customCoordinatesGetter(new KeyboardEvent(KeyboardCode.Left, { code: KeyboardCode.Left }), {
+            active,
+            currentCoordinates: initialCoordinates,
+            context,
+        });
+        expect(result).toEqual({ x: -110, y: 0 });
+    });
+
+    it('should respond to ArrowDown', () => {
+        const result = customCoordinatesGetter(new KeyboardEvent(KeyboardCode.Down, { code: KeyboardCode.Down }), {
+            active,
+            currentCoordinates: initialCoordinates,
+            context,
+        });
+        expect(result).toEqual({ x: 0, y: 220 });
+    });
+
+    it('should respond to ArrowUp', () => {
+        const result = customCoordinatesGetter(new KeyboardEvent(KeyboardCode.Up, { code: KeyboardCode.Up }), {
+            active,
+            currentCoordinates: initialCoordinates,
+            context,
+        });
+        expect(result).toEqual({ x: 0, y: -220 });
+    });
+
+    it('should return undefined for other keys', () => {
+        const result = customCoordinatesGetter(new KeyboardEvent(KeyboardCode.Enter, { code: KeyboardCode.Enter }), {
+            active,
+            currentCoordinates: initialCoordinates,
+            context,
+        });
+        expect(result).toBeUndefined();
+    });
+});

--- a/packages/shared/src/utils/customCoordinatesGetterFactory.ts
+++ b/packages/shared/src/utils/customCoordinatesGetterFactory.ts
@@ -1,0 +1,39 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { KeyboardCode, type KeyboardCoordinateGetter } from '@dnd-kit/core';
+
+const directions: string[] = [KeyboardCode.Down, KeyboardCode.Right, KeyboardCode.Up, KeyboardCode.Left];
+
+export const customCoordinatesGetterFactory =
+    (columnGap: number, rowGap: number): KeyboardCoordinateGetter =>
+    (event, { currentCoordinates, context: { activeNode } }) => {
+        event.preventDefault();
+        if (directions.includes(event.code)) {
+            const width = activeNode?.offsetWidth ?? 0;
+            const height = activeNode?.offsetHeight ?? 0;
+
+            switch (event.code as KeyboardCode) {
+                case KeyboardCode.Right:
+                    return {
+                        ...currentCoordinates,
+                        x: currentCoordinates.x + width + columnGap,
+                    };
+                case KeyboardCode.Left:
+                    return {
+                        ...currentCoordinates,
+                        x: currentCoordinates.x - width - columnGap,
+                    };
+                case KeyboardCode.Down:
+                    return {
+                        ...currentCoordinates,
+                        y: currentCoordinates.y + height + rowGap,
+                    };
+                case KeyboardCode.Up:
+                    return {
+                        ...currentCoordinates,
+                        y: currentCoordinates.y - height - rowGap,
+                    };
+            }
+        }
+        return undefined;
+    };

--- a/packages/thumbnail-grid-block/src/ThumbnailGridBlock.tsx
+++ b/packages/thumbnail-grid-block/src/ThumbnailGridBlock.tsx
@@ -11,8 +11,8 @@ import {
     useEditorState,
     usePrivacySettings,
 } from '@frontify/app-bridge';
-import { type BlockProps, Security, gutterSpacingStyleMap, useDndSensors } from '@frontify/guideline-blocks-settings';
-import { generateRandomId, StyleProvider } from '@frontify/guideline-blocks-shared';
+import { type BlockProps, Security, gutterSpacingStyleMap } from '@frontify/guideline-blocks-settings';
+import { generateRandomId, StyleProvider, useDndSensors } from '@frontify/guideline-blocks-shared';
 import { useCallback, useEffect, useState } from 'react';
 
 import { Grid, Item, SortableItem } from './components/';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1135,6 +1135,9 @@ importers:
       '@codemirror/lang-css':
         specifier: ^6.3.1
         version: 6.3.1
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@frontify/app-bridge':
         specifier: ^4.0.0-alpha.64
         version: 4.0.0-alpha.65(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sinon@21.0.3)


### PR DESCRIPTION
Moving the `useDndSensor` hook from `brand-sdk` to `shared` package of this repo.