### PR TITLE
feat(*): remove modal extensions from postcss scoping

### DIFF
--- a/examples/asset-upload/block-scope.json
+++ b/examples/asset-upload/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "example-asset-upload"
+}

--- a/examples/asset-upload/postcss.config.js
+++ b/examples/asset-upload/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.example-asset-upload' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/examples/asset-upload/src/ExampleAssetUploadBlock.tsx
+++ b/examples/asset-upload/src/ExampleAssetUploadBlock.tsx
@@ -6,6 +6,8 @@ import { type BlockProps } from '@frontify/guideline-blocks-settings';
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type ReactElement, useEffect, useState } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { IMAGE_SETTING_ID } from './settings';
 
 export const ExampleAssetUploadBlock = ({ appBridge }: BlockProps): ReactElement => {
@@ -66,44 +68,42 @@ export const ExampleAssetUploadBlock = ({ appBridge }: BlockProps): ReactElement
     };
 
     return (
-        <div className="example-asset-upload">
-            <StyleProvider>
-                <div className="tw-flex tw-flex-col tw-gap-4">
-                    <div className="tw-flex tw-gap-4">
-                        <Button onPress={onOpenAssetChooser}>Open asset chooser</Button>
-                        <Button onPress={openFileDialog} disabled={loading}>
-                            {loading ? 'Uploading...' : 'Upload'}
-                        </Button>
-                    </div>
+        <StyleProvider scope={blockScope.scope}>
+            <div className="tw-flex tw-flex-col tw-gap-4">
+                <div className="tw-flex tw-gap-4">
+                    <Button onPress={onOpenAssetChooser}>Open asset chooser</Button>
+                    <Button onPress={openFileDialog} disabled={loading}>
+                        {loading ? 'Uploading...' : 'Upload'}
+                    </Button>
+                </div>
 
-                    <div data-test-id="example-asset-upload-block">
-                        {blockAssets[IMAGE_SETTING_ID] ? (
-                            blockAssets[IMAGE_SETTING_ID].map((asset: Asset) => (
-                                <div key={asset.id}>
-                                    <img
-                                        src={asset.previewUrl}
-                                        alt={asset.title}
-                                        data-test-id="example-asset-upload-image"
-                                    />
-                                    <div className="tw-flex tw-flex-col tw-gap-4">
-                                        <strong>{asset.title}</strong>
-                                        <div className="tw-flex tw-gap-4">
-                                            {/* oxlint-disable-next-line @eslint-react/static-components */}
-                                            <Link link={asset.previewUrl} text="Preview URL" />
-                                            {/* oxlint-disable-next-line @eslint-react/static-components */}
-                                            <Link link={asset.genericUrl} text="Generic URL" />
-                                            {/* oxlint-disable-next-line @eslint-react/static-components */}
-                                            {asset.originUrl && <Link link={asset.originUrl} text="Origin URL" />}
-                                        </div>
+                <div data-test-id="example-asset-upload-block">
+                    {blockAssets[IMAGE_SETTING_ID] ? (
+                        blockAssets[IMAGE_SETTING_ID].map((asset: Asset) => (
+                            <div key={asset.id}>
+                                <img
+                                    src={asset.previewUrl}
+                                    alt={asset.title}
+                                    data-test-id="example-asset-upload-image"
+                                />
+                                <div className="tw-flex tw-flex-col tw-gap-4">
+                                    <strong>{asset.title}</strong>
+                                    <div className="tw-flex tw-gap-4">
+                                        {/* oxlint-disable-next-line @eslint-react/static-components */}
+                                        <Link link={asset.previewUrl} text="Preview URL" />
+                                        {/* oxlint-disable-next-line @eslint-react/static-components */}
+                                        <Link link={asset.genericUrl} text="Generic URL" />
+                                        {/* oxlint-disable-next-line @eslint-react/static-components */}
+                                        {asset.originUrl && <Link link={asset.originUrl} text="Origin URL" />}
                                     </div>
                                 </div>
-                            ))
-                        ) : (
-                            <p>No image set</p>
-                        )}
-                    </div>
+                            </div>
+                        ))
+                    ) : (
+                        <p>No image set</p>
+                    )}
                 </div>
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/animation-curve-block/block-scope.json
+++ b/packages/animation-curve-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "animation-curve-block"
+}

--- a/packages/animation-curve-block/postcss.config.js
+++ b/packages/animation-curve-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.animation-curve-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/animation-curve-block/src/AnimationCurveBlock.tsx
+++ b/packages/animation-curve-block/src/AnimationCurveBlock.tsx
@@ -8,6 +8,8 @@ import { type BlockProps, gutterSpacingStyleMap } from '@frontify/guideline-bloc
 import { StyleProvider, useDndSensors } from '@frontify/guideline-blocks-shared';
 import { useState } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { BlankSlate, Card, SortableCard } from './components';
 import { gridClasses } from './constants';
 import { type AnimationCurve, type AnimationCurvePatch, type Settings } from './types';
@@ -56,7 +58,7 @@ export const AnimationCurveBlock = ({ appBridge }: BlockProps) => {
     };
 
     return (
-        <StyleProvider className="animation-curve-block">
+        <StyleProvider scope={blockScope.scope}>
             <div className="tw-@container">
                 <DndContext
                     sensors={sensors}

--- a/packages/animation-curve-block/src/AnimationCurveBlock.tsx
+++ b/packages/animation-curve-block/src/AnimationCurveBlock.tsx
@@ -56,8 +56,8 @@ export const AnimationCurveBlock = ({ appBridge }: BlockProps) => {
     };
 
     return (
-        <div className="animation-curve-block tw-@container">
-            <StyleProvider>
+        <StyleProvider className="animation-curve-block">
+            <div className="tw-@container">
                 <DndContext
                     sensors={sensors}
                     collisionDetection={closestCenter}
@@ -114,7 +114,7 @@ export const AnimationCurveBlock = ({ appBridge }: BlockProps) => {
                         )}
                     </div>
                 </DndContext>
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/asset-kit-block/block-scope.json
+++ b/packages/asset-kit-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "asset-kit-block"
+}

--- a/packages/asset-kit-block/postcss.config.js
+++ b/packages/asset-kit-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.asset-kit-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -19,6 +19,8 @@ import {
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type ReactElement, useEffect, useRef, useState } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { AssetGrid, AssetSelection, DownloadMessage, InformationSection } from './components';
 import { blockStyle } from './helpers';
 import { ASSET_SETTINGS_ID } from './settings';
