### PR TITLE
feat(AudioBlock): add settings schema

### DIFF
--- a/packages/audio-block/manifest.json
+++ b/packages/audio-block/manifest.json
@@ -1,8 +1,46 @@
 {
     "appId": "clepuuziz00010iw1zvjzlvme",
-    "i18nFields": ["title", "description"],
-    "searchFields": [
-        { "settingId": "title", "type": "fondueRte" },
-        { "settingId": "description", "type": "fondueRte" }
-    ]
+    "settingsSchema": {
+        "type": "object",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "required": ["positioning", "security", "downloadable"],
+        "additionalProperties": false,
+        "properties": {
+            "title": {
+                "type": "string",
+                "frontify-type": "fondueRte",
+                "frontify-serializable": true,
+                "frontify-serialization-index": 1,
+                "frontify-translatable": true,
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "description": {
+                "type": "string",
+                "frontify-type": "fondueRte",
+                "frontify-serializable": true,
+                "frontify-serialization-index": 2,
+                "frontify-translatable": true,
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "positioning": {
+                "type": "string",
+                "enum": ["Above", "Below"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "security": {
+                "type": "string",
+                "enum": ["Global", "Custom"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "downloadable": {
+                "type": "boolean",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            }
+        }
+    }
 }


### PR DESCRIPTION
# Data fix PR for anomalies

https://github.com/Frontify/app-server/pull/33480

# Block settings usage

App: `clepuuziz00010iw1zvjzlvme`

| Metric | Value |
| --- | ---: |
| Customers scanned | 1,860 |
| Customers with blocks | 438 |
| Total blocks | 20,321 |
| Distinct fields | 10 |

## Field usage

`% blocks` is share of all blocks carrying the field. `% customers` is share of tenants where it appears at least once.

| Field | Blocks | % blocks | Customers | % customers | Types |
| --- | ---: | ---: | ---: | ---: | --- |
| `downloadable` | 20,279 | 99.8% | 437 | 99.8% | boolean |
| `positioning` | 20,279 | 99.8% | 437 | 99.8% | string |
| `security` | 20,279 | 99.8% | 437 | 99.8% | string |
| `title` | 18,612 | 91.6% | 369 | 84.2% | string |
| `description` | 2,407 | 11.8% | 134 | 30.6% | string |
| `attachments[]` | 42 | 0.2% | 1 | 0.2% | object |
| `attachments[].id` | 42 | 0.2% | 1 | 0.2% | integer |
| `attachments` | 24 | 0.1% | 1 | 0.2% | array |
| `attachments_order[]` | 6 | 0.0% | 1 | 0.2% | integer |
| `attachments_order` | 2 | 0.0% | 1 | 0.2% | array |

---

Schema validation script ran successfully: [https://rundeck-engineering.frontify.io/execution/show/200251#nodes](https://rundeck-engineering.frontify.io/execution/show/200251#nodes)