### PR TITLE
chore: move pnpm settings to pnpm-workspace.yaml and refresh security overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,31 +51,5 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
     },
-    "pnpm": {
-        "patchedDependencies": {
-            "@udecode/plate-emoji@31.4.0": "patches/@udecode__plate-emoji@31.4.0.patch"
-        },
-        "onlyBuiltDependencies": [
-            "cypress",
-            "msw",
-            "esbuild"
-        ],
-        "overrides": {
-            "ajv@>=7.0.0-alpha.0 <8.18.0": "^8.18.0",
-            "immer": "^10.2.0",
-            "minimatch@^3": "npm:minimatch@^3.1.4",
-            "lodash@^4": "^4.18.1",
-            "ws@>=8.0.0 <8.21.0": "^8.21.1",
-            "brace-expansion@>=2.0.0 <2.1.2": "^5.0.9",
-            "brace-expansion@>=3.0.0 <5.0.7": "^5.0.7",
-            "esbuild@<0.28.1": "^0.28.1",
-            "fast-uri@>=3.0.0 <3.1.4": "^4.1.2",
-            "tmp@<0.2.6": "^0.2.7",
-            "systeminformation@<5.31.7": "^5.33.0",
-            "form-data@>=4.0.0 <4.0.6": "^4.0.6",
-            "qs@>=6.11.1 <=6.15.1": "^6.15.3",
-            "uuid@<11.1.1": "^11.1.1"
-        }
-    },
     "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,9 @@ overrides:
   lodash@^4: ^4.18.1
   ws@>=8.0.0 <8.21.0: ^8.21.1
   brace-expansion@>=2.0.0 <2.1.2: ^5.0.9
-  brace-expansion@>=3.0.0 <5.0.7: ^5.0.7
+  brace-expansion@>=3.0.0 <5.0.9: ^5.0.9
   esbuild@<0.28.1: ^0.28.1
-  fast-uri@>=3.0.0 <3.1.4: ^4.1.2
+  fast-uri@>=3.0.0 <4.1.2: ^4.1.2
   tmp@<0.2.6: ^0.2.7
   systeminformation@<5.31.7: ^5.33.0
   form-data@>=4.0.0 <4.0.6: ^4.0.6
@@ -815,7 +815,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@types/node@25.6.0)(@vitest/ui@4.1.10)(happy-dom@20.8.9)(msw@2.12.14(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.10(@types/node@25.6.0)(@vitest/ui@4.1.10)(happy-dom@20.8.9)(msw@2.12.14(@types/node@25.6.0)(typescript@6.0.3))(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.3))
 
   packages/figma-block:
     dependencies:
@@ -6175,10 +6175,6 @@ packages:
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
-
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
@@ -7000,9 +6996,6 @@ packages:
 
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
-
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
 
   fast-uri@4.1.2:
     resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
@@ -14862,6 +14855,15 @@ snapshots:
       msw: 2.12.14(@types/node@25.6.0)(typescript@6.0.3)
       vite: 7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.1)(yaml@2.8.3)
 
+  '@vitest/mocker@4.1.10(msw@2.12.14(@types/node@25.6.0)(typescript@6.0.3))(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.14(@types/node@25.6.0)(typescript@6.0.3)
+      vite: 8.1.5(@types/node@25.6.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.3)
+
   '@vitest/pretty-format@4.1.10':
     dependencies:
       tinyrainbow: 3.1.1
@@ -14889,7 +14891,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@25.6.0)(@vitest/ui@4.1.10)(happy-dom@20.8.9)(msw@2.12.14(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.1)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@25.6.0)(@vitest/ui@4.1.10)(happy-dom@20.8.9)(msw@2.12.14(@types/node@25.6.0)(typescript@6.0.3))(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.3))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -15208,10 +15210,6 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-
-  brace-expansion@5.0.7:
-    dependencies:
-      balanced-match: 4.0.4
 
   brace-expansion@5.0.9:
     dependencies:
@@ -16342,7 +16340,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -16351,8 +16349,6 @@ snapshots:
   fast-querystring@1.1.2:
     dependencies:
       fast-decode-uri-component: 1.0.1
-
-  fast-uri@4.1.1: {}
 
   fast-uri@4.1.2: {}
 
@@ -17325,7 +17321,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@10.2.6:
     dependencies:
@@ -18879,6 +18875,21 @@ snapshots:
       terser: 5.46.1
       yaml: 2.8.3
 
+  vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.23
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.6.0
+      esbuild: 0.28.2
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      terser: 5.46.1
+      yaml: 2.8.3
+
   vitest@4.1.10(@types/node@25.6.0)(@vitest/ui@4.1.10)(happy-dom@20.8.9)(msw@2.12.14(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.10
@@ -18900,6 +18911,35 @@ snapshots:
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
       vite: 7.3.6(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.1)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+      '@vitest/ui': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.8.9
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@types/node@25.6.0)(@vitest/ui@4.1.10)(happy-dom@20.8.9)(msw@2.12.14(@types/node@25.6.0)(typescript@6.0.3))(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(msw@2.12.14(@types/node@25.6.0)(typescript@6.0.3))(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.1.5(@types/node@25.6.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,24 @@ prefer-workspace-packages: true
 packages:
     - "packages/*"
     - "examples/*"
+patchedDependencies:
+    "@udecode/plate-emoji@31.4.0": patches/@udecode__plate-emoji@31.4.0.patch
+onlyBuiltDependencies:
+    - cypress
+    - msw
+    - esbuild
+overrides:
+    "ajv@>=7.0.0-alpha.0 <8.18.0": ^8.18.0
+    immer: ^10.2.0
+    "minimatch@^3": npm:minimatch@^3.1.4
+    "lodash@^4": ^4.18.1
+    "ws@>=8.0.0 <8.21.0": ^8.21.1
+    "brace-expansion@>=2.0.0 <2.1.2": ^5.0.9
+    "brace-expansion@>=3.0.0 <5.0.9": ^5.0.9
+    "esbuild@<0.28.1": ^0.28.1
+    "fast-uri@>=3.0.0 <4.1.2": ^4.1.2
+    "tmp@<0.2.6": ^0.2.7
+    "systeminformation@<5.31.7": ^5.33.0
+    "form-data@>=4.0.0 <4.0.6": ^4.0.6
+    "qs@>=6.11.1 <=6.15.1": ^6.15.3
+    "uuid@<11.1.1": ^11.1.1


### PR DESCRIPTION
pnpm 10.30+ no longer reads the `pnpm` field from `package.json`, which produced this warning on every install:

> [WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.patchedDependencies", "pnpm.onlyBuiltDependencies", "pnpm.overrides".

Moved `patchedDependencies`, `onlyBuiltDependencies`, and `overrides` to `pnpm-workspace.yaml`, their new home.

Since the overrides were silently ignored, `pnpm audit` surfaced 3 high vulnerabilities — two of which were stale ranges that would have been missed regardless, because newer advisories raised the patched floor above the pinned targets:

| Package | Before | Resolved to | After |
| --- | --- | --- | --- |
| `brace-expansion` | `>=3.0.0 <5.0.7` → `^5.0.7` | `5.0.7` (vulnerable, needs ≥5.0.9) | `>=3.0.0 <5.0.9` → `^5.0.9` |
| `fast-uri` | `>=3.0.0 <3.1.4` → `^4.1.2` | `4.1.1` (range didn't cover 4.x) | `>=3.0.0 <4.1.2` → `^4.1.2` |