@@ -89,7 +91,7 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement | null =>
     }
 
     return (
-        <StyleProvider className="asset-kit-block">
+        <StyleProvider scope={blockScope.scope}>
             <div
                 data-test-id="asset-kit-block"
                 className={joinClassNames([

--- a/packages/asset-kit-block/src/AssetKitBlock.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.tsx
@@ -89,91 +89,89 @@ export const AssetKitBlock = ({ appBridge }: BlockProps): ReactElement | null =>
     }
 
     return (
-        <div className="asset-kit-block">
-            <StyleProvider>
-                <div
-                    data-test-id="asset-kit-block"
-                    className={joinClassNames([
-                        'tw-w-full tw-space-y-8',
-                        (hasBorder_blocks || hasBackgroundBlocks) && 'tw-p-5 sm:tw-p-8',
-                    ])}
-                    style={{
-                        ...blockStyle(blockSettings),
-                    }}
-                >
-                    <div className="sm:tw-flex tw-gap-8 tw-space-y-3 md:tw-space-y-0">
-                        <InformationSection
-                            description={description}
-                            isEditing={isEditing}
-                            setBlockSettings={setBlockSettings}
-                            title={title}
-                            appBridge={appBridge}
-                        />
-                        <div className="tw-flex-none">
-                            <button
-                                type="button"
-                                data-test-id="asset-kit-block-download-button"
-                                className="[&>div]:!tw-@container-normal"
-                                disabled={isButtonDisabled}
-                                onClick={isEditing ? undefined : startDownload}
-                                onMouseEnter={() => setButtonHover(true)}
-                                onMouseLeave={() => setButtonHover(false)}
-                                style={{
-                                    ...BlockStyles.buttonPrimary,
-                                    ...(buttonHover ? BlockStyles.buttonPrimary?.hover : null),
-                                    ...(isButtonDisabled ? { opacity: 0.5 } : null),
-                                    overflow: 'visible',
-                                }}
-                            >
-                                <RichTextEditor
-                                    id={`asset-kit-block-download-button-text-${appBridge.context('blockId').get()}`}
-                                    value={
-                                        hasRichTextValue(buttonText)
-                                            ? buttonText
-                                            : convertToRteValue('p', 'Download package')
-                                    }
-                                    isEditing={isEditing}
-                                    plugins={new PluginComposer({ noToolbar: true }).setPlugin()}
-                                    onTextChange={(buttonText) => setBlockSettings({ buttonText })}
-                                />
-                                <span
-                                    data-test-id="asset-kit-block-screen-reader"
-                                    ref={screenReaderRef}
-                                    role="status"
-                                    className="tw-absolute -tw-left-[10000px] tw-top-auto tw-w-1 tw-h-1 tw-overflow-hidden"
-                                />
-                            </button>
-                        </div>
-                    </div>
-
-                    {![AssetBulkDownloadState.Init, AssetBulkDownloadState.Ready].includes(status) && (
-                        <DownloadMessage blockStyle={blockStyle(blockSettings)} status={status} />
-                    )}
-
-                    <div>
-                        <AssetGrid
-                            appBridge={appBridge}
-                            currentAssets={currentAssets}
-                            deleteAssetIdsFromKey={deleteAssetIdsFromKey}
-                            updateAssetIdsFromKey={updateAssetIdsFromKey}
-                            isEditing={isEditing}
-                            showThumbnails={showThumbnails}
-                            showCount={showCount}
-                            countColor={assetCountColor === 'override' ? countCustomColor : undefined}
-                        />
-
-                        {isEditing && (
-                            <AssetSelection
-                                appBridge={appBridge}
-                                isUploadingAssets={isUploadingAssets}
-                                setIsUploadingAssets={setIsUploadingAssets}
-                                addAssetIdsToKey={addAssetIdsToKey}
-                                currentAssets={currentAssets}
+        <StyleProvider className="asset-kit-block">
+            <div
+                data-test-id="asset-kit-block"
+                className={joinClassNames([
+                    'tw-w-full tw-space-y-8',
+                    (hasBorder_blocks || hasBackgroundBlocks) && 'tw-p-5 sm:tw-p-8',
+                ])}
+                style={{
+                    ...blockStyle(blockSettings),
+                }}
+            >
+                <div className="sm:tw-flex tw-gap-8 tw-space-y-3 md:tw-space-y-0">
+                    <InformationSection
+                        description={description}
+                        isEditing={isEditing}
+                        setBlockSettings={setBlockSettings}
+                        title={title}
+                        appBridge={appBridge}
+                    />
+                    <div className="tw-flex-none">
+                        <button
+                            type="button"
+                            data-test-id="asset-kit-block-download-button"
+                            className="[&>div]:!tw-@container-normal"
+                            disabled={isButtonDisabled}
+                            onClick={isEditing ? undefined : startDownload}
+                            onMouseEnter={() => setButtonHover(true)}
+                            onMouseLeave={() => setButtonHover(false)}
+                            style={{
+                                ...BlockStyles.buttonPrimary,
+                                ...(buttonHover ? BlockStyles.buttonPrimary?.hover : null),
+                                ...(isButtonDisabled ? { opacity: 0.5 } : null),
+                                overflow: 'visible',
+                            }}
+                        >
+                            <RichTextEditor
+                                id={`asset-kit-block-download-button-text-${appBridge.context('blockId').get()}`}
+                                value={
+                                    hasRichTextValue(buttonText)
+                                        ? buttonText
+                                        : convertToRteValue('p', 'Download package')
+                                }
+                                isEditing={isEditing}
+                                plugins={new PluginComposer({ noToolbar: true }).setPlugin()}
+                                onTextChange={(buttonText) => setBlockSettings({ buttonText })}
                             />
-                        )}
+                            <span
+                                data-test-id="asset-kit-block-screen-reader"
+                                ref={screenReaderRef}
+                                role="status"
+                                className="tw-absolute -tw-left-[10000px] tw-top-auto tw-w-1 tw-h-1 tw-overflow-hidden"
+                            />
+                        </button>
                     </div>
                 </div>
-            </StyleProvider>
-        </div>
+
+                {![AssetBulkDownloadState.Init, AssetBulkDownloadState.Ready].includes(status) && (
+                    <DownloadMessage blockStyle={blockStyle(blockSettings)} status={status} />
+                )}
+
+                <div>
+                    <AssetGrid
+                        appBridge={appBridge}
+                        currentAssets={currentAssets}
+                        deleteAssetIdsFromKey={deleteAssetIdsFromKey}
+                        updateAssetIdsFromKey={updateAssetIdsFromKey}
+                        isEditing={isEditing}
+                        showThumbnails={showThumbnails}
+                        showCount={showCount}
+                        countColor={assetCountColor === 'override' ? countCustomColor : undefined}
+                    />
+
+                    {isEditing && (
+                        <AssetSelection
+                            appBridge={appBridge}
+                            isUploadingAssets={isUploadingAssets}
+                            setIsUploadingAssets={setIsUploadingAssets}
+                            addAssetIdsToKey={addAssetIdsToKey}
+                            currentAssets={currentAssets}
+                        />
+                    )}
+                </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/audio-block/block-scope.json
+++ b/packages/audio-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "audio-block"
+}

--- a/packages/audio-block/postcss.config.js
+++ b/packages/audio-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.audio-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/audio-block/src/AudioBlock.tsx
+++ b/packages/audio-block/src/AudioBlock.tsx
@@ -26,6 +26,8 @@ import {
 import { DownloadButton, generateRandomId, StyleProvider } from '@frontify/guideline-blocks-shared';
 import { useEffect, useState } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { AudioPlayer, BlockAttachments, UploadPlaceholder } from './components';
 import { getDescriptionPlugins, titlePlugins } from './helpers/plugins';
 import { ATTACHMENTS_ASSET_ID, AUDIO_ID } from './settings';
@@ -123,7 +125,7 @@ export const AudioBlock = ({ appBridge }: BlockProps) => {
             assetId={ATTACHMENTS_ASSET_ID}
             appBridge={appBridge}
         >
-            <StyleProvider className="audio-block">
+            <StyleProvider scope={blockScope.scope}>
                 <div
                     data-test-id="audio-block"
                     className={joinClassNames([

--- a/packages/audio-block/src/AudioBlock.tsx
+++ b/packages/audio-block/src/AudioBlock.tsx
@@ -123,81 +123,77 @@ export const AudioBlock = ({ appBridge }: BlockProps) => {
             assetId={ATTACHMENTS_ASSET_ID}
             appBridge={appBridge}
         >
-            <div className="audio-block">
-                <StyleProvider>
-                    <div
-                        data-test-id="audio-block"
-                        className={joinClassNames([
-                            'tw-flex tw-gap-3',
-                            blockSettings.positioning === TextPosition.Below ? 'tw-flex-col' : 'tw-flex-col-reverse',
-                        ])}
-                    >
-                        {audio ? (
-                            <AudioPlayer
-                                audio={audio}
-                                isEditing={isEditing}
-                                isLoading={isLoading}
-                                openFileDialog={openFileDialog}
-                                openAssetChooser={onOpenAssetChooser}
-                                onRemoveAsset={onRemoveAsset}
+            <StyleProvider className="audio-block">
+                <div
+                    data-test-id="audio-block"
+                    className={joinClassNames([
+                        'tw-flex tw-gap-3',
+                        blockSettings.positioning === TextPosition.Below ? 'tw-flex-col' : 'tw-flex-col-reverse',
+                    ])}
+                >
+                    {audio ? (
+                        <AudioPlayer
+                            audio={audio}
+                            isEditing={isEditing}
+                            isLoading={isLoading}
+                            openFileDialog={openFileDialog}
+                            openAssetChooser={onOpenAssetChooser}
+                            onRemoveAsset={onRemoveAsset}
+                        />
+                    ) : (
+                        isEditing && (
+                            <UploadPlaceholder
+                                onUploadClick={openFileDialog}
+                                onAssetChooseClick={onOpenAssetChooser}
+                                onFilesDrop={onFilesDrop}
+                                loading={isLoading}
                             />
-                        ) : (
-                            isEditing && (
-                                <UploadPlaceholder
-                                    onUploadClick={openFileDialog}
-                                    onAssetChooseClick={onOpenAssetChooser}
-                                    onFilesDrop={onFilesDrop}
-                                    loading={isLoading}
+                        )
+                    )}
+                    <div className="tw-flex tw-gap-4 tw-justify-between tw-w-full tw-relative">
+                        <div className="tw-flex-1">
+                            <div data-test-id="block-title">
+                                <RichTextEditor
+                                    key={titleKey}
+                                    id={`${blockId}-title`}
+                                    plugins={titlePlugins}
+                                    isEditing={isEditing}
+                                    onTextChange={onTitleChange}
+                                    value={titleValue}
+                                    placeholder="Asset name"
+                                    showSerializedText={hasRichTextValue(titleValue)}
                                 />
-                            )
-                        )}
-                        <div className="tw-flex tw-gap-4 tw-justify-between tw-w-full tw-relative">
-                            <div className="tw-flex-1">
-                                <div data-test-id="block-title">
-                                    <RichTextEditor
-                                        key={titleKey}
-                                        id={`${blockId}-title`}
-                                        plugins={titlePlugins}
-                                        isEditing={isEditing}
-                                        onTextChange={onTitleChange}
-                                        value={titleValue}
-                                        placeholder="Asset name"
-                                        showSerializedText={hasRichTextValue(titleValue)}
-                                    />
-                                </div>
-
-                                <div data-test-id="block-description">
-                                    <RichTextEditor
-                                        id={`${blockId}-description`}
-                                        plugins={getDescriptionPlugins(appBridge)}
-                                        isEditing={isEditing}
-                                        onTextChange={onDescriptionChange}
-                                        value={descriptionValue}
-                                        placeholder="Add a description here"
-                                        showSerializedText={hasRichTextValue(descriptionValue)}
-                                    />
-                                </div>
                             </div>
-                            {audio && !isEditing && (
-                                <div className="tw-flex tw-gap-2 tw-leading-normal" data-test-id="view-mode-addons">
-                                    {isDownloadable(
-                                        blockSettings.security,
-                                        blockSettings.downloadable,
-                                        assetDownloadEnabled
-                                    ) && (
-                                        <DownloadButton
-                                            onDownload={() =>
-                                                appBridge.dispatch({ name: 'downloadAsset', payload: audio })
-                                            }
-                                        />
-                                    )}
-                                    <BlockAttachments appBridge={appBridge} />
-                                </div>
-                            )}
+
+                            <div data-test-id="block-description">
+                                <RichTextEditor
+                                    id={`${blockId}-description`}
+                                    plugins={getDescriptionPlugins(appBridge)}
+                                    isEditing={isEditing}
+                                    onTextChange={onDescriptionChange}
+                                    value={descriptionValue}
+                                    placeholder="Add a description here"
+                                    showSerializedText={hasRichTextValue(descriptionValue)}
+                                />
+                            </div>
                         </div>
+                        {audio && !isEditing && (
+                            <div className="tw-flex tw-gap-2 tw-leading-normal" data-test-id="view-mode-addons">
+                                {isDownloadable(
+                                    blockSettings.security,
+                                    blockSettings.downloadable,
+                                    assetDownloadEnabled
+                                ) && (
+                                    <DownloadButton
+                                        onDownload={() => appBridge.dispatch({ name: 'downloadAsset', payload: audio })}
+                                    />
+                                )}
+                                <BlockAttachments appBridge={appBridge} />
+                            </div>
+                        )}
                     </div>
-                </StyleProvider>
-            </div>
+                </div>
+            </StyleProvider>
         </AttachmentOperationsProvider>
     );
 };

--- a/packages/callout-block/block-scope.json
+++ b/packages/callout-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "callout-block"
+}

--- a/packages/callout-block/postcss.config.js
+++ b/packages/callout-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.callout-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/callout-block/src/CalloutBlock.tsx
+++ b/packages/callout-block/src/CalloutBlock.tsx
@@ -13,6 +13,8 @@ import {
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type CSSProperties, type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { CalloutIcon } from './components/CalloutIcon';
 import { computeStyles } from './helpers/color';
 import { isThemeEnabled } from './helpers/theme';
@@ -157,7 +159,7 @@ export const CalloutBlock = ({ appBridge }: BlockProps): ReactElement => {
     const iconType = blockSettings.iconSwitch ? Icon.Custom : blockSettings.iconType;
 
     return (
-        <StyleProvider className="callout-block">
+        <StyleProvider scope={blockScope.scope}>
             <div ref={hostElement}>
                 <div
                     data-test-id="callout-block"

--- a/packages/callout-block/src/CalloutBlock.tsx
+++ b/packages/callout-block/src/CalloutBlock.tsx
@@ -157,8 +157,8 @@ export const CalloutBlock = ({ appBridge }: BlockProps): ReactElement => {
     const iconType = blockSettings.iconSwitch ? Icon.Custom : blockSettings.iconType;
 
     return (
-        <div ref={hostElement} className="callout-block">
-            <StyleProvider>
+        <StyleProvider className="callout-block">
+            <div ref={hostElement}>
                 <div
                     data-test-id="callout-block"
                     style={{
@@ -189,7 +189,7 @@ export const CalloutBlock = ({ appBridge }: BlockProps): ReactElement => {
                         />
                     </div>
                 </div>
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/code-snippet-block/block-scope.json
+++ b/packages/code-snippet-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "code-snippet-block"
+}

--- a/packages/code-snippet-block/postcss.config.js
+++ b/packages/code-snippet-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.code-snippet-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/code-snippet-block/src/CodeSnippetBlock.tsx
+++ b/packages/code-snippet-block/src/CodeSnippetBlock.tsx
@@ -13,6 +13,8 @@ import CodeMirror from '@uiw/react-codemirror';
 import debounce from 'lodash-es/debounce';
 import { type FC, useEffect, useMemo, useState } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { DEFAULT_BORDER_COLOR } from './constants';
 import { headerThemes } from './headerThemes';
 import { useCodeMirrorExtensions } from './hooks/useCodeMirrorExtensions';
@@ -89,7 +91,7 @@ export const CodeSnippetBlock: FC<BlockProps> = ({ appBridge }) => {
     };
 
     return (
-        <StyleProvider className="code-snippet-block">
+        <StyleProvider scope={blockScope.scope}>
             <div
                 data-test-id="code-snippet-block"
                 className="tw-overflow-hidden"

--- a/packages/code-snippet-block/src/CodeSnippetBlock.tsx
+++ b/packages/code-snippet-block/src/CodeSnippetBlock.tsx
@@ -89,124 +89,122 @@ export const CodeSnippetBlock: FC<BlockProps> = ({ appBridge }) => {
     };
 
     return (
-        <div className="code-snippet-block">
-            <StyleProvider>
-                <div
-                    data-test-id="code-snippet-block"
-                    className="tw-overflow-hidden"
-                    style={{
-                        fontFamily: 'Menlo, Courier, monospace',
-                        fontSize: '12px',
-                        border: hasBorder
-                            ? `${borderStyle} ${borderWidth} ${toRgbaString(borderColor || DEFAULT_BORDER_COLOR)}`
-                            : 'none',
-                        borderRadius: customCornerRadiusStyle.borderRadius,
-                    }}
-                >
-                    <div className={merge(['tw-relative tw-group/copy', !isEditing && 'CodeMirror-readonly'])}>
-                        {withHeading && (
-                            <div
-                                data-test-id="code-snippet-header"
-                                className="tw-py-2 tw-px-3 tw-bg-black-5 tw-border-b tw-border-black-10 tw-text-small tw-flex tw-justify-between tw-items-center"
-                                style={{ ...getStyle(), letterSpacing: 'normal' }}
-                            >
-                                {isEditing ? (
-                                    <div
-                                        id={labelId}
-                                        className="tw-max-w-[150px]"
-                                        style={
-                                            {
-                                                '--base-color': getStyle().backgroundColor,
-                                                '--text-color': getStyle().color,
-                                                '--line-color-xx-strong': setAlpha(0.8, getStyle().color),
-                                            } as React.CSSProperties
-                                        }
+        <StyleProvider className="code-snippet-block">
+            <div
+                data-test-id="code-snippet-block"
+                className="tw-overflow-hidden"
+                style={{
+                    fontFamily: 'Menlo, Courier, monospace',
+                    fontSize: '12px',
+                    border: hasBorder
+                        ? `${borderStyle} ${borderWidth} ${toRgbaString(borderColor || DEFAULT_BORDER_COLOR)}`
+                        : 'none',
+                    borderRadius: customCornerRadiusStyle.borderRadius,
+                }}
+            >
+                <div className={merge(['tw-relative tw-group/copy', !isEditing && 'CodeMirror-readonly'])}>
+                    {withHeading && (
+                        <div
+                            data-test-id="code-snippet-header"
+                            className="tw-py-2 tw-px-3 tw-bg-black-5 tw-border-b tw-border-black-10 tw-text-small tw-flex tw-justify-between tw-items-center"
+                            style={{ ...getStyle(), letterSpacing: 'normal' }}
+                        >
+                            {isEditing ? (
+                                <div
+                                    id={labelId}
+                                    className="tw-max-w-[150px]"
+                                    style={
+                                        {
+                                            '--base-color': getStyle().backgroundColor,
+                                            '--text-color': getStyle().color,
+                                            '--line-color-xx-strong': setAlpha(0.8, getStyle().color),
+                                        } as React.CSSProperties
+                                    }
+                                >
+                                    <Select
+                                        value={selectedLanguage}
+                                        onSelect={(value) => handleLanguageChange(value as Language)}
                                     >
-                                        <Select
-                                            value={selectedLanguage}
-                                            onSelect={(value) => handleLanguageChange(value as Language)}
+                                        {Object.entries(languageNameMap).map(([value, label]) => (
+                                            <Select.Item value={value} key={value}>
+                                                {label}
+                                            </Select.Item>
+                                        ))}
+                                    </Select>
+                                </div>
+                            ) : (
+                                <span id={labelId}>{languageNameMap[selectedLanguage]}</span>
+                            )}
+                            <button
+                                type="button"
+                                data-test-id="header-copy-button"
+                                className="tw-items-center tw-justify-end tw-gap-1 tw-flex"
+                                style={{
+                                    ...getStyle(),
+                                    color: blockSettings.theme === 'default' ? '#000000' : getStyle().color,
+                                }}
+                                onClick={handleCopy}
+                            >
+                                {getCopyButtonText()}
+                            </button>
+                        </div>
+                    )}
+                    <CodeMirror
+                        theme={getTheme()}
+                        value={contentValue}
+                        extensions={extensions}
+                        onChange={handleChange}
+                        readOnly={!isEditing}
+                        basicSetup={{
+                            lineNumbers: withRowNumbers,
+                            searchKeymap: false,
+                            highlightActiveLineGutter: false,
+                            highlightActiveLine: false,
+                            lintKeymap: false,
+                            autocompletion: false,
+                            syntaxHighlighting: true,
+                        }}
+                        onCreateEditor={(view) =>
+                            view.dom.querySelector('.cm-content')?.setAttribute('aria-labelledby', labelId)
+                        }
+                        placeholder={isEditing ? '< please add snippet here >' : ''}
+                    />
+                    {!withHeading && (
+                        <div className="tw-absolute tw-p-1 tw-dark tw-top-0 tw-right-0 tw-hidden group-hover/copy:tw-block">
+                            {blockSettings.content && (blockSettings.content.match(/\n/g) || []).length > 1 ? (
+                                <Tooltip.Root
+                                    open={isCopyTooltipOpen}
+                                    onOpenChange={setIsCopyTooltipOpen}
+                                    enterDelay={0}
+                                >
+                                    <Tooltip.Trigger>
+                                        <button
+                                            type="button"
+                                            data-test-id="copy-button"
+                                            className="tw-p-2 tw-rounded-md"
+                                            style={getStyle()}
+                                            onClick={handleCopy}
                                         >
-                                            {Object.entries(languageNameMap).map(([value, label]) => (
-                                                <Select.Item value={value} key={value}>
-                                                    {label}
-                                                </Select.Item>
-                                            ))}
-                                        </Select>
-                                    </div>
-                                ) : (
-                                    <span id={labelId}>{languageNameMap[selectedLanguage]}</span>
-                                )}
+                                            {isCopied ? <IconCheckMark /> : <IconClipboard />}
+                                        </button>
+                                    </Tooltip.Trigger>
+                                    <Tooltip.Content>{isCopied ? 'Copied' : 'Copy to clipboard'}</Tooltip.Content>
+                                </Tooltip.Root>
+                            ) : (
                                 <button
                                     type="button"
-                                    data-test-id="header-copy-button"
-                                    className="tw-items-center tw-justify-end tw-gap-1 tw-flex"
-                                    style={{
-                                        ...getStyle(),
-                                        color: blockSettings.theme === 'default' ? '#000000' : getStyle().color,
-                                    }}
+                                    className="tw-flex tw-items-center tw-justify-end tw-gap-1 tw-pr-2 tw-rounded-md"
+                                    style={getStyle()}
                                     onClick={handleCopy}
+                                    aria-live="assertive"
                                 >
                                     {getCopyButtonText()}
                                 </button>
-                            </div>
-                        )}
-                        <CodeMirror
-                            theme={getTheme()}
-                            value={contentValue}
-                            extensions={extensions}
-                            onChange={handleChange}
-                            readOnly={!isEditing}
-                            basicSetup={{
-                                lineNumbers: withRowNumbers,
-                                searchKeymap: false,
-                                highlightActiveLineGutter: false,
-                                highlightActiveLine: false,
-                                lintKeymap: false,
-                                autocompletion: false,
-                                syntaxHighlighting: true,
-                            }}
-                            onCreateEditor={(view) =>
-                                view.dom.querySelector('.cm-content')?.setAttribute('aria-labelledby', labelId)
-                            }
-                            placeholder={isEditing ? '< please add snippet here >' : ''}
-                        />
-                        {!withHeading && (
-                            <div className="tw-absolute tw-p-1 tw-dark tw-top-0 tw-right-0 tw-hidden group-hover/copy:tw-block">
-                                {blockSettings.content && (blockSettings.content.match(/\n/g) || []).length > 1 ? (
-                                    <Tooltip.Root
-                                        open={isCopyTooltipOpen}
-                                        onOpenChange={setIsCopyTooltipOpen}
-                                        enterDelay={0}
-                                    >
-                                        <Tooltip.Trigger>
-                                            <button
-                                                type="button"
-                                                data-test-id="copy-button"
-                                                className="tw-p-2 tw-rounded-md"
-                                                style={getStyle()}
-                                                onClick={handleCopy}
-                                            >
-                                                {isCopied ? <IconCheckMark /> : <IconClipboard />}
-                                            </button>
-                                        </Tooltip.Trigger>
-                                        <Tooltip.Content>{isCopied ? 'Copied' : 'Copy to clipboard'}</Tooltip.Content>
-                                    </Tooltip.Root>
-                                ) : (
-                                    <button
-                                        type="button"
-                                        className="tw-flex tw-items-center tw-justify-end tw-gap-1 tw-pr-2 tw-rounded-md"
-                                        style={getStyle()}
-                                        onClick={handleCopy}
-                                        aria-live="assertive"
-                                    >
-                                        {getCopyButtonText()}
-                                    </button>
-                                )}
-                            </div>
-                        )}
-                    </div>
+                            )}
+                        </div>
+                    )}
                 </div>
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/compare-slider-block/block-scope.json
+++ b/packages/compare-slider-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "compare-slider-block"
+}

--- a/packages/compare-slider-block/postcss.config.js
+++ b/packages/compare-slider-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.compare-slider-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/compare-slider-block/src/CompareSliderBlock.tsx
+++ b/packages/compare-slider-block/src/CompareSliderBlock.tsx
@@ -372,62 +372,60 @@ export const CompareSliderBlock = ({ appBridge }: BlockProps) => {
         );
     }
     return (
-        <div className="compare-slider-block">
-            <StyleProvider>
-                <div
-                    data-test-id="compare-slider-block"
-                    ref={setContainerRef}
-                    className="tw-w-full tw-flex tw-relative"
-                    style={{ aspectRatio }}
-                >
-                    {isFirstAssetLoaded && isSecondAssetLoaded && (
-                        <>
-                            <div
-                                data-test-id="compare-slider-block-slider"
-                                className="tw-w-full tw-overflow-hidden tw-relative [&_.handle]:focus-within:tw-ring-4 [&_.handle]:focus-within:tw-ring-offset-2"
-                                style={{
-                                    ...getBorderStyle(),
-                                    borderRadius: getBorderRadius(),
-                                }}
-                            >
-                                <ReactCompareSlider
-                                    position={currentSliderPosition}
-                                    className="tw-size-full"
-                                    onPositionChange={setCurrentSliderPosition}
-                                    itemOne={renderSliderItem(SliderImageSlot.First)}
-                                    itemTwo={renderSliderItem(SliderImageSlot.Second)}
-                                    handle={
-                                        <SliderLine
-                                            alignment={alignment}
-                                            handle={handle}
-                                            sliderColor={sliderColor || DEFAULT_LINE_COLOR}
-                                            sliderStyle={sliderStyle}
-                                            sliderWidth={sliderWidth}
-                                        />
-                                    }
-                                    portrait={alignment === Alignment.Vertical}
-                                    onlyHandleDraggable
-                                />
-                            </div>
-                            {isEditing && (
-                                <EditorOverlay
-                                    alignment={alignment}
-                                    openAssetChooser={onOpenAssetChooser}
-                                    startFileDialogUpload={startFileDialogUpload}
-                                    firstAsset={firstAsset}
-                                    secondAsset={secondAsset}
-                                    borderStyle={{ ...getBorderStyle(), borderColor: 'transparent' }}
-                                    renderLabel={renderLabel}
-                                    handleAssetDelete={handleAssetDelete}
-                                    firstAlt={firstAssetAlt}
-                                    secondAlt={secondAssetAlt}
-                                    updateImageAlt={updateImageAlt}
-                                />
-                            )}
-                        </>
-                    )}
-                </div>
-            </StyleProvider>
-        </div>
+        <StyleProvider className="compare-slider-block">
+            <div
+                data-test-id="compare-slider-block"
+                ref={setContainerRef}
+                className="tw-w-full tw-flex tw-relative"
+                style={{ aspectRatio }}
+            >
+                {isFirstAssetLoaded && isSecondAssetLoaded && (
+                    <>
+                        <div
+                            data-test-id="compare-slider-block-slider"
+                            className="tw-w-full tw-overflow-hidden tw-relative [&_.handle]:focus-within:tw-ring-4 [&_.handle]:focus-within:tw-ring-offset-2"
+                            style={{
+                                ...getBorderStyle(),
+                                borderRadius: getBorderRadius(),
+                            }}
+                        >
+                            <ReactCompareSlider
+                                position={currentSliderPosition}
+                                className="tw-size-full"
+                                onPositionChange={setCurrentSliderPosition}
+                                itemOne={renderSliderItem(SliderImageSlot.First)}
+                                itemTwo={renderSliderItem(SliderImageSlot.Second)}
+                                handle={
+                                    <SliderLine
+                                        alignment={alignment}
+                                        handle={handle}
+                                        sliderColor={sliderColor || DEFAULT_LINE_COLOR}
+                                        sliderStyle={sliderStyle}
+                                        sliderWidth={sliderWidth}
+                                    />
+                                }
+                                portrait={alignment === Alignment.Vertical}
+                                onlyHandleDraggable
+                            />
+                        </div>
+                        {isEditing && (
+                            <EditorOverlay
+                                alignment={alignment}
+                                openAssetChooser={onOpenAssetChooser}
+                                startFileDialogUpload={startFileDialogUpload}
+                                firstAsset={firstAsset}
+                                secondAsset={secondAsset}
+                                borderStyle={{ ...getBorderStyle(), borderColor: 'transparent' }}
+                                renderLabel={renderLabel}
+                                handleAssetDelete={handleAssetDelete}
+                                firstAlt={firstAssetAlt}
+                                secondAlt={secondAssetAlt}
+                                updateImageAlt={updateImageAlt}
+                            />
+                        )}
+                    </>
+                )}
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/compare-slider-block/src/CompareSliderBlock.tsx
+++ b/packages/compare-slider-block/src/CompareSliderBlock.tsx
@@ -15,6 +15,8 @@ import { ResponsiveImage, StyleProvider, useImageContainer } from '@frontify/gui
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ReactCompareSlider } from 'react-compare-slider';
 
+import blockScope from '../block-scope.json';
+
 import {
     EditorOverlay,
     Label,
@@ -372,7 +374,7 @@ export const CompareSliderBlock = ({ appBridge }: BlockProps) => {
         );
     }
     return (
-        <StyleProvider className="compare-slider-block">
+        <StyleProvider scope={blockScope.scope}>
             <div
                 data-test-id="compare-slider-block"
                 ref={setContainerRef}

--- a/packages/divider-block/block-scope.json
+++ b/packages/divider-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "divider-block"
+}

--- a/packages/divider-block/postcss.config.js
+++ b/packages/divider-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.divider-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/divider-block/src/DividerBlock.tsx
+++ b/packages/divider-block/src/DividerBlock.tsx
@@ -4,6 +4,8 @@ import { useBlockSettings } from '@frontify/app-bridge';
 import { type BlockProps, joinClassNames, toRgbaString } from '@frontify/guideline-blocks-settings';
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 
+import blockScope from '../block-scope.json';
+
 import {
     ALIGNMENT_DEFAULT_VALUE,
     COLOR_DEFAULT_RGBA_VALUE,
@@ -23,7 +25,7 @@ export const DividerBlock = ({ appBridge }: BlockProps) => {
     const [blockSettings] = useBlockSettings<Settings>(appBridge);
 
     return (
-        <StyleProvider className="divider-block">
+        <StyleProvider scope={blockScope.scope}>
             <div
                 data-test-id="divider-block"
                 className={joinClassNames([

--- a/packages/divider-block/src/DividerBlock.tsx
+++ b/packages/divider-block/src/DividerBlock.tsx
@@ -23,46 +23,44 @@ export const DividerBlock = ({ appBridge }: BlockProps) => {
     const [blockSettings] = useBlockSettings<Settings>(appBridge);
 
     return (
-        <div className="divider-block">
-            <StyleProvider>
+        <StyleProvider className="divider-block">
+            <div
+                data-test-id="divider-block"
+                className={joinClassNames([
+                    'tw-flex',
+                    css.dividerBlock,
+                    dividerAlignmentClasses[blockSettings.alignment ?? ALIGNMENT_DEFAULT_VALUE],
+                ])}
+            >
                 <div
-                    data-test-id="divider-block"
-                    className={joinClassNames([
-                        'tw-flex',
-                        css.dividerBlock,
-                        dividerAlignmentClasses[blockSettings.alignment ?? ALIGNMENT_DEFAULT_VALUE],
-                    ])}
+                    data-test-id="divider-wrapper"
+                    className="tw-flex tw-items-center tw-transition-all"
+                    style={{
+                        width: blockSettings.isWidthCustom ? blockSettings.widthCustom : blockSettings.widthSimple,
+                        height: blockSettings.isHeightCustom
+                            ? blockSettings.heightCustom
+                            : dividerHeightValues[blockSettings.heightSimple ?? HEIGHT_DEFAULT_VALUE],
+                    }}
                 >
-                    <div
-                        data-test-id="divider-wrapper"
-                        className="tw-flex tw-items-center tw-transition-all"
+                    <hr
+                        data-test-id="divider-line"
+                        className={joinClassNames([
+                            'tw-border-t tw-m-0 tw-w-full',
+                            dividerStyleClasses[
+                                blockSettings.isLine === DividerStyle.Solid
+                                    ? (blockSettings.style ?? STYLE_DEFAULT_VALUE)
+                                    : DividerStyle.NoLine
+                            ],
+                        ])}
                         style={{
-                            width: blockSettings.isWidthCustom ? blockSettings.widthCustom : blockSettings.widthSimple,
-                            height: blockSettings.isHeightCustom
-                                ? blockSettings.heightCustom
-                                : dividerHeightValues[blockSettings.heightSimple ?? HEIGHT_DEFAULT_VALUE],
+                            borderTopWidth: blockSettings.thickness,
+                            borderTopColor: blockSettings.color
+                                ? toRgbaString(blockSettings.color)
+                                : toRgbaString(COLOR_DEFAULT_RGBA_VALUE),
                         }}
-                    >
-                        <hr
-                            data-test-id="divider-line"
-                            className={joinClassNames([
-                                'tw-border-t tw-m-0 tw-w-full',
-                                dividerStyleClasses[
-                                    blockSettings.isLine === DividerStyle.Solid
-                                        ? (blockSettings.style ?? STYLE_DEFAULT_VALUE)
-                                        : DividerStyle.NoLine
-                                ],
-                            ])}
-                            style={{
-                                borderTopWidth: blockSettings.thickness,
-                                borderTopColor: blockSettings.color
-                                    ? toRgbaString(blockSettings.color)
-                                    : toRgbaString(COLOR_DEFAULT_RGBA_VALUE),
-                            }}
-                        />
-                    </div>
+                    />
                 </div>
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/dos-donts-block/block-scope.json
+++ b/packages/dos-donts-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "dos-donts-block"
+}

--- a/packages/dos-donts-block/postcss.config.js
+++ b/packages/dos-donts-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.dos-donts-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/dos-donts-block/src/DosDontsBlock.tsx
+++ b/packages/dos-donts-block/src/DosDontsBlock.tsx
@@ -372,8 +372,8 @@ export const DosDontsBlock: FC<BlockProps> = ({ appBridge }) => {
     const activeItem = localItems.find((x) => x.id === activeId);
 
     return (
-        <div ref={containerRef} className="dos-donts-block tw-@container">
-            <StyleProvider>
+        <StyleProvider className="dos-donts-block">
+            <div ref={containerRef} className="tw-@container">
                 <DndContext
                     sensors={sensors}
                     collisionDetection={closestCenter}
@@ -477,7 +477,7 @@ export const DosDontsBlock: FC<BlockProps> = ({ appBridge }) => {
                         </Dialog.Footer>
                     </Dialog.Content>
                 </Dialog.Root>
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/dos-donts-block/src/DosDontsBlock.tsx
+++ b/packages/dos-donts-block/src/DosDontsBlock.tsx
@@ -25,6 +25,8 @@ import { generateRandomId, StyleProvider, useDndSensors } from '@frontify/guidel
 import throttle from 'lodash-es/throttle';
 import { type FC, useCallback, useContext, useEffect, useRef, useState } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { AssetsContext, AssetsProvider } from './AssetsProvider';
 import { CONTAINER_SMALL_LIMIT, DONT_ICON_ASSET_KEY, DO_ICON_ASSET_KEY } from './const';
 import { DoDontItem, SortableDoDontItem } from './DoDontItem';
@@ -372,7 +374,7 @@ export const DosDontsBlock: FC<BlockProps> = ({ appBridge }) => {
     const activeItem = localItems.find((x) => x.id === activeId);
 
     return (
-        <StyleProvider className="dos-donts-block">
+        <StyleProvider scope={blockScope.scope}>
             <div ref={containerRef} className="tw-@container">
                 <DndContext
                     sensors={sensors}

--- a/packages/figma-block/block-scope.json
+++ b/packages/figma-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "figma-block"
+}

--- a/packages/figma-block/postcss.config.js
+++ b/packages/figma-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.figma-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/figma-block/src/FigmaBlock.tsx
+++ b/packages/figma-block/src/FigmaBlock.tsx
@@ -13,6 +13,8 @@ import { type BlockProps } from '@frontify/guideline-blocks-settings';
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type ReactElement, useEffect, useMemo, useRef, useState } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { FigmaImagePreview } from './components/FigmaImagePreview';
 import { FigmaLiveModal } from './components/FigmaLiveModal';
 import { FigmaLivePreview } from './components/FigmaLivePreview';
@@ -98,7 +100,7 @@ export const FigmaBlock = ({ appBridge }: BlockProps): ReactElement => {
     };
 
     return (
-        <StyleProvider className="figma-block">
+        <StyleProvider scope={blockScope.scope}>
             <div ref={ref} data-test-id="figma-block">
                 {referenceUrl ? (
                     <ReferenceErrorMessage originalUrl={referenceUrl} />

--- a/packages/figma-block/src/FigmaBlock.tsx
+++ b/packages/figma-block/src/FigmaBlock.tsx
@@ -98,8 +98,8 @@ export const FigmaBlock = ({ appBridge }: BlockProps): ReactElement => {
     };
 
     return (
-        <div ref={ref} data-test-id="figma-block" className="figma-block">
-            <StyleProvider>
+        <StyleProvider className="figma-block">
+            <div ref={ref} data-test-id="figma-block">
                 {referenceUrl ? (
                     <ReferenceErrorMessage originalUrl={referenceUrl} />
                 ) : (
@@ -154,7 +154,7 @@ export const FigmaBlock = ({ appBridge }: BlockProps): ReactElement => {
                         )}
                     </>
                 )}
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/glyphs-block/block-scope.json
+++ b/packages/glyphs-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "glyphs-block"
+}

--- a/packages/glyphs-block/postcss.config.js
+++ b/packages/glyphs-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.glyphs-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/glyphs-block/src/GlyphsBlock.tsx
+++ b/packages/glyphs-block/src/GlyphsBlock.tsx
@@ -5,6 +5,8 @@ import { toRgbaString } from '@frontify/guideline-blocks-settings';
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type ReactElement } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { getRadiusValue } from './helpers';
 import { BLACK_COLOR, DEFAULT_CHARS, WHITE_COLOR } from './settings';
 import { type BlockProps, type Settings } from './types';
@@ -69,7 +71,7 @@ export const GlyphsBlock = ({ appBridge }: BlockProps): ReactElement => {
     });
 
     return (
-        <StyleProvider className="glyphs-block">
+        <StyleProvider scope={blockScope.scope}>
             <ul
                 data-test-id="glyphs-block"
                 className="tw-grid tw-grid-cols-6"

--- a/packages/glyphs-block/src/GlyphsBlock.tsx
+++ b/packages/glyphs-block/src/GlyphsBlock.tsx
@@ -69,25 +69,23 @@ export const GlyphsBlock = ({ appBridge }: BlockProps): ReactElement => {
     });
 
     return (
-        <div className="glyps-block">
-            <StyleProvider>
-                <ul
-                    data-test-id="glyphs-block"
-                    className="tw-grid tw-grid-cols-6"
-                    style={{
-                        fontWeight: blockSettings.fontWeight,
-                        fontSize: blockSettings.fontSize,
-                        fontFamily: fontFamily || 'inherit',
-                        color: toRgbaString(fontColor || BLACK_COLOR),
-                        ...(hasBorder && {
-                            gap: borderWidth,
-                            padding: borderWidth,
-                        }),
-                    }}
-                >
-                    {items}
-                </ul>
-            </StyleProvider>
-        </div>
+        <StyleProvider className="glyphs-block">
+            <ul
+                data-test-id="glyphs-block"
+                className="tw-grid tw-grid-cols-6"
+                style={{
+                    fontWeight: blockSettings.fontWeight,
+                    fontSize: blockSettings.fontSize,
+                    fontFamily: fontFamily || 'inherit',
+                    color: toRgbaString(fontColor || BLACK_COLOR),
+                    ...(hasBorder && {
+                        gap: borderWidth,
+                        padding: borderWidth,
+                    }),
+                }}
+            >
+                {items}
+            </ul>
+        </StyleProvider>
     );
 };

--- a/packages/gradient-block/block-scope.json
+++ b/packages/gradient-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "gradient-block"
+}

--- a/packages/gradient-block/postcss.config.js
+++ b/packages/gradient-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.gradient-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/gradient-block/src/GradientBlock.tsx
+++ b/packages/gradient-block/src/GradientBlock.tsx
@@ -7,6 +7,8 @@ import { type BlockProps } from '@frontify/guideline-blocks-settings';
 import { CssValueDisplay, StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type MouseEvent, type ReactElement, useEffect, useRef, useState } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { AddColorButton, ColorFlyout, ColorTooltip, SquareBadgesRow } from './components';
 import { DEFAULT_GRADIENT_COLORS, DEFAULT_HEIGHT_VALUE, DEFAULT_ORIENTATION_VALUE } from './constants';
 import { parseGradientColorsToCss, toHex6or8String } from './helpers';
@@ -79,7 +81,7 @@ export const GradientBlock = ({ appBridge }: BlockProps): ReactElement => {
     const cssValue = parseGradientColorsToCss(gradientColors, gradientOrientation);
 
     return (
-        <StyleProvider className="gradient-block">
+        <StyleProvider scope={blockScope.scope}>
             <div data-test-id="gradient-block" ref={gradientBlockRef}>
                 <div className="tw-border tw-border-line-strong tw-rounded-medium tw-p-0.5">
                     <div

--- a/packages/gradient-block/src/GradientBlock.tsx
+++ b/packages/gradient-block/src/GradientBlock.tsx
@@ -79,8 +79,8 @@ export const GradientBlock = ({ appBridge }: BlockProps): ReactElement => {
     const cssValue = parseGradientColorsToCss(gradientColors, gradientOrientation);
 
     return (
-        <div data-test-id="gradient-block" className="gradient-block" ref={gradientBlockRef}>
-            <StyleProvider>
+        <StyleProvider className="gradient-block">
+            <div data-test-id="gradient-block" ref={gradientBlockRef}>
                 <div className="tw-border tw-border-line-strong tw-rounded-medium tw-p-0.5">
                     <div
                         data-test-id="gradient-block-display"
@@ -145,7 +145,7 @@ export const GradientBlock = ({ appBridge }: BlockProps): ReactElement => {
                     )
                 )}
                 {displayCss && <CssValueDisplay cssValue={cssValue} placeholder="<add colors to generate CSS code>" />}
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/image-block/block-scope.json
+++ b/packages/image-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "image-block"
+}

--- a/packages/image-block/postcss.config.js
+++ b/packages/image-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.image-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -28,6 +28,8 @@ import {
 import { StyleProvider, generateRandomId, getEditAltTextToolbarButton } from '@frontify/guideline-blocks-shared';
 import { useEffect, useState } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { DownloadAndAttachments } from './components/DownloadAndAttachments';
 import { Image } from './components/Image';
 import { ImageCaption } from './components/ImageCaption';
@@ -165,7 +167,7 @@ export const ImageBlock = ({ appBridge }: BlockProps) => {
             assetId={ATTACHMENTS_ASSET_ID}
             appBridge={appBridge}
         >
-            <StyleProvider className="image-block">
+            <StyleProvider scope={blockScope.scope}>
                 <div className="tw-@container">
                     <div
                         data-test-id="image-block"

--- a/packages/image-block/src/ImageBlock.tsx
+++ b/packages/image-block/src/ImageBlock.tsx
@@ -165,118 +165,116 @@ export const ImageBlock = ({ appBridge }: BlockProps) => {
             assetId={ATTACHMENTS_ASSET_ID}
             appBridge={appBridge}
         >
-            <div className="image-block">
-                <StyleProvider>
-                    <div className="tw-@container">
+            <StyleProvider className="image-block">
+                <div className="tw-@container">
+                    <div
+                        data-test-id="image-block"
+                        className={`tw-flex tw-h-auto ${mapCaptionPositionClasses[positioning]}`}
+                    >
                         <div
-                            data-test-id="image-block"
-                            className={`tw-flex tw-h-auto ${mapCaptionPositionClasses[positioning]}`}
+                            className={merge([
+                                'tw-relative',
+                                attachmentCount > 0 && 'tw-min-h-11',
+                                [CaptionPosition.Above, CaptionPosition.Below].includes(positioning)
+                                    ? 'tw-w-full'
+                                    : imageRatioValues[ratio],
+                            ])}
                         >
-                            <div
-                                className={merge([
-                                    'tw-relative',
-                                    attachmentCount > 0 && 'tw-min-h-11',
-                                    [CaptionPosition.Above, CaptionPosition.Below].includes(positioning)
-                                        ? 'tw-w-full'
-                                        : imageRatioValues[ratio],
-                                ])}
-                            >
-                                <DownloadAndAttachments
-                                    appBridge={appBridge}
-                                    blockSettings={blockSettings}
-                                    image={image}
-                                    ariaLabel={ariaLabel}
-                                    isAssetDownloadable={isAssetDownloadable}
-                                    isEditing={isEditing}
-                                />
-                                {image ? (
-                                    <BlockItemWrapper
-                                        shouldHideWrapper={!isEditing}
-                                        showAttachments
-                                        toolbarItems={[
-                                            image
-                                                ? getEditAltTextToolbarButton({
-                                                      localAltText,
-                                                      setLocalAltText,
-                                                      blockSettings,
-                                                      setBlockSettings,
-                                                  })
-                                                : undefined,
-                                            {
-                                                type: 'menu',
-                                                items: [
-                                                    [
-                                                        {
-                                                            title: 'Replace with upload',
-                                                            icon: <IconArrowCircleUp size={20} />,
-                                                            onClick: openFileDialog,
-                                                        },
-                                                        {
-                                                            title: 'Replace with asset',
-                                                            icon: <IconImageStack size={20} />,
-                                                            onClick: onOpenAssetChooser,
-                                                        },
-                                                    ],
-                                                    [
-                                                        {
-                                                            title: 'Delete',
-                                                            icon: <IconTrashBin size={20} />,
-                                                            style: 'danger',
-                                                            onClick: onRemoveAsset,
-                                                        },
-                                                    ],
-                                                ],
-                                            },
-                                        ]}
-                                    >
-                                        {isLoading ? (
-                                            <div className="tw-flex tw-items-center tw-justify-center tw-h-64">
-                                                <LoadingCircle />
-                                            </div>
-                                        ) : (
-                                            <Image
-                                                appBridge={appBridge}
-                                                blockSettings={blockSettings}
-                                                isEditing={isEditing}
-                                                image={image}
-                                                isDownloadable={isAssetDownloadable}
-                                                isAssetViewerEnabled={isAssetViewerEnabled}
-                                            />
-                                        )}
-                                    </BlockItemWrapper>
-                                ) : (
-                                    isEditing && (
-                                        <BlockItemWrapper
-                                            shouldHideWrapper={attachmentCount === 0}
-                                            showAttachments
-                                            toolbarItems={[]}
-                                        >
-                                            <UploadPlaceholder
-                                                loading={isLoading}
-                                                onUploadClick={openFileDialog}
-                                                onFilesDrop={onFilesDrop}
-                                                onAssetChooseClick={onOpenAssetChooser}
-                                            />
-                                        </BlockItemWrapper>
-                                    )
-                                )}
-                            </div>
-
-                            <ImageCaption
-                                titleKey={titleKey}
-                                blockId={blockId}
-                                isEditing={isEditing}
-                                description={description}
-                                name={name}
-                                positioning={positioning}
+                            <DownloadAndAttachments
                                 appBridge={appBridge}
-                                ratio={ratio}
-                                setBlockSettings={setBlockSettings}
+                                blockSettings={blockSettings}
+                                image={image}
+                                ariaLabel={ariaLabel}
+                                isAssetDownloadable={isAssetDownloadable}
+                                isEditing={isEditing}
                             />
+                            {image ? (
+                                <BlockItemWrapper
+                                    shouldHideWrapper={!isEditing}
+                                    showAttachments
+                                    toolbarItems={[
+                                        image
+                                            ? getEditAltTextToolbarButton({
+                                                  localAltText,
+                                                  setLocalAltText,
+                                                  blockSettings,
+                                                  setBlockSettings,
+                                              })
+                                            : undefined,
+                                        {
+                                            type: 'menu',
+                                            items: [
+                                                [
+                                                    {
+                                                        title: 'Replace with upload',
+                                                        icon: <IconArrowCircleUp size={20} />,
+                                                        onClick: openFileDialog,
+                                                    },
+                                                    {
+                                                        title: 'Replace with asset',
+                                                        icon: <IconImageStack size={20} />,
+                                                        onClick: onOpenAssetChooser,
+                                                    },
+                                                ],
+                                                [
+                                                    {
+                                                        title: 'Delete',
+                                                        icon: <IconTrashBin size={20} />,
+                                                        style: 'danger',
+                                                        onClick: onRemoveAsset,
+                                                    },
+                                                ],
+                                            ],
+                                        },
+                                    ]}
+                                >
+                                    {isLoading ? (
+                                        <div className="tw-flex tw-items-center tw-justify-center tw-h-64">
+                                            <LoadingCircle />
+                                        </div>
+                                    ) : (
+                                        <Image
+                                            appBridge={appBridge}
+                                            blockSettings={blockSettings}
+                                            isEditing={isEditing}
+                                            image={image}
+                                            isDownloadable={isAssetDownloadable}
+                                            isAssetViewerEnabled={isAssetViewerEnabled}
+                                        />
+                                    )}
+                                </BlockItemWrapper>
+                            ) : (
+                                isEditing && (
+                                    <BlockItemWrapper
+                                        shouldHideWrapper={attachmentCount === 0}
+                                        showAttachments
+                                        toolbarItems={[]}
+                                    >
+                                        <UploadPlaceholder
+                                            loading={isLoading}
+                                            onUploadClick={openFileDialog}
+                                            onFilesDrop={onFilesDrop}
+                                            onAssetChooseClick={onOpenAssetChooser}
+                                        />
+                                    </BlockItemWrapper>
+                                )
+                            )}
                         </div>
+
+                        <ImageCaption
+                            titleKey={titleKey}
+                            blockId={blockId}
+                            isEditing={isEditing}
+                            description={description}
+                            name={name}
+                            positioning={positioning}
+                            appBridge={appBridge}
+                            ratio={ratio}
+                            setBlockSettings={setBlockSettings}
+                        />
                     </div>
-                </StyleProvider>
-            </div>
+                </div>
+            </StyleProvider>
         </AttachmentOperationsProvider>
     );
 };

--- a/packages/quote-block/block-scope.json
+++ b/packages/quote-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "quote-block"
+}

--- a/packages/quote-block/postcss.config.js
+++ b/packages/quote-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.quote-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/quote-block/src/QuoteBlock.tsx
+++ b/packages/quote-block/src/QuoteBlock.tsx
@@ -24,6 +24,8 @@ import {
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type FC, useEffect } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { QuoteBlockIcon } from './QuoteBlockIcon';
 import { CUSTOM_QUOTE_STYLE_LEFT_ID, CUSTOM_QUOTE_STYLE_RIGHT_ID, DEFAULT_COLOR_VALUE } from './settings';
 import {
@@ -116,7 +118,7 @@ export const QuoteBlock: FC<BlockProps> = ({ appBridge }) => {
     };
 
     return (
-        <StyleProvider className="quote-block">
+        <StyleProvider scope={blockScope.scope}>
             <div data-test-id="quote-block" className={isEditing ? '' : 'tw-text-primary'}>
                 <div className={getWrapperClasses()}>
                     {isQuotationMarkType && (

--- a/packages/quote-block/src/QuoteBlock.tsx
+++ b/packages/quote-block/src/QuoteBlock.tsx
@@ -116,79 +116,75 @@ export const QuoteBlock: FC<BlockProps> = ({ appBridge }) => {
     };
 
     return (
-        <div className="quote-block">
-            <StyleProvider>
-                <div data-test-id="quote-block" className={isEditing ? '' : 'tw-text-primary'}>
-                    <div className={getWrapperClasses()}>
-                        {isQuotationMarkType && (
-                            <QuoteBlockIcon
-                                color={iconColor}
-                                isCustomSize={blockSettings.isCustomSize}
-                                sizeValue={sizeValue}
-                                sizeChoice={blockSettings.sizeChoice}
-                                customIcon={customLeftIcon}
-                                quoteStyle={
-                                    blockSettings.isCustomQuoteStyleLeft
-                                        ? QuoteStyle.Custom
-                                        : (blockSettings.quoteStyleLeft ?? QuoteStyle.DoubleUp)
-                                }
-                            />
-                        )}
-
-                        <figure
-                            data-test-id="quote-block-author"
-                            className={
-                                isFullWidth && isQuotationMarkType
-                                    ? 'tw-flex-1 tw-w-full tw-overflow-hidden'
-                                    : 'tw-min-w-4'
+        <StyleProvider className="quote-block">
+            <div data-test-id="quote-block" className={isEditing ? '' : 'tw-text-primary'}>
+                <div className={getWrapperClasses()}>
+                    {isQuotationMarkType && (
+                        <QuoteBlockIcon
+                            color={iconColor}
+                            isCustomSize={blockSettings.isCustomSize}
+                            sizeValue={sizeValue}
+                            sizeChoice={blockSettings.sizeChoice}
+                            customIcon={customLeftIcon}
+                            quoteStyle={
+                                blockSettings.isCustomQuoteStyleLeft
+                                    ? QuoteStyle.Custom
+                                    : (blockSettings.quoteStyleLeft ?? QuoteStyle.DoubleUp)
                             }
+                        />
+                    )}
+
+                    <figure
+                        data-test-id="quote-block-author"
+                        className={
+                            isFullWidth && isQuotationMarkType ? 'tw-flex-1 tw-w-full tw-overflow-hidden' : 'tw-min-w-4'
+                        }
+                    >
+                        <blockquote
+                            style={isQuotationMarkType ? {} : borderStyles}
+                            className={merge([
+                                isQuotationMarkType ? '' : accentLineClassName,
+                                textAlignmentClassNames[textAlignment],
+                                '[&>div]:!tw-@container-normal',
+                            ])}
                         >
-                            <blockquote
-                                style={isQuotationMarkType ? {} : borderStyles}
-                                className={merge([
-                                    isQuotationMarkType ? '' : accentLineClassName,
-                                    textAlignmentClassNames[textAlignment],
-                                    '[&>div]:!tw-@container-normal',
-                                ])}
-                            >
-                                <RichTextEditor
-                                    id={String(appBridge.context('blockId').get())}
-                                    placeholder={isEditing ? 'Add your quote text here' : undefined}
-                                    value={blockSettings.content ?? convertToRteValue(TextStyles.quote)}
-                                    onTextChange={onChangeContent}
-                                    plugins={customPlugins}
-                                    isEditing={isEditing}
-                                />
-                            </blockquote>
-                            {showAuthor && (
-                                <figcaption
-                                    className="tw-text-right tw-break-all"
-                                    style={{
-                                        color: BlockStyles[TextStyles.p].color,
-                                    }}
-                                >
-                                    {`- ${blockSettings.authorName}`}
-                                </figcaption>
-                            )}
-                        </figure>
-                        {isQuotationMarkType && (
-                            <QuoteBlockIcon
-                                color={iconColor}
-                                isCustomSize={blockSettings.isCustomSize}
-                                sizeValue={sizeValue}
-                                sizeChoice={blockSettings.sizeChoice}
-                                customIcon={customRightIcon}
-                                quoteStyle={
-                                    blockSettings.isCustomQuoteStyleRight
-                                        ? QuoteStyle.Custom
-                                        : (blockSettings.quoteStyleRight ?? QuoteStyle.None)
-                                }
-                                position="bottom"
+                            <RichTextEditor
+                                id={String(appBridge.context('blockId').get())}
+                                placeholder={isEditing ? 'Add your quote text here' : undefined}
+                                value={blockSettings.content ?? convertToRteValue(TextStyles.quote)}
+                                onTextChange={onChangeContent}
+                                plugins={customPlugins}
+                                isEditing={isEditing}
                             />
+                        </blockquote>
+                        {showAuthor && (
+                            <figcaption
+                                className="tw-text-right tw-break-all"
+                                style={{
+                                    color: BlockStyles[TextStyles.p].color,
+                                }}
+                            >
+                                {`- ${blockSettings.authorName}`}
+                            </figcaption>
                         )}
-                    </div>
+                    </figure>
+                    {isQuotationMarkType && (
+                        <QuoteBlockIcon
+                            color={iconColor}
+                            isCustomSize={blockSettings.isCustomSize}
+                            sizeValue={sizeValue}
+                            sizeChoice={blockSettings.sizeChoice}
+                            customIcon={customRightIcon}
+                            quoteStyle={
+                                blockSettings.isCustomQuoteStyleRight
+                                    ? QuoteStyle.Custom
+                                    : (blockSettings.quoteStyleRight ?? QuoteStyle.None)
+                            }
+                            position="bottom"
+                        />
+                    )}
                 </div>
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/shared/src/components/StyleProvider/StyleProvider.tsx
+++ b/packages/shared/src/components/StyleProvider/StyleProvider.tsx
@@ -7,6 +7,10 @@ import { type ReactNode } from 'react';
 
 import './styles.css';
 
-export const StyleProvider = ({ children }: { children: ReactNode }) => {
-    return <ThemeProvider theme="light">{children}</ThemeProvider>;
+export const StyleProvider = ({ children, className }: { children: ReactNode; className?: string }) => {
+    return (
+        <ThemeProvider className={className} theme="light">
+            {children}
+        </ThemeProvider>
+    );
 };

--- a/packages/shared/src/components/StyleProvider/StyleProvider.tsx
+++ b/packages/shared/src/components/StyleProvider/StyleProvider.tsx
@@ -7,9 +7,9 @@ import { type ReactNode } from 'react';
 
 import './styles.css';
 
-export const StyleProvider = ({ children, className }: { children: ReactNode; className?: string }) => {
+export const StyleProvider = ({ children, scope }: { children: ReactNode; scope: string }) => {
     return (
-        <ThemeProvider className={className} theme="light">
+        <ThemeProvider className={scope} theme="light">
             {children}
         </ThemeProvider>
     );

--- a/packages/sketchfab-block/block-scope.json
+++ b/packages/sketchfab-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "sketchfab-block"
+}

--- a/packages/sketchfab-block/postcss.config.js
+++ b/packages/sketchfab-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.sketchfab-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/sketchfab-block/src/SketchfabBlock.tsx
+++ b/packages/sketchfab-block/src/SketchfabBlock.tsx
@@ -8,6 +8,8 @@ import { type BlockProps, joinClassNames, toHex8String } from '@frontify/guideli
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type FC, useEffect, useState } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { SKETCHFAB_RULE_ERROR, generateIframeUrl, generateSketchfabEmbedUrl, getIframeBorderStyles } from './helpers';
 import { URL_INPUT_PLACEHOLDER } from './settings';
 import { type Settings, SketchfabAccount, SketchfabNavigation, SketchfabTheme, heights, radiusClassMap } from './types';
@@ -146,7 +148,7 @@ export const SketchfabBlock: FC<BlockProps> = ({ appBridge }) => {
     }, [blockSettings]);
 
     return (
-        <StyleProvider className="sketchfab-block">
+        <StyleProvider scope={blockScope.scope}>
             <div data-test-id="sketchfab-block" className="tw-relative">
                 {iframeUrl && (
                     <div>

--- a/packages/sketchfab-block/src/SketchfabBlock.tsx
+++ b/packages/sketchfab-block/src/SketchfabBlock.tsx
@@ -146,69 +146,67 @@ export const SketchfabBlock: FC<BlockProps> = ({ appBridge }) => {
     }, [blockSettings]);
 
     return (
-        <div className="sketchfab-block">
-            <StyleProvider>
-                <div data-test-id="sketchfab-block" className="tw-relative">
-                    {iframeUrl && (
-                        <div>
-                            <iframe
-                                className={joinClassNames(['tw-w-full', !hasRadius && radiusClassMap[radiusChoice]])}
-                                style={{
-                                    ...(hasBorder ? getIframeBorderStyles(borderStyle, borderWidth, borderColor) : {}),
-                                    borderRadius: hasRadius ? radiusValue : '',
-                                }}
-                                height={isCustomHeight ? customHeight : heights[height]}
-                                src={iframeUrl.toString()}
-                                frameBorder="0"
-                                data-test-id="sketchfab-iframe"
-                                title="3D model from Sketchfab"
-                                sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-presentation"
-                            />
-                        </div>
-                    )}
-                    {isEditing && !iframeUrl && (
-                        <div
-                            className="tw-flex tw-flex-col tw-items-center tw-bg-black-5 tw-p-20 tw-gap-8 tw-body-medium"
-                            data-test-id="sketchfab-empty-block-edit"
-                        >
-                            <Text color="weak">Enter a URL to your 3D model from Sketchfab.</Text>
-                            <div className="tw-text-secondary tw-flex tw-items-start tw-gap-3 tw-w-full tw-justify-center">
-                                <div className="tw-flex-none tw-mt-[2px]">
-                                    <IconLinkBox size={32} />
-                                </div>
-                                <div className="tw-w-full tw-max-w-sm">
-                                    <FormControl
-                                        helper={inputError ? { text: SKETCHFAB_RULE_ERROR } : undefined}
-                                        style={inputError ? FormControlStyle.Danger : FormControlStyle.Primary}
-                                    >
-                                        <TextInput
-                                            value={localUrl}
-                                            onChange={(event) => setLocalUrl(event.target.value)}
-                                            onKeyDown={(event) => {
-                                                if (event.key === 'Enter') {
-                                                    saveLink();
-                                                }
-                                            }}
-                                            placeholder={URL_INPUT_PLACEHOLDER}
-                                        />
-                                    </FormControl>
-                                </div>
-                                <Button onPress={saveLink}>Confirm</Button>
-                            </div>
-                        </div>
-                    )}
-                    {!isEditing && !iframeUrl && (
-                        <div
-                            className="tw-flex tw-items-center tw-justify-center tw-bg-black-5 tw-p-20"
-                            data-test-id="sketchfab-empty-block-view"
-                        >
-                            <Text color="weak">
+        <StyleProvider className="sketchfab-block">
+            <div data-test-id="sketchfab-block" className="tw-relative">
+                {iframeUrl && (
+                    <div>
+                        <iframe
+                            className={joinClassNames(['tw-w-full', !hasRadius && radiusClassMap[radiusChoice]])}
+                            style={{
+                                ...(hasBorder ? getIframeBorderStyles(borderStyle, borderWidth, borderColor) : {}),
+                                borderRadius: hasRadius ? radiusValue : '',
+                            }}
+                            height={isCustomHeight ? customHeight : heights[height]}
+                            src={iframeUrl.toString()}
+                            frameBorder="0"
+                            data-test-id="sketchfab-iframe"
+                            title="3D model from Sketchfab"
+                            sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-presentation"
+                        />
+                    </div>
+                )}
+                {isEditing && !iframeUrl && (
+                    <div
+                        className="tw-flex tw-flex-col tw-items-center tw-bg-black-5 tw-p-20 tw-gap-8 tw-body-medium"
+                        data-test-id="sketchfab-empty-block-edit"
+                    >
+                        <Text color="weak">Enter a URL to your 3D model from Sketchfab.</Text>
+                        <div className="tw-text-secondary tw-flex tw-items-start tw-gap-3 tw-w-full tw-justify-center">
+                            <div className="tw-flex-none tw-mt-[2px]">
                                 <IconLinkBox size={32} />
-                            </Text>
+                            </div>
+                            <div className="tw-w-full tw-max-w-sm">
+                                <FormControl
+                                    helper={inputError ? { text: SKETCHFAB_RULE_ERROR } : undefined}
+                                    style={inputError ? FormControlStyle.Danger : FormControlStyle.Primary}
+                                >
+                                    <TextInput
+                                        value={localUrl}
+                                        onChange={(event) => setLocalUrl(event.target.value)}
+                                        onKeyDown={(event) => {
+                                            if (event.key === 'Enter') {
+                                                saveLink();
+                                            }
+                                        }}
+                                        placeholder={URL_INPUT_PLACEHOLDER}
+                                    />
+                                </FormControl>
+                            </div>
+                            <Button onPress={saveLink}>Confirm</Button>
                         </div>
-                    )}
-                </div>
-            </StyleProvider>
-        </div>
+                    </div>
+                )}
+                {!isEditing && !iframeUrl && (
+                    <div
+                        className="tw-flex tw-items-center tw-justify-center tw-bg-black-5 tw-p-20"
+                        data-test-id="sketchfab-empty-block-view"
+                    >
+                        <Text color="weak">
+                            <IconLinkBox size={32} />
+                        </Text>
+                    </div>
+                )}
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/storybook-block/block-scope.json
+++ b/packages/storybook-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "storybook-block"
+}

--- a/packages/storybook-block/postcss.config.js
+++ b/packages/storybook-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.storybook-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/storybook-block/src/StorybookBlock.tsx
+++ b/packages/storybook-block/src/StorybookBlock.tsx
@@ -108,60 +108,56 @@ export const StorybookBlock: FC<BlockProps> = ({ appBridge }) => {
     );
 
     return (
-        <div className="storybook-block">
-            <StyleProvider>
-                <div data-test-id="storybook-block" className="tw-relative">
-                    {iframe ? (
-                        isEditing ? (
-                            <Resizeable saveHeight={saveHeight} initialHeight={activeHeight}>
-                                <div>{iframe}</div>
-                            </Resizeable>
-                        ) : (
-                            <div style={{ height: activeHeight }}>{iframe}</div>
-                        )
-                    ) : isEditing ? (
+        <StyleProvider className="storybook-block">
+            <div data-test-id="storybook-block" className="tw-relative">
+                {iframe ? (
+                    isEditing ? (
                         <Resizeable saveHeight={saveHeight} initialHeight={activeHeight}>
-                            <div
-                                className="tw-flex tw-justify-center tw-items-center tw-bg-black-5 tw-p-20 tw-text-black-40 tw-space-x-2 tw-resize-y tw-body-medium"
-                                data-test-id="storybook-empty-wrapper"
-                            >
-                                <IconStorybook size={32} />
-                                <div
-                                    className={`tw-w-full tw-max-w-sm ${!isValidStorybookUrl(submittedUrl) && 'tw-pt-6'}`}
-                                >
-                                    <FormControl
-                                        helper={!isValidStorybookUrl(submittedUrl) ? { text: ERROR_MSG } : undefined}
-                                        style={
-                                            !isValidStorybookUrl(submittedUrl)
-                                                ? FormControlStyle.Danger
-                                                : FormControlStyle.Primary
-                                        }
-                                    >
-                                        <TextInput
-                                            value={input}
-                                            onChange={(event) => setInput(event.target.value)}
-                                            onKeyDown={(event) => {
-                                                if (event.key === 'Enter') {
-                                                    saveInputLink();
-                                                }
-                                            }}
-                                            placeholder={URL_INPUT_PLACEHOLDER}
-                                        />
-                                    </FormControl>
-                                </div>
-                                <Button onPress={saveInputLink}>Confirm</Button>
-                            </div>
+                            <div>{iframe}</div>
                         </Resizeable>
                     ) : (
+                        <div style={{ height: activeHeight }}>{iframe}</div>
+                    )
+                ) : isEditing ? (
+                    <Resizeable saveHeight={saveHeight} initialHeight={activeHeight}>
                         <div
-                            className="tw-flex tw-items-center tw-justify-center tw-bg-black-5"
-                            style={{ height: activeHeight }}
+                            className="tw-flex tw-justify-center tw-items-center tw-bg-black-5 tw-p-20 tw-text-black-40 tw-space-x-2 tw-resize-y tw-body-medium"
+                            data-test-id="storybook-empty-wrapper"
                         >
-                            No Storybook-URL defined.
+                            <IconStorybook size={32} />
+                            <div className={`tw-w-full tw-max-w-sm ${!isValidStorybookUrl(submittedUrl) && 'tw-pt-6'}`}>
+                                <FormControl
+                                    helper={!isValidStorybookUrl(submittedUrl) ? { text: ERROR_MSG } : undefined}
+                                    style={
+                                        !isValidStorybookUrl(submittedUrl)
+                                            ? FormControlStyle.Danger
+                                            : FormControlStyle.Primary
+                                    }
+                                >
+                                    <TextInput
+                                        value={input}
+                                        onChange={(event) => setInput(event.target.value)}
+                                        onKeyDown={(event) => {
+                                            if (event.key === 'Enter') {
+                                                saveInputLink();
+                                            }
+                                        }}
+                                        placeholder={URL_INPUT_PLACEHOLDER}
+                                    />
+                                </FormControl>
+                            </div>
+                            <Button onPress={saveInputLink}>Confirm</Button>
                         </div>
-                    )}
-                </div>
-            </StyleProvider>
-        </div>
+                    </Resizeable>
+                ) : (
+                    <div
+                        className="tw-flex tw-items-center tw-justify-center tw-bg-black-5"
+                        style={{ height: activeHeight }}
+                    >
+                        No Storybook-URL defined.
+                    </div>
+                )}
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/storybook-block/src/StorybookBlock.tsx
+++ b/packages/storybook-block/src/StorybookBlock.tsx
@@ -8,6 +8,8 @@ import { type BlockProps, radiusStyleMap, toRgbaString } from '@frontify/guideli
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type FC, useCallback, useEffect, useState } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { Resizeable } from './components/Resizable';
 import { BORDER_COLOR_DEFAULT_VALUE, ERROR_MSG, URL_INPUT_PLACEHOLDER } from './settings';
 import {
@@ -108,7 +110,7 @@ export const StorybookBlock: FC<BlockProps> = ({ appBridge }) => {
     );
 
     return (
-        <StyleProvider className="storybook-block">
+        <StyleProvider scope={blockScope.scope}>
             <div data-test-id="storybook-block" className="tw-relative">
                 {iframe ? (
                     isEditing ? (

--- a/packages/template-block/block-scope.json
+++ b/packages/template-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "template-block"
+}

--- a/packages/template-block/postcss.config.js
+++ b/packages/template-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.template-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/template-block/src/TemplateBlock.tsx
+++ b/packages/template-block/src/TemplateBlock.tsx
@@ -69,8 +69,8 @@ export const TemplateBlock = ({ appBridge }: BlockProps): ReactElement => {
     }
 
     return (
-        <div data-test-id="container" className="template-block tw-@container">
-            <StyleProvider>
+        <StyleProvider className="template-block">
+            <div data-test-id="container" className="tw-@container">
                 <div data-test-id="card" style={cardStyles}>
                     {isEditing && lastErrorMessage !== '' && <AlertError errorMessage={lastErrorMessage} />}
 
@@ -140,7 +140,7 @@ export const TemplateBlock = ({ appBridge }: BlockProps): ReactElement => {
                         </div>
                     )}
                 </div>
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/template-block/src/TemplateBlock.tsx
+++ b/packages/template-block/src/TemplateBlock.tsx
@@ -6,6 +6,8 @@ import { type BlockProps } from '@frontify/guideline-blocks-settings';
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type ReactElement } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { AlertError } from './components/AlertError';
 import { CtaButton } from './components/CtaButton';
 import { TemplatePreview } from './components/TemplatePreview';
@@ -65,11 +67,11 @@ export const TemplateBlock = ({ appBridge }: BlockProps): ReactElement => {
     const handleOpenTemplateChooser = () => appBridge.dispatch(openTemplateChooser());
 
     if (!isEditing && (!selectedTemplate || !hasAuthenticatedUser)) {
-        return <div data-test-id="container" className="template-block"></div>;
+        return <div data-test-id="container" className={blockScope.scope}></div>;
     }
 
     return (
-        <StyleProvider className="template-block">
+        <StyleProvider scope={blockScope.scope}>
             <div data-test-id="container" className="tw-@container">
                 <div data-test-id="card" style={cardStyles}>
                     {isEditing && lastErrorMessage !== '' && <AlertError errorMessage={lastErrorMessage} />}

--- a/packages/text-block/block-scope.json
+++ b/packages/text-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "text-block"
+}

--- a/packages/text-block/postcss.config.js
+++ b/packages/text-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.text-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/text-block/src/TextBlock.tsx
+++ b/packages/text-block/src/TextBlock.tsx
@@ -6,6 +6,8 @@ import { type BlockProps, RichTextEditor } from '@frontify/guideline-blocks-sett
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type ReactElement, useCallback, useMemo } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { getPlugins } from './getPlugins';
 import { PLACEHOLDER } from './settings';
 import { type Settings, spacingValues } from './types';
@@ -21,7 +23,7 @@ export const TextBlock = ({ appBridge }: BlockProps): ReactElement => {
     const handleTextChange = useCallback((content: string) => setBlockSettings({ content }), [setBlockSettings]);
 
     return (
-        <StyleProvider className="text-block">
+        <StyleProvider scope={blockScope.scope}>
             <div data-test-id="text-block-wrapper" className={merge([isEditing && 'tw-min-h-9'])}>
                 <RichTextEditor
                     id={String(appBridge.context('blockId').get())}

--- a/packages/text-block/src/TextBlock.tsx
+++ b/packages/text-block/src/TextBlock.tsx
@@ -21,8 +21,8 @@ export const TextBlock = ({ appBridge }: BlockProps): ReactElement => {
     const handleTextChange = useCallback((content: string) => setBlockSettings({ content }), [setBlockSettings]);
 
     return (
-        <div data-test-id="text-block-wrapper" className={merge(['text-block', isEditing && 'tw-min-h-9'])}>
-            <StyleProvider>
+        <StyleProvider className="text-block">
+            <div data-test-id="text-block-wrapper" className={merge([isEditing && 'tw-min-h-9'])}>
                 <RichTextEditor
                     id={String(appBridge.context('blockId').get())}
                     isEditing={isEditing}
@@ -33,7 +33,7 @@ export const TextBlock = ({ appBridge }: BlockProps): ReactElement => {
                     placeholder={PLACEHOLDER}
                     onTextChange={handleTextChange}
                 />
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 };

--- a/packages/thumbnail-grid-block/block-scope.json
+++ b/packages/thumbnail-grid-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "thumbnail-grid-block"
+}

--- a/packages/thumbnail-grid-block/postcss.config.js
+++ b/packages/thumbnail-grid-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.thumbnail-grid-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/thumbnail-grid-block/src/ThumbnailGridBlock.tsx
+++ b/packages/thumbnail-grid-block/src/ThumbnailGridBlock.tsx
@@ -15,6 +15,8 @@ import { type BlockProps, Security, gutterSpacingStyleMap } from '@frontify/guid
 import { generateRandomId, StyleProvider, useDndSensors } from '@frontify/guideline-blocks-shared';
 import { useCallback, useEffect, useState } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { Grid, Item, SortableItem } from './components/';
 import { getThumbnailStyles } from './helper';
 import { type Settings, type Thumbnail } from './types';
@@ -180,7 +182,7 @@ export const ThumbnailGridBlock = ({ appBridge }: BlockProps) => {
     };
 
     return (
-        <StyleProvider className="thumbnail-grid-block">
+        <StyleProvider scope={blockScope.scope}>
             <DndContext
                 sensors={sensors}
                 collisionDetection={closestCenter}

--- a/packages/thumbnail-grid-block/src/ThumbnailGridBlock.tsx
+++ b/packages/thumbnail-grid-block/src/ThumbnailGridBlock.tsx
@@ -180,48 +180,46 @@ export const ThumbnailGridBlock = ({ appBridge }: BlockProps) => {
     };
 
     return (
-        <div className="thumbnail-grid-block">
-            <StyleProvider>
-                <DndContext
-                    sensors={sensors}
-                    collisionDetection={closestCenter}
-                    onDragEnd={handleDragEnd}
-                    onDragStart={handleDragStart}
-                    modifiers={[restrictToParentElement]}
-                >
-                    <SortableContext items={itemsState} strategy={rectSortingStrategy}>
-                        <div className="tw-@container tw-translate-x-0 tw-isolate">
-                            <Grid columnCount={blockSettings.columnCount} gap={gap}>
-                                {itemsState.map((item, i) => (
-                                    <SortableItem
-                                        key={item.id}
-                                        item={item}
-                                        isAssetViewerEnabled={isAssetViewerEnabled}
-                                        image={blockAssets?.[item.id]?.[0]}
-                                        isLoading={getIsItemUploading(item.id)}
-                                        showDeleteButton={i !== itemsState.length - 1}
-                                        openAssetInAssetViewer={openAssetInAssetViewer}
-                                        {...thumbnailProps}
-                                    />
-                                ))}
-                            </Grid>
-                        </div>
-                        <DragOverlay>
-                            {draggedItem && (
-                                <Item
-                                    key={draggedItem.id}
-                                    item={draggedItem}
-                                    image={blockAssets?.[draggedItem.id]?.[0]}
-                                    isLoading={getIsItemUploading(draggedItem.id)}
-                                    isDragging
-                                    showDeleteButton={itemsState[itemsState.length - 1]?.id !== draggedItem.id}
+        <StyleProvider className="thumbnail-grid-block">
+            <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+                onDragStart={handleDragStart}
+                modifiers={[restrictToParentElement]}
+            >
+                <SortableContext items={itemsState} strategy={rectSortingStrategy}>
+                    <div className="tw-@container tw-translate-x-0 tw-isolate">
+                        <Grid columnCount={blockSettings.columnCount} gap={gap}>
+                            {itemsState.map((item, i) => (
+                                <SortableItem
+                                    key={item.id}
+                                    item={item}
+                                    isAssetViewerEnabled={isAssetViewerEnabled}
+                                    image={blockAssets?.[item.id]?.[0]}
+                                    isLoading={getIsItemUploading(item.id)}
+                                    showDeleteButton={i !== itemsState.length - 1}
+                                    openAssetInAssetViewer={openAssetInAssetViewer}
                                     {...thumbnailProps}
                                 />
-                            )}
-                        </DragOverlay>
-                    </SortableContext>
-                </DndContext>
-            </StyleProvider>
-        </div>
+                            ))}
+                        </Grid>
+                    </div>
+                    <DragOverlay>
+                        {draggedItem && (
+                            <Item
+                                key={draggedItem.id}
+                                item={draggedItem}
+                                image={blockAssets?.[draggedItem.id]?.[0]}
+                                isLoading={getIsItemUploading(draggedItem.id)}
+                                isDragging
+                                showDeleteButton={itemsState[itemsState.length - 1]?.id !== draggedItem.id}
+                                {...thumbnailProps}
+                            />
+                        )}
+                    </DragOverlay>
+                </SortableContext>
+            </DndContext>
+        </StyleProvider>
     );
 };

--- a/packages/ui-pattern-block/block-scope.json
+++ b/packages/ui-pattern-block/block-scope.json
@@ -1,0 +1,3 @@
+{
+    "scope": "ui-pattern-block"
+}

--- a/packages/ui-pattern-block/postcss.config.js
+++ b/packages/ui-pattern-block/postcss.config.js
@@ -1,9 +1,11 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+const blockScope = require('./block-scope.json');
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
-        require('../../postcss/scope')({ scope: '.ui-pattern-block' }),
+        require('../../postcss/scope')({ scope: blockScope.scope }),
     ],
 };

--- a/packages/ui-pattern-block/src/UIPatternBlock.spec.ct.tsx
+++ b/packages/ui-pattern-block/src/UIPatternBlock.spec.ct.tsx
@@ -10,7 +10,7 @@ import { Height, Padding, Preprocessor, SandpackTemplate, TextAlignment } from '
 import { UIPatternBlock } from './UIPatternBlock';
 
 const UiPatternBlockSelector = '[data-test-id="ui-pattern-block"]';
-const UiPatternBlockFlexboxSelector = '[data-test-id="ui-pattern-block"] > div > div';
+const UiPatternBlockFlexboxSelector = '[data-test-id="ui-pattern-block"] > div';
 const UiPatternBlockWrapperSelector = '[data-test-id="ui-pattern-block-wrapper"]';
 const ToolbarTabButtonSelector = '[data-test-id="toolbar-tab-btn"]';
 const ToolbarSelector = '[data-test-id="ui-pattern-files-toolbar"]';

--- a/packages/ui-pattern-block/src/UIPatternBlock.tsx
+++ b/packages/ui-pattern-block/src/UIPatternBlock.tsx
@@ -185,8 +185,8 @@ export const UIPatternBlock = withAttachmentsProvider(({ appBridge }: BlockProps
     const borderRadius = hasBorder ? getRadiusValue(hasRadius, radiusValue, radiusChoice) : 0;
 
     return (
-        <div key={sandpackTemplate} data-test-id="ui-pattern-block" className="ui-pattern-block">
-            <StyleProvider>
+        <StyleProvider className="ui-pattern-block">
+            <div key={sandpackTemplate} data-test-id="ui-pattern-block">
                 <div
                     className={joinClassNames([
                         'tw-flex tw-gap-3',
@@ -297,7 +297,7 @@ export const UIPatternBlock = withAttachmentsProvider(({ appBridge }: BlockProps
                         )}
                     </div>
                 </div>
-            </StyleProvider>
-        </div>
+            </div>
+        </StyleProvider>
     );
 }, ATTACHMENTS_ASSET_ID);

--- a/packages/ui-pattern-block/src/UIPatternBlock.tsx
+++ b/packages/ui-pattern-block/src/UIPatternBlock.tsx
@@ -17,6 +17,8 @@ import {
 import { StyleProvider } from '@frontify/guideline-blocks-shared';
 import { type ReactElement, useMemo, useRef, useState } from 'react';
 
+import blockScope from '../block-scope.json';
+
 import { Captions, CodeEditor, ExternalDependencies, NPMDependencies, ResponsivePreview } from './components';
 import { AttachmentsButton } from './components/AttachmentsButton';
 import {
@@ -185,7 +187,7 @@ export const UIPatternBlock = withAttachmentsProvider(({ appBridge }: BlockProps
     const borderRadius = hasBorder ? getRadiusValue(hasRadius, radiusValue, radiusChoice) : 0;
 
     return (
-        <StyleProvider className="ui-pattern-block">
+        <StyleProvider scope={blockScope.scope}>
             <div key={sandpackTemplate} data-test-id="ui-pattern-block">
                 <div
                     className={joinClassNames([

--- a/packages/ui-pattern-block/src/components/ResponsivePreview.tsx
+++ b/packages/ui-pattern-block/src/components/ResponsivePreview.tsx
@@ -8,6 +8,8 @@ import { joinClassNames } from '@frontify/guideline-blocks-settings';
 import { Fragment, type ReactElement, useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+import blockScope from '../../block-scope.json';
+
 interface Props {
     onClose: () => void;
 }
@@ -65,7 +67,7 @@ export const ResponsivePreview = ({ onClose }: Props): ReactElement => {
     }, [onPreviewClose]);
 
     return createPortal(
-        <div ref={modalRef} data-test-id="ui-pattern-responsive-preview" className="ui-pattern-block">
+        <div ref={modalRef} data-test-id="ui-pattern-responsive-preview" className={blockScope.scope}>
             <div className="tw-fixed tw-z-[5000] tw-box-border tw-w-full tw-h-full tw-top-0 tw-left-0 tw-p-6 tw-pb-12">
                 <div className="tw-w-full tw-h-full tw-flex tw-flex-col tw-gap-8 tw-items-center">
                     <button

--- a/postcss/scope.js
+++ b/postcss/scope.js
@@ -3,12 +3,23 @@
 /**
  * This custom plugin prepends every css rule in the generated style.css
  * with an extra selector, essentially scoping the whole css file to the specific block
+ *
+ * The `scope` option is the block scope class name (e.g. `text-block`) and has to come from the
+ * block's `block-scope.json`, which is the single source of truth shared with the block itself.
  */
 
 /**
  * @type {import('postcss').PluginCreator}
  */
 module.exports = (opts = {}) => {
+    if (!opts.scope) {
+        throw new Error(
+            "The scope plugin requires a `scope` option, read it from the block's `block-scope.json`",
+        );
+    }
+
+    const scopeSelector = `.${opts.scope}`;
+
     return {
         postcssPlugin: "scope",
         Root(root) {
@@ -24,7 +35,7 @@ module.exports = (opts = {}) => {
                     originalSelector
                         .split(/(?<!\\),\s*/g)
                         .map((individualSelector) =>
-                            getScopedSelector(individualSelector, opts.scope)
+                            getScopedSelector(individualSelector, scopeSelector)
                         )
                         .join(", ")
                 );

--- a/postcss/scope.js
+++ b/postcss/scope.js
@@ -24,9 +24,9 @@ module.exports = (opts = {}) => {
                     originalSelector
                         .split(/(?<!\\),\s*/g)
                         .map((individualSelector) =>
-                            getScopedSelector(individualSelector, opts.scope),
+                            getScopedSelector(individualSelector, opts.scope)
                         )
-                        .join(", "),
+                        .join(", ")
                 );
             });
         },
@@ -45,17 +45,9 @@ const getScopedSelector = (selector, scope) => {
 
     // Prefix all rules with .selector that match the condition
     if (selector.includes("tw-") || tagSelectorRegex.test(selector)) {
-        return `${scope} ${selector}${getModalExtensions(selector)}`;
+        return `${scope} ${selector}`;
     }
 
     // Return the original rule
     return selector;
-};
-
-const getModalExtensions = (selector) => {
-    if (!selector.includes(".")) {
-        return "";
-    }
-
-    return `, body > [role='toolbar'] ${selector}, body [data-overlay-container] ${selector}, body [role='dialog'] ${selector}, body [data-is-underlay="true"] ${selector}`;
 };


### PR DESCRIPTION
Instead of adding a bunch of modal related selectors, we now use ThemeProvider className. Adjusted all blocks, mostly just whitespace changes.

**Before:**

```
<div className="text-block">
    <StyleProvider>
        [...]
    </StyleProvider>
</div>
```

```
.text-block .myClass, body > [role='toolbar'] .myClass, body > [role="dialog"] .myClass { ... }
```

**After:**

```
<StyleProvider className="text-block">
    [...]
</StyleProvider>
```

```
.text-block .myClass { ... }
```