### PR TITLE
fix(CalloutBlock): compute accessible text colors at WCAG AA 4.5:1

### DIFF
--- a/packages/callout-block/package.json
+++ b/packages/callout-block/package.json
@@ -24,6 +24,7 @@
     },
     "devDependencies": {
         "@babel/core": "^7.29.0",
+        "@ctrl/tinycolor": "^4.2.0",
         "@frontify/frontify-cli": "^6.2.6",
         "@frontify/oxfmt-config": "^0.0.2",
         "@frontify/oxlint-config-react": "^0.0.2",

--- a/packages/callout-block/src/CalloutBlock.spec.ct.tsx
+++ b/packages/callout-block/src/CalloutBlock.spec.ct.tsx
@@ -1,11 +1,16 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
+import { readability } from '@ctrl/tinycolor';
 import { AssetDummy, withAppBridgeBlockStubs } from '@frontify/app-bridge';
 import { mount } from 'cypress/react';
 
 import { CalloutBlock } from './CalloutBlock';
+import { getEffectiveBackgroundColor } from './helpers/color';
 import { ICON_ASSET_ID } from './settings';
 import { Alignment, Appearance, Icon, Padding, Type, Width } from './types';
+
+/** WCAG AA contrast for normal text — asserted via TinyColor, independent of production's own contrast math. */
+const MIN_WCAG_AA_CONTRAST = 4.5;
 
 const CalloutBlockSelector = '[data-test-id="callout-block"]';
 const RichTextEditorSelector = '[data-test-id="rich-text-editor"]';
@@ -16,6 +21,35 @@ const CalloutIconInfoSelector = '[data-test-id="callout-icon-info"]';
 
 const EXAMPLE_THEME_SETTINGS =
     ':root {--f-theme-settings-accent-color-info-color: rgba(26, 199, 211, 1); --f-theme-settings-accent-color-note-color: rgba(246, 216, 56, 1); --f-theme-settings-accent-color-tip-color: rgba(42, 191, 24, 1); --f-theme-settings-accent-color-warning-color: rgba(222, 27, 27, 1);}';
+
+const WHITE_SCHEME = 'rgb(255, 255, 255)';
+
+const expectReadableAdjustedTextColor = (accentRgb: string) => {
+    cy.get(HtmlContentSelector).should(($el) => {
+        const textColor = $el.css('color');
+        expect(textColor).not.to.eq(accentRgb);
+        expect(readability(textColor, getEffectiveBackgroundColor(accentRgb, WHITE_SCHEME))).to.be.at.least(
+            MIN_WCAG_AA_CONTRAST
+        );
+    });
+};
+
+const expectThemeTextColorsMatchBlockColor = (accentRgb: string) => {
+    cy.get(CalloutBlockSelector).should(($el) => {
+        const block = $el[0];
+        const textColor = getComputedStyle(block).color;
+        const heading = block.style.getPropertyValue('--f-theme-settings-heading1-color').trim();
+        const body = block.style.getPropertyValue('--f-theme-settings-body-color').trim();
+        const link = block.style.getPropertyValue('--f-theme-settings-link-color').trim();
+
+        expect(heading).to.eq(body);
+        expect(body).to.eq(link);
+        expect(heading.length).to.be.greaterThan(0);
+        expect(readability(textColor, getEffectiveBackgroundColor(accentRgb, WHITE_SCHEME))).to.be.at.least(
+            MIN_WCAG_AA_CONTRAST
+        );
+    });
+};
 
 describe('Callout Block', () => {
     beforeEach(() => {
@@ -149,7 +183,7 @@ describe('Callout Block', () => {
         mount(<CalloutBlockWithStubs />);
 
         cy.get(CalloutBlockSelector).should('have.css', 'background-color', 'rgba(26, 199, 211, 0.1)');
-        cy.get(HtmlContentSelector).should('have.css', 'color', 'rgb(26, 199, 211)');
+        expectReadableAdjustedTextColor('rgb(26, 199, 211)');
     });
 
     it('renders a callout block with the correct colors for type note', () => {
@@ -163,7 +197,7 @@ describe('Callout Block', () => {
         mount(<CalloutBlockWithStubs />);
 
         cy.get(CalloutBlockSelector).should('have.css', 'background-color', 'rgba(246, 216, 56, 0.1)');
-        cy.get(HtmlContentSelector).should('have.css', 'color', 'rgb(0, 0, 0)');
+        expectReadableAdjustedTextColor('rgb(246, 216, 56)');
     });
 
     it('renders a callout block with the correct colors for type tip', () => {
@@ -177,7 +211,7 @@ describe('Callout Block', () => {
         mount(<CalloutBlockWithStubs />);
 
         cy.get(CalloutBlockSelector).should('have.css', 'background-color', 'rgba(42, 191, 24, 0.1)');
-        cy.get(HtmlContentSelector).should('have.css', 'color', 'rgb(42, 191, 24)');
+        expectReadableAdjustedTextColor('rgb(42, 191, 24)');
     });
 
     it('renders a callout block with the correct colors for type warning', () => {
@@ -191,7 +225,7 @@ describe('Callout Block', () => {
         mount(<CalloutBlockWithStubs />);
 
         cy.get(CalloutBlockSelector).should('have.css', 'background-color', 'rgba(222, 27, 27, 0.1)');
-        cy.get(HtmlContentSelector).should('have.css', 'color', 'rgb(222, 27, 27)');
+        expectReadableAdjustedTextColor('rgb(222, 27, 27)');
     });
 
     it('renders a warning block with the overwritten css variables for the theme styles', () => {
@@ -204,12 +238,8 @@ describe('Callout Block', () => {
 
         mount(<CalloutBlockWithStubs />);
 
-        cy.get(CalloutBlockSelector)
-            .should('have.css', '--f-theme-settings-heading1-color', 'rgba(222, 27, 27, 1)')
-            .and('have.css', '--f-theme-settings-body-color', 'rgba(222, 27, 27, 1)')
-            .and('have.css', '--f-theme-settings-link-color', 'rgba(222, 27, 27, 1)')
-            .and('have.css', 'color', 'rgb(222, 27, 27)')
-            .and('have.css', 'background-color', 'rgba(222, 27, 27, 0.1)');
+        cy.get(CalloutBlockSelector).should('have.css', 'background-color', 'rgba(222, 27, 27, 0.1)');
+        expectThemeTextColorsMatchBlockColor('rgb(222, 27, 27)');
     });
 
     it('renders a note block with the overwritten css variables for the theme styles', () => {
@@ -222,12 +252,8 @@ describe('Callout Block', () => {
 
         mount(<CalloutBlockWithStubs />);
 
-        cy.get(CalloutBlockSelector)
-            .should('have.css', '--f-theme-settings-heading1-color', 'black')
-            .and('have.css', '--f-theme-settings-body-color', 'black')
-            .and('have.css', '--f-theme-settings-link-color', 'black')
-            .and('have.css', 'color', 'rgb(0, 0, 0)')
-            .and('have.css', 'background-color', 'rgba(246, 216, 56, 0.1)');
+        cy.get(CalloutBlockSelector).should('have.css', 'background-color', 'rgba(246, 216, 56, 0.1)');
+        expectThemeTextColorsMatchBlockColor('rgb(246, 216, 56)');
     });
 
     it('renders a callout block with light appearance', () => {
@@ -253,7 +279,7 @@ describe('Callout Block', () => {
         cy.get(HtmlContentSelector).should('have.css', 'color', 'rgb(50, 40, 145)');
     });
 
-    it('should turn text to white when a black accent sits on a black section background', () => {
+    it('should use a lighter readable text color when a black accent sits on a black section background', () => {
         cy.document().then((doc) => {
             const style = doc.querySelector('#test-settings');
             if (style) {
@@ -274,7 +300,13 @@ describe('Callout Block', () => {
         mount(<CalloutBlockWithStubs />);
 
         cy.get(CalloutBlockSelector).should('have.css', 'background-color', 'rgba(0, 0, 0, 0.1)');
-        cy.get(HtmlContentSelector).should('have.css', 'color', 'rgb(255, 255, 255)');
+        cy.get(HtmlContentSelector).should(($el) => {
+            const textColor = $el.css('color');
+            expect(textColor).not.to.eq('rgb(0, 0, 0)');
+            expect(readability(textColor, getEffectiveBackgroundColor('rgb(0, 0, 0)', 'rgb(0, 0, 0)'))).to.be.at.least(
+                MIN_WCAG_AA_CONTRAST
+            );
+        });
     });
 
     it('renders a callout block with strong appearance', () => {

--- a/packages/callout-block/src/helpers/color.spec.ts
+++ b/packages/callout-block/src/helpers/color.spec.ts
@@ -1,0 +1,124 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import { readability } from '@ctrl/tinycolor';
+import { THEME_PREFIX, toColorObject } from '@frontify/guideline-blocks-settings';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Appearance, Type } from '../types';
+
+import { computeStyles, getEffectiveBackgroundColor } from './color';
+
+const WHITE_SCHEME = 'rgb(255, 255, 255)';
+
+/** WCAG AA contrast for normal text — asserted via TinyColor, independent of production's own contrast math. */
+const MIN_WCAG_AA_CONTRAST = 4.5;
+
+const createHost = (cssVariables: Record<string, string>): HTMLDivElement => {
+    const host = document.createElement('div');
+    for (const [name, value] of Object.entries(cssVariables)) {
+        host.style.setProperty(name, value);
+    }
+    document.body.appendChild(host);
+    return host;
+};
+
+describe('computeStyles', () => {
+    afterEach(() => {
+        document.body.replaceChildren();
+    });
+
+    it('should keep the accent as text color for Light appearance when contrast meets WCAG AA', () => {
+        const accent = 'rgb(50, 40, 145)';
+        const host = createHost({
+            [`${THEME_PREFIX}accent-color-note-color`]: accent,
+            [`${THEME_PREFIX}background-color`]: WHITE_SCHEME,
+        });
+
+        const { textColor } = computeStyles(Type.Note, Appearance.Light, host);
+
+        expect(textColor).toBe(accent);
+        expect(readability(textColor, getEffectiveBackgroundColor(accent, WHITE_SCHEME))).toBeGreaterThanOrEqual(
+            MIN_WCAG_AA_CONTRAST
+        );
+    });
+
+    it('should darken the accent for Light appearance when contrast is too low', () => {
+        const accent = 'rgb(246, 216, 56)';
+        const host = createHost({
+            [`${THEME_PREFIX}accent-color-note-color`]: accent,
+            [`${THEME_PREFIX}background-color`]: WHITE_SCHEME,
+        });
+
+        const { textColor } = computeStyles(Type.Note, Appearance.Light, host);
+        const effectiveBackground = getEffectiveBackgroundColor(accent, WHITE_SCHEME);
+        const text = toColorObject(textColor);
+        const accentColor = toColorObject(accent);
+
+        expect(textColor).not.toBe(accent);
+        expect(text.red === text.green && text.green === text.blue).toBe(false);
+        expect(text.red).toBeLessThan(accentColor.red);
+        expect(text.green).toBeLessThan(accentColor.green);
+        expect(text.blue).toBeLessThan(accentColor.blue);
+        expect(readability(textColor, effectiveBackground)).toBeGreaterThanOrEqual(MIN_WCAG_AA_CONTRAST);
+    });
+
+    it('should lighten toward white for Light appearance on a dark scheme background', () => {
+        const accent = 'rgb(0, 0, 0)';
+        const scheme = 'rgb(0, 0, 0)';
+        const host = createHost({
+            [`${THEME_PREFIX}accent-color-note-color`]: accent,
+            [`${THEME_PREFIX}background-color`]: scheme,
+        });
+
+        const { textColor } = computeStyles(Type.Note, Appearance.Light, host);
+        const effectiveBackground = getEffectiveBackgroundColor(accent, scheme);
+        const { red, green, blue } = toColorObject(textColor);
+
+        expect(textColor).not.toBe(accent);
+        expect(red).toBe(green);
+        expect(green).toBe(blue);
+        expect(red).toBeGreaterThan(0);
+        expect(readability(textColor, effectiveBackground)).toBeGreaterThanOrEqual(MIN_WCAG_AA_CONTRAST);
+    });
+
+    it('should use white for Strong appearance on a dark accent', () => {
+        const accent = 'rgb(50, 40, 145)';
+        const host = createHost({
+            [`${THEME_PREFIX}accent-color-note-color`]: accent,
+            [`${THEME_PREFIX}background-color`]: WHITE_SCHEME,
+        });
+
+        const { backgroundColor, textColor } = computeStyles(Type.Note, Appearance.Strong, host);
+
+        expect(backgroundColor.trim()).toBe(accent);
+        expect(textColor).toBe('rgb(255, 255, 255)');
+        expect(readability(textColor, accent)).toBeGreaterThanOrEqual(MIN_WCAG_AA_CONTRAST);
+    });
+
+    it('should use black for Strong appearance on a light accent', () => {
+        const accent = 'rgb(246, 216, 56)';
+        const host = createHost({
+            [`${THEME_PREFIX}accent-color-note-color`]: accent,
+            [`${THEME_PREFIX}background-color`]: WHITE_SCHEME,
+        });
+
+        const { backgroundColor, textColor } = computeStyles(Type.Note, Appearance.Strong, host);
+
+        expect(backgroundColor.trim()).toBe(accent);
+        expect(textColor).toBe('rgb(0, 0, 0)');
+        expect(readability(textColor, accent)).toBeGreaterThanOrEqual(MIN_WCAG_AA_CONTRAST);
+    });
+
+    it('should use white for Strong appearance on a pure black background', () => {
+        const accent = 'rgb(0, 0, 0)';
+        const host = createHost({
+            [`${THEME_PREFIX}accent-color-note-color`]: accent,
+            [`${THEME_PREFIX}background-color`]: WHITE_SCHEME,
+        });
+
+        const { textColor } = computeStyles(Type.Note, Appearance.Strong, host);
+
+        expect(textColor).toBe('rgb(255, 255, 255)');
+        expect(readability(textColor, accent)).toBeGreaterThanOrEqual(MIN_WCAG_AA_CONTRAST);
+    });
+});

--- a/packages/callout-block/src/helpers/color.ts
+++ b/packages/callout-block/src/helpers/color.ts
@@ -1,10 +1,14 @@
 /* (c) Copyright Frontify Ltd., all rights reserved. */
 
-import { type Color, THEME_PREFIX, isDark, setAlpha, toColorObject } from '@frontify/guideline-blocks-settings';
+import { type Color, THEME_PREFIX, setAlpha, toColorObject } from '@frontify/guideline-blocks-settings';
 
 import { Appearance, Type } from '../types';
 
-const MIN_READABLE_CONTRAST = 1.9;
+/** WCAG AA contrast ratio for normal text */
+const MIN_READABLE_CONTRAST = 4.5;
+
+const WHITE = 'rgb(255, 255, 255)';
+const BLACK = 'rgb(0, 0, 0)';
 
 const getAccentColor = (type: Type, hostElement: HTMLDivElement | null): string => {
     const style = getComputedStyle(hostElement ?? document.body);
@@ -22,10 +26,10 @@ const getAccentColor = (type: Type, hostElement: HTMLDivElement | null): string 
 
 const getSchemeBackgroundColor = (hostElement: HTMLDivElement | null): string => {
     const style = getComputedStyle(hostElement ?? document.body);
-    return style.getPropertyValue(`${THEME_PREFIX}background-color`).trim() || 'rgb(255, 255, 255)';
+    return style.getPropertyValue(`${THEME_PREFIX}background-color`).trim() || WHITE;
 };
 
-const getEffectiveBackgroundColor = (accentColor: string, schemeBackgroundColor: string): string => {
+export const getEffectiveBackgroundColor = (accentColor: string, schemeBackgroundColor: string): string => {
     const accent = toColorObject(accentColor);
     const scheme = toColorObject(schemeBackgroundColor);
     const blendChannel = (channel: 'red' | 'green' | 'blue') =>
@@ -49,26 +53,64 @@ const getContrastRatio = (firstColor: string, secondColor: string): number => {
     return (lighter + 0.05) / (darker + 0.05);
 };
 
-const getReadableTextColor = (accentColor: string, backgroundColor: string): string => {
-    if (getContrastRatio(accentColor, backgroundColor) >= MIN_READABLE_CONTRAST) {
-        return accentColor;
+const isDarkBackground = (backgroundColor: string): boolean =>
+    getContrastRatio(WHITE, backgroundColor) > getContrastRatio(BLACK, backgroundColor);
+
+const toRgbString = ({ red, green, blue }: Pick<Color, 'red' | 'green' | 'blue'>): string =>
+    `rgb(${red}, ${green}, ${blue})`;
+
+const mixColors = (from: Color, to: Color, amount: number): string => {
+    const mixChannel = (channel: 'red' | 'green' | 'blue') =>
+        Math.round(from[channel] + (to[channel] - from[channel]) * amount);
+    return toRgbString({ red: mixChannel('red'), green: mixChannel('green'), blue: mixChannel('blue') });
+};
+
+/**
+ * Mix `from` toward `to` with the smallest amount that still meets WCAG AA against the background.
+ * Callers pass a `to` pole that already meets AA (white/black via isDarkBackground).
+ */
+const mixUntilContrast = (from: string, to: string, backgroundColor: string): string => {
+    if (getContrastRatio(from, backgroundColor) >= MIN_READABLE_CONTRAST) {
+        return from;
     }
 
-    const whiteContrast = getContrastRatio('rgb(255, 255, 255)', backgroundColor);
-    const blackContrast = getContrastRatio('rgb(0, 0, 0)', backgroundColor);
-    return whiteContrast > blackContrast ? 'white' : 'black';
+    const fromColor = toColorObject(from);
+    const toColor = toColorObject(to);
+    let low = 0;
+    let high = 1000;
+    let best = to;
+
+    while (low <= high) {
+        const mid = Math.floor((low + high) / 2);
+        const candidate = mixColors(fromColor, toColor, mid / 1000);
+        if (getContrastRatio(candidate, backgroundColor) >= MIN_READABLE_CONTRAST) {
+            best = candidate;
+            high = mid - 1;
+        } else {
+            low = mid + 1;
+        }
+    }
+
+    return best;
 };
+
+/** Strong appearance: white on dark backgrounds, black on light ones. */
+const getStrongTextColor = (backgroundColor: string): string => (isDarkBackground(backgroundColor) ? WHITE : BLACK);
+
+/** Light appearance: keep the accent when it meets AA, otherwise mix toward black/white. */
+const getLightTextColor = (accentColor: string, backgroundColor: string): string =>
+    mixUntilContrast(accentColor, isDarkBackground(backgroundColor) ? WHITE : BLACK, backgroundColor);
 
 export const computeStyles = (type: Type, appearance: Appearance, hostElement: HTMLDivElement | null) => {
     const accentColor = getAccentColor(type, hostElement);
 
     if (appearance === Appearance.Strong) {
-        return { backgroundColor: accentColor, textColor: isDark(accentColor, 185) ? 'white' : 'black' };
+        return { backgroundColor: accentColor, textColor: getStrongTextColor(accentColor) };
     }
 
     const backgroundColor = setAlpha(0.1, accentColor);
     const effectiveBackgroundColor = getEffectiveBackgroundColor(accentColor, getSchemeBackgroundColor(hostElement));
-    const textColor = getReadableTextColor(accentColor, effectiveBackgroundColor);
+    const textColor = getLightTextColor(accentColor, effectiveBackgroundColor);
 
     return { backgroundColor, textColor };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,6 +440,9 @@ importers:
       '@babel/core':
         specifier: ^7.29.0
         version: 7.29.7
+      '@ctrl/tinycolor':
+        specifier: ^4.2.0
+        version: 4.2.0
       '@frontify/frontify-cli':
         specifier: ^6.2.6
         version: 6.2.6(@types/node@25.6.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.3)


### PR DESCRIPTION
- Raise callout text contrast to WCAG AA 4.5:1
- Light: keep the accent when it already passes, otherwise mix it toward black/white
- Strong: pick white or black from contrast
- Tests assert AA with TinyColor instead of hardcoded mixer RGBs