### PR TITLE
fix(CodeSnippetBlock): keep code text in the selected scheme's foreground [GCM-566]

### DIFF
--- a/packages/code-snippet-block/src/CodeSnippetBlock.spec.tsx
+++ b/packages/code-snippet-block/src/CodeSnippetBlock.spec.tsx
@@ -31,6 +31,7 @@ const TOOLTIP_CONTENT_TEST_ID = 'fondue-tooltip-content';
 const EDITOR_SELECTOR = '.cm-editor';
 const LINE_NUMBERS_SELECTOR = '.cm-lineNumbers';
 const LINE_TOKEN_SELECTOR = '.cm-line span';
+const LINE_SELECTOR = '.cm-line';
 
 const EXAMPLE_COLOR: Color = { red: 22, green: 181, blue: 181, name: 'Java' };
 
@@ -134,6 +135,28 @@ describe('Code Snippet Block', () => {
 
         expect(getComputedStyle(tokens[0]).color).toBe('#708');
         expect(getComputedStyle(tokens[1]).color).toBe('#00f');
+    });
+
+    it('should paint untokenized text in the foreground of the selected dark theme', () => {
+        const { container } = renderCodeSnippetBlock({
+            blockSettings: { theme: 'dracula', content: 'some plain text' },
+        });
+
+        const line = container.querySelector(LINE_SELECTOR);
+
+        expect(line).not.toBeNull();
+        expect(getComputedStyle(line as Element).color).toBe('#f8f8f2');
+    });
+
+    it('should paint untokenized text in black when the default theme is selected', () => {
+        const { container } = renderCodeSnippetBlock({
+            blockSettings: { theme: 'default', content: 'some plain text' },
+        });
+
+        const line = container.querySelector(LINE_SELECTOR);
+
+        expect(line).not.toBeNull();
+        expect(getComputedStyle(line as Element).color).toBe('#000000');
     });
 
     it('should switch the language from the dropdown inside the block', async () => {

--- a/packages/code-snippet-block/src/CodeSnippetBlock.tsx
+++ b/packages/code-snippet-block/src/CodeSnippetBlock.tsx
@@ -26,7 +26,6 @@ export const CodeSnippetBlock: FC<BlockProps> = ({ appBridge }) => {
     const [contentValue] = useState(blockSettings.content);
     const [pendingLanguage, setPendingLanguage] = useState<Language>();
     const selectedLanguage = pendingLanguage ?? blockSettings.language ?? 'plain';
-    const extensions = useCodeMirrorExtensions(selectedLanguage);
     const [isCopied, setIsCopied] = useState(false);
     const [isCopyTooltipOpen, setIsCopyTooltipOpen] = useState(false);
     const labelId = useMemo(() => `${appBridge.context('blockId').get()}-header`, [appBridge]);
@@ -41,6 +40,8 @@ export const CodeSnippetBlock: FC<BlockProps> = ({ appBridge }) => {
         theme = 'default',
     } = blockSettings;
 
+    const extensions = useCodeMirrorExtensions(selectedLanguage, theme);
+
     const getTheme = () => {
         if (theme !== 'default' && Object.keys(themes).includes(theme)) {
             return themes[theme];
@@ -48,7 +49,7 @@ export const CodeSnippetBlock: FC<BlockProps> = ({ appBridge }) => {
         return 'light';
     };
 
-    const getStyle = () => headerThemes[blockSettings.theme ?? 'default'];
+    const getStyle = () => headerThemes[theme];
 
     const getCopyButtonText = () =>
         isCopied ? (

--- a/packages/code-snippet-block/src/hooks/useCodeMirrorExtensions.ts
+++ b/packages/code-snippet-block/src/hooks/useCodeMirrorExtensions.ts
@@ -16,9 +16,7 @@ export const useCodeMirrorExtensions = (selectedLanguage: Language, selectedThem
             extensions.push(langs[selectedLanguage]());
         }
 
-        // Shields the editor from typography inherited from the guideline theme. The colour has to be
-        // the selected scheme's own foreground: `initial` would resolve to black and make every dark
-        // scheme unreadable, while leaving it out lets the guideline's body colour bleed in.
+        // Prevent inherited typography from overriding CodeMirror token styling.
         extensions.push(
             EditorView.theme({
                 '&.cm-editor': {

--- a/packages/code-snippet-block/src/hooks/useCodeMirrorExtensions.ts
+++ b/packages/code-snippet-block/src/hooks/useCodeMirrorExtensions.ts
@@ -5,9 +5,10 @@ import { langs } from '@uiw/codemirror-extensions-langs';
 import { type Extension } from '@uiw/react-codemirror';
 import { useMemo } from 'react';
 
-import { type Language } from '../types';
+import { themeForegrounds } from '../themeForegrounds';
+import { type Language, type Theme } from '../types';
 
-export const useCodeMirrorExtensions = (selectedLanguage: Language): Extension[] =>
+export const useCodeMirrorExtensions = (selectedLanguage: Language, selectedTheme: Theme): Extension[] =>
     useMemo(() => {
         const extensions: Extension[] = [];
 
@@ -15,7 +16,9 @@ export const useCodeMirrorExtensions = (selectedLanguage: Language): Extension[]
             extensions.push(langs[selectedLanguage]());
         }
 
-        // Prevent inherited typography from overriding CodeMirror token styling.
+        // Shields the editor from typography inherited from the guideline theme. The colour has to be
+        // the selected scheme's own foreground: `initial` would resolve to black and make every dark
+        // scheme unreadable, while leaving it out lets the guideline's body colour bleed in.
         extensions.push(
             EditorView.theme({
                 '&.cm-editor': {
@@ -23,10 +26,10 @@ export const useCodeMirrorExtensions = (selectedLanguage: Language): Extension[]
                 },
                 '.cm-content, .cm-line': {
                     letterSpacing: 'normal',
-                    color: 'initial',
+                    color: themeForegrounds[selectedTheme],
                 },
             })
         );
 
         return extensions;
-    }, [selectedLanguage]);
+    }, [selectedLanguage, selectedTheme]);

--- a/packages/code-snippet-block/src/themeForegrounds.ts
+++ b/packages/code-snippet-block/src/themeForegrounds.ts
@@ -22,16 +22,8 @@ import {
 
 import { type Theme } from './types';
 
-/**
- * CodeMirror's built-in light theme sets no foreground of its own, so the "Default theme" choice
- * falls back to the same black the browser would paint.
- */
 const DEFAULT_THEME_FOREGROUND = '#000000';
 
-/**
- * The foreground each colour scheme paints its code in. Taken from the theme packages themselves so
- * the values cannot drift away from what CodeMirror actually renders.
- */
 export const themeForegrounds: Record<Theme, string> = {
     default: DEFAULT_THEME_FOREGROUND,
     abcdef: defaultSettingsAbcdef.foreground ?? DEFAULT_THEME_FOREGROUND,

--- a/packages/code-snippet-block/src/themeForegrounds.ts
+++ b/packages/code-snippet-block/src/themeForegrounds.ts
@@ -1,0 +1,54 @@
+/* (c) Copyright Frontify Ltd., all rights reserved. */
+
+import {
+    defaultSettingsAbcdef,
+    defaultSettingsAndroidstudio,
+    defaultSettingsAtomone,
+    defaultSettingsBbedit,
+    defaultSettingsBespin,
+    defaultSettingsDarcula,
+    defaultSettingsDracula,
+    defaultSettingsDuotoneDark,
+    defaultSettingsDuotoneLight,
+    defaultSettingsEclipse,
+    defaultSettingsGithubDark,
+    defaultSettingsGithubLight,
+    defaultSettingsGruvboxDark,
+    defaultSettingsOkaidia,
+    defaultSettingsSublime,
+    defaultSettingsXcodeDark,
+    defaultSettingsXcodeLight,
+} from '@uiw/codemirror-themes-all';
+
+import { type Theme } from './types';
+
+/**
+ * CodeMirror's built-in light theme sets no foreground of its own, so the "Default theme" choice
+ * falls back to the same black the browser would paint.
+ */
+const DEFAULT_THEME_FOREGROUND = '#000000';
+
+/**
+ * The foreground each colour scheme paints its code in. Taken from the theme packages themselves so
+ * the values cannot drift away from what CodeMirror actually renders.
+ */
+export const themeForegrounds: Record<Theme, string> = {
+    default: DEFAULT_THEME_FOREGROUND,
+    abcdef: defaultSettingsAbcdef.foreground ?? DEFAULT_THEME_FOREGROUND,
+    androidstudio: defaultSettingsAndroidstudio.foreground ?? DEFAULT_THEME_FOREGROUND,
+    atomone: defaultSettingsAtomone.foreground ?? DEFAULT_THEME_FOREGROUND,
+    bbedit: defaultSettingsBbedit.foreground ?? DEFAULT_THEME_FOREGROUND,
+    bespin: defaultSettingsBespin.foreground ?? DEFAULT_THEME_FOREGROUND,
+    darcula: defaultSettingsDarcula.foreground ?? DEFAULT_THEME_FOREGROUND,
+    dracula: defaultSettingsDracula.foreground ?? DEFAULT_THEME_FOREGROUND,
+    duotoneDark: defaultSettingsDuotoneDark.foreground ?? DEFAULT_THEME_FOREGROUND,
+    duotoneLight: defaultSettingsDuotoneLight.foreground ?? DEFAULT_THEME_FOREGROUND,
+    eclipse: defaultSettingsEclipse.foreground ?? DEFAULT_THEME_FOREGROUND,
+    githubDark: defaultSettingsGithubDark.foreground ?? DEFAULT_THEME_FOREGROUND,
+    githubLight: defaultSettingsGithubLight.foreground ?? DEFAULT_THEME_FOREGROUND,
+    gruvboxDark: defaultSettingsGruvboxDark.foreground ?? DEFAULT_THEME_FOREGROUND,
+    okaidia: defaultSettingsOkaidia.foreground ?? DEFAULT_THEME_FOREGROUND,
+    sublime: defaultSettingsSublime.foreground ?? DEFAULT_THEME_FOREGROUND,
+    xcodeDark: defaultSettingsXcodeDark.foreground ?? DEFAULT_THEME_FOREGROUND,
+    xcodeLight: defaultSettingsXcodeLight.foreground ?? DEFAULT_THEME_FOREGROUND,
+};


### PR DESCRIPTION
## GCM-566 — Code snippet text turns black in dark schemes

**Before** :

![Before](https://raw.githubusercontent.com/Frontify/guideline-blocks/gcm-566-screenshots/before.png)

**After**:

![After](https://raw.githubusercontent.com/Frontify/guideline-blocks/gcm-566-screenshots/after.png)

### Root cause

`useCodeMirrorExtensions` shields the editor from typography inherited from the guideline theme (introduced in #1292). Part of that shield was:

```ts
'.cm-content, .cm-line': {
    letterSpacing: 'normal',
    color: 'initial',
},
```

`initial` is not "whatever CodeMirror would do" — for `color` it resolves to black. 