### PR TITLE
feat(QuoteBlock): add settings schema

### DIFF
--- a/packages/quote-block/manifest.json
+++ b/packages/quote-block/manifest.json
@@ -75,15 +75,11 @@
             },
             "isCustomQuoteStyleLeft": {
                 "type": "boolean",
-                "frontify-translatable": true,
-                "frontify-machine-translatable": false,
                 "frontify-api-read": true,
                 "frontify-api-write": true
             },
             "isCustomQuoteStyleRight": {
                 "type": "boolean",
-                "frontify-translatable": true,
-                "frontify-machine-translatable": false,
                 "frontify-api-read": true,
                 "frontify-api-write": true
             },
@@ -103,8 +99,6 @@
                     "None",
                     "Custom"
                 ],
-                "frontify-translatable": true,
-                "frontify-machine-translatable": false,
                 "frontify-api-read": true,
                 "frontify-api-write": true
             },
@@ -124,8 +118,6 @@
                     "None",
                     "Custom"
                 ],
-                "frontify-translatable": true,
-                "frontify-machine-translatable": false,
                 "frontify-api-read": true,
                 "frontify-api-write": true
             },

--- a/packages/quote-block/manifest.json
+++ b/packages/quote-block/manifest.json
@@ -1,8 +1,184 @@
 {
     "appId": "cl5wcp42a00010jw8t6x51t6n",
-    "i18nFields": ["content"],
-    "searchFields": [
-        { "settingId": "authorName", "type": "string" },
-        { "settingId": "content", "type": "fondueRte" }
-    ]
+    "settingsSchema": {
+        "type": "object",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "color": {
+                "type": ["null", "object"],
+                "required": ["red", "green", "blue"],
+                "additionalProperties": false,
+                "properties": {
+                    "red": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "green": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "blue": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "alpha": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "name": { "type": "string", "frontify-api-read": true, "frontify-api-write": true }
+                }
+            }
+        },
+        "required": [
+            "type",
+            "isCustomQuoteStyleLeft",
+            "isCustomQuoteStyleRight",
+            "quoteStyleLeft",
+            "quoteStyleRight",
+            "showAuthor",
+            "textAlignment",
+            "quotationMarksAnchoring",
+            "isCustomSize",
+            "sizeChoice",
+            "showAccentLine",
+            "lineType",
+            "lineWidthValue"
+        ],
+        "additionalProperties": false,
+        "properties": {
+            "content": {
+                "type": "string",
+                "frontify-type": "fondueRte",
+                "frontify-serializable": true,
+                "frontify-serialization-index": 2,
+                "frontify-translatable": true,
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "type": {
+                "type": "string",
+                "enum": ["QuotationMarks", "Indentation"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "isCustomQuoteStyleLeft": {
+                "type": "boolean",
+                "frontify-translatable": true,
+                "frontify-machine-translatable": false,
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "isCustomQuoteStyleRight": {
+                "type": "boolean",
+                "frontify-translatable": true,
+                "frontify-machine-translatable": false,
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "quoteStyleLeft": {
+                "type": "string",
+                "enum": [
+                    "DoubleUp",
+                    "DoubleDown",
+                    "SingleUp",
+                    "SingleDown",
+                    "DoubleChevronLeft",
+                    "DoubleChevronRight",
+                    "SingleChevronLeft",
+                    "SingleChevronRight",
+                    "HookBracketLeft",
+                    "HookBracketRight",
+                    "None",
+                    "Custom"
+                ],
+                "frontify-translatable": true,
+                "frontify-machine-translatable": false,
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "quoteStyleRight": {
+                "type": "string",
+                "enum": [
+                    "DoubleUp",
+                    "DoubleDown",
+                    "SingleUp",
+                    "SingleDown",
+                    "DoubleChevronLeft",
+                    "DoubleChevronRight",
+                    "SingleChevronLeft",
+                    "SingleChevronRight",
+                    "HookBracketLeft",
+                    "HookBracketRight",
+                    "None",
+                    "Custom"
+                ],
+                "frontify-translatable": true,
+                "frontify-machine-translatable": false,
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "showAuthor": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "authorName": {
+                "type": "string",
+                "frontify-serializable": true,
+                "frontify-serialization-index": 1,
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "textAlignment": {
+                "type": "string",
+                "enum": ["left", "center", "right"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "quotationMarksAnchoring": {
+                "type": "string",
+                "enum": ["fullWidth", "hugText"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "isCustomSize": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "sizeChoice": {
+                "type": "string",
+                "enum": ["SmallSize", "MediumSize", "LargeSize"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "sizeValue": {
+                "type": "string",
+                "pattern": "^[0-9]+px$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "isCustomQuotesColor": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "quotesColor": { "$ref": "#/$defs/color" },
+            "showAccentLine": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "lineType": {
+                "type": "string",
+                "enum": ["solid", "dashed", "dotted"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "lineWidthValue": {
+                "type": "string",
+                "pattern": "^[0-9]+px$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "isCustomLineColor": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "accentLineColor": { "$ref": "#/$defs/color" }
+        }
+    }
 }


### PR DESCRIPTION
# Data fix PR for anomalies

https://github.com/Frontify/app-server/pull/33303

# Block settings usage

App: `cl5wcp42a00010jw8t6x51t6n`

| Metric | Value |
| --- | ---: |
| Customers scanned | 1,860 |
| Customers with blocks | 1,263 |
| Total blocks | 57,145 |
| Distinct fields | 47 |

## Field usage

`% blocks` is share of all blocks carrying the field. `% customers` is share of tenants where it appears at least once.

| Field | Blocks | % blocks | Customers | % customers | Types |
| --- | ---: | ---: | ---: | ---: | --- |
| `quoteStyleRight` | 57,141 | 100.0% | 1,263 | 100.0% | string |
| `isCustomSize` | 57,140 | 100.0% | 1,263 | 100.0% | boolean |
| `lineType` | 57,140 | 100.0% | 1,263 | 100.0% | string |
| `quoteStyleLeft` | 57,140 | 100.0% | 1,263 | 100.0% | string |
| `showAccentLine` | 57,140 | 100.0% | 1,263 | 100.0% | boolean |
| `showAuthor` | 57,140 | 100.0% | 1,263 | 100.0% | boolean |
| `sizeChoice` | 57,140 | 100.0% | 1,263 | 100.0% | string |
| `type` | 57,140 | 100.0% | 1,263 | 100.0% | string |
| `lineWidthValue` | 57,123 | 100.0% | 1,263 | 100.0% | string |
| `quotationMarksAnchoring` | 57,119 | 100.0% | 1,263 | 100.0% | string |
| `quotesColor.blue` | 57,119 | 100.0% | 1,263 | 100.0% | integer |
| `quotesColor.green` | 57,119 | 100.0% | 1,263 | 100.0% | integer |
| `quotesColor.red` | 57,119 | 100.0% | 1,263 | 100.0% | integer |
| `textAlignment` | 57,119 | 100.0% | 1,263 | 100.0% | string |
| `isCustomQuoteStyleLeft` | 57,118 | 100.0% | 1,263 | 100.0% | boolean |
| `isCustomQuoteStyleRight` | 57,118 | 100.0% | 1,263 | 100.0% | boolean |
| `accentLineColor.blue` | 57,108 | 99.9% | 1,263 | 100.0% | integer |
| `accentLineColor.green` | 57,108 | 99.9% | 1,263 | 100.0% | integer |
| `accentLineColor.red` | 57,108 | 99.9% | 1,263 | 100.0% | integer |
| `accentLineColor` | 57,084 | 99.9% | 1,262 | 99.9% | object |
| `accentLineColor.name` | 57,001 | 99.7% | 1,261 | 99.8% | string |
| `quotesColor.name` | 56,826 | 99.4% | 1,262 | 99.9% | string |
| `accentLineColor.alpha` | 56,587 | 99.0% | 1,261 | 99.8% | integer |
| `quotesColor` | 56,316 | 98.5% | 1,260 | 99.8% | object |
| `quotesColor.alpha` | 55,097 | 96.4% | 1,258 | 99.6% | integer |
| `content` | 55,094 | 96.4% | 1,172 | 92.8% | string |
| `isCustomQuotesColor` | 45,841 | 80.2% | 1,183 | 93.7% | boolean |
| `isCustomLineColor` | 45,691 | 80.0% | 1,182 | 93.6% | boolean |
| `sizeValue` | 7,670 | 13.4% | 411 | 32.5% | string |
| `project` | 1,077 | 1.9% | 110 | 8.7% | integer |
| `authorName` | 917 | 1.6% | 158 | 12.5% | string |
| `accentLinecolor` | 40 | 0.1% | 2 | 0.2% | object |
| `accentLinecolor.name` | 40 | 0.1% | 2 | 0.2% | string |
| `accentLinecolor.alpha` | 23 | 0.0% | 2 | 0.2% | integer |
| `accentLinecolor.blue` | 23 | 0.0% | 2 | 0.2% | integer |
| `accentLinecolor.green` | 23 | 0.0% | 2 | 0.2% | integer |
| `accentLinecolor.red` | 23 | 0.0% | 2 | 0.2% | integer |
| `accentLinecolor.a` | 17 | 0.0% | 2 | 0.2% | integer |
| `accentLinecolor.b` | 17 | 0.0% | 2 | 0.2% | integer |
| `accentLinecolor.g` | 17 | 0.0% | 2 | 0.2% | integer |
| `accentLinecolor.r` | 17 | 0.0% | 2 | 0.2% | integer |
| `isCustomLineWidth` | 17 | 0.0% | 2 | 0.2% | boolean |
| `lineWidthChoice` | 17 | 0.0% | 2 | 0.2% | string |
| `quotesColor.a` | 17 | 0.0% | 2 | 0.2% | integer |
| `quotesColor.b` | 17 | 0.0% | 2 | 0.2% | integer |
| `quotesColor.g` | 17 | 0.0% | 2 | 0.2% | integer |
| `quotesColor.r` | 17 | 0.0% | 2 | 0.2% | integer |

