### PR TITLE
chore: move mapColorPalettes from guideline-blocks-settings to gradient block

### DIFF
--- a/packages/gradient-block/src/GradientBlock.tsx
+++ b/packages/gradient-block/src/GradientBlock.tsx
@@ -3,13 +3,14 @@
 import { useBlockSettings, useColorPalettes, useEditorState } from '@frontify/app-bridge';
 import { type Palette } from '@frontify/fondue';
 import { Divider } from '@frontify/fondue/components';
-import { type BlockProps, mapAppBridgeColorPalettesToFonduePalettes } from '@frontify/guideline-blocks-settings';
+import { type BlockProps } from '@frontify/guideline-blocks-settings';
 import { CssValueDisplay, StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type MouseEvent, type ReactElement, useEffect, useRef, useState } from 'react';
 
 import { AddColorButton, ColorFlyout, ColorTooltip, SquareBadgesRow } from './components';
 import { DEFAULT_GRADIENT_COLORS, DEFAULT_HEIGHT_VALUE, DEFAULT_ORIENTATION_VALUE } from './constants';
 import { parseGradientColorsToCss, toHex6or8String } from './helpers';
+import { mapAppBridgeColorPalettesToFonduePalettes } from './helpers/mapColorPalettes';
 import { type GradientColor, type Settings, gradientHeightValues, gradientOrientationValues } from './types';
 
 export const GradientBlock = ({ appBridge }: BlockProps): ReactElement => {

--- a/packages/gradient-block/src/helpers/mapColorPalettes.spec.ts
+++ b/packages/gradient-block/src/helpers/mapColorPalettes.spec.ts
@@ -1,0 +1,48 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { ColorDummy } from '@frontify/app-bridge';
+import { describe, expect, it } from 'vitest';
+
+import { mapAppBridgeColorPalettesToFonduePalettes } from './mapColorPalettes';
+
+describe('mapAppBridgeColorPalettesToFonduePalettes', () => {
+    it('should map app bridge color palette to fondue palette', () => {
+        const result = mapAppBridgeColorPalettesToFonduePalettes([
+            {
+                id: 19,
+                name: 'Awesome color palette',
+                description: 'This is an awesome color palette',
+                colors: [ColorDummy.green(), ColorDummy.yellow(), ColorDummy.red()],
+            },
+        ]);
+        expect(result).toEqual([
+            {
+                id: 19,
+                title: 'Awesome color palette',
+                colors: [
+                    {
+                        alpha: 1,
+                        blue: 0,
+                        green: 255,
+                        red: 0,
+                        name: 'Green',
+                    },
+                    {
+                        alpha: 1,
+                        blue: 0,
+                        green: 255,
+                        red: 255,
+                        name: 'Yellow',
+                    },
+                    {
+                        alpha: 1,
+                        blue: 0,
+                        green: 0,
+                        red: 255,
+                        name: 'Red',
+                    },
+                ],
+            },
+        ]);
+    });
+});

--- a/packages/gradient-block/src/helpers/mapColorPalettes.ts
+++ b/packages/gradient-block/src/helpers/mapColorPalettes.ts
@@ -1,0 +1,66 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { type ColorPalette } from '@frontify/app-bridge';
+import { type Palette } from '@frontify/fondue';
+
+type Nullable<T> = T | null;
+
+type V3Color = {
+    id: number;
+    name: Nullable<string>;
+    red: Nullable<number>;
+    green: Nullable<number>;
+    blue: Nullable<number>;
+    alpha: Nullable<number>;
+};
+
+type V4Color = {
+    id: number;
+    title: Nullable<string>;
+    revision: {
+        rgba: {
+            red: Nullable<number>;
+            green: Nullable<number>;
+            blue: Nullable<number>;
+            alpha: Nullable<number>;
+        };
+    };
+};
+
+type Color = V3Color | V4Color;
+
+export const mapAppBridgeColorPalettesToFonduePalettes = (colorPalettes: ColorPalette[]): Palette[] => {
+    return colorPalettes.map(mapAppBridgeColorPaletteToFonduePalette);
+};
+
+const mapAppBridgeColorPaletteToFonduePalette = (colorPalette: ColorPalette): Palette => {
+    return {
+        id: colorPalette.id,
+        title: colorPalette.name,
+        colors: colorPalette.colors.map(mapColor),
+    };
+};
+
+const isV4Color = (color: Color): color is V4Color => {
+    return 'revision' in color;
+};
+
+const mapColor = (color: Color) => {
+    if (isV4Color(color)) {
+        const { title, revision } = color;
+        return {
+            alpha: revision.rgba.alpha ? revision.rgba.alpha / 255 : 1,
+            red: revision.rgba.red ?? 0,
+            green: revision.rgba.green ?? 0,
+            blue: revision.rgba.blue ?? 0,
+            name: title ?? '',
+        };
+    }
+    return {
+        alpha: color.alpha ? color.alpha / 255 : 1,
+        red: color.red ?? 0,
+        green: color.green ?? 0,
+        blue: color.blue ?? 0,
+        name: color.name ?? '',
+    };
+};


### PR DESCRIPTION
Gradient block is the only consumer of this helper so we're moving it close to it, no reason to live in `brand-sdk/guideline-blocks-settings`.