### PR TITLE
feat(AssetKitBlock): add settings schema

### DIFF
--- a/packages/asset-kit-block/manifest.json
+++ b/packages/asset-kit-block/manifest.json
@@ -1,8 +1,135 @@
 {
     "appId": "cle6w2ie00001c0w4oq99llxh",
-    "i18nFields": ["title", "description", "buttonText"],
-    "searchFields": [
-        { "settingId": "title", "type": "fondueRte" },
-        { "settingId": "description", "type": "fondueRte" }
-    ]
+    "settingsSchema": {
+        "type": "object",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "color": {
+                "type": ["null", "object"],
+                "required": ["red", "green", "blue"],
+                "additionalProperties": false,
+                "properties": {
+                    "red": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "green": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "blue": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "alpha": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "name": { "type": "string", "frontify-api-read": true, "frontify-api-write": true }
+                }
+            },
+            "borderStyle": {
+                "type": "string",
+                "enum": ["Solid", "Dotted", "Dashed"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "sizeChoice": {
+                "type": "string",
+                "enum": ["None", "Small", "Medium", "Large"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "pixelValue": {
+                "type": "string",
+                "pattern": "^[0-9]+px$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            }
+        },
+        "required": [
+            "showThumbnails",
+            "showCount",
+            "assetCountColor",
+            "hasBackgroundBlocks",
+            "hasBorder_blocks",
+            "borderStyle_blocks",
+            "borderWidth_blocks",
+            "hasRadius_blocks",
+            "radiusChoice_blocks",
+            "hasBackgroundThumbnails",
+            "hasBorder_thumbnails",
+            "borderStyle_thumbnails",
+            "borderWidth_thumbnails",
+            "hasRadius_thumbnails",
+            "radiusChoice_thumbnails"
+        ],
+        "additionalProperties": false,
+        "properties": {
+            "title": {
+                "type": "string",
+                "frontify-type": "fondueRte",
+                "frontify-serializable": true,
+                "frontify-serialization-index": 1,
+                "frontify-translatable": true,
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "description": {
+                "type": "string",
+                "frontify-type": "fondueRte",
+                "frontify-serializable": true,
+                "frontify-serialization-index": 2,
+                "frontify-translatable": true,
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "buttonText": {
+                "type": "string",
+                "frontify-type": "fondueRte",
+                "frontify-translatable": true,
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "showThumbnails": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "showCount": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "assetCountColor": {
+                "type": "string",
+                "enum": ["inherit", "override"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "countCustomColor": { "$ref": "#/$defs/color" },
+            "hasBackgroundBlocks": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "backgroundColorBlocks": { "$ref": "#/$defs/color" },
+            "hasBorder_blocks": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "borderStyle_blocks": { "$ref": "#/$defs/borderStyle" },
+            "borderWidth_blocks": { "$ref": "#/$defs/pixelValue" },
+            "borderColor_blocks": { "$ref": "#/$defs/color" },
+            "hasRadius_blocks": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "radiusChoice_blocks": { "$ref": "#/$defs/sizeChoice" },
+            "radiusValue_blocks": { "$ref": "#/$defs/pixelValue" },
+            "hasBackgroundThumbnails": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "backgroundColorThumbnails": { "$ref": "#/$defs/color" },
+            "hasBorder_thumbnails": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "borderStyle_thumbnails": { "$ref": "#/$defs/borderStyle" },
+            "borderWidth_thumbnails": { "$ref": "#/$defs/pixelValue" },
+            "borderColor_thumbnails": { "$ref": "#/$defs/color" },
+            "hasRadius_thumbnails": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "radiusChoice_thumbnails": { "$ref": "#/$defs/sizeChoice" },
+            "radiusValue_thumbnails": { "$ref": "#/$defs/pixelValue" }
+        }
+    }
 }

--- a/packages/asset-kit-block/src/AssetKitBlock.spec.ct.tsx
+++ b/packages/asset-kit-block/src/AssetKitBlock.spec.ct.tsx
@@ -381,9 +381,6 @@ describe('AssetKit Block', () => {
 
     it('should announce the download to screen readers if download happened', () => {
         const [AssetKitBlockWithStubs] = withAppBridgeBlockStubs(AssetKitBlock, {
-            blockSettings: {
-                downloadUrlBlock: 'dummy-download-url',
-            },
             blockAssets: {
                 [ASSET_SETTINGS_ID]: [AssetDummy.with(1)],
             },

--- a/packages/asset-kit-block/src/types.ts
+++ b/packages/asset-kit-block/src/types.ts
@@ -26,7 +26,6 @@ export type Settings = {
     radiusValue_thumbnails?: number;
     description?: string;
     title?: string;
-    downloadUrlBlock?: string;
     showThumbnails?: boolean;
     showCount?: boolean;
     assetCountColor?: 'inherit' | 'override';


### PR DESCRIPTION
# Data fix PR for anomalies

https://github.com/Frontify/app-server/pull/33541

# Block settings usage

App: `cle6w2ie00001c0w4oq99llxh`

| Metric | Value |
| --- | ---: |
| Customers scanned | 1,860 |
| Customers with blocks | 943 |
| Total blocks | 88,766 |
| Distinct fields | 74 |

## Field usage

`% blocks` is share of all blocks carrying the field. `% customers` is share of tenants where it appears at least once.

| Field | Blocks | % blocks | Customers | % customers | Types |
| --- | ---: | ---: | ---: | ---: | --- |
| `hasBorder_blocks` | 88,695 | 99.9% | 943 | 100.0% | boolean |
| `radiusChoice_blocks` | 88,693 | 99.9% | 943 | 100.0% | string |
| `borderStyle_thumbnails` | 88,691 | 99.9% | 943 | 100.0% | string |
| `hasBorder_thumbnails` | 88,691 | 99.9% | 943 | 100.0% | boolean |
| `radiusChoice_thumbnails` | 88,691 | 99.9% | 943 | 100.0% | string |
| `borderStyle_blocks` | 88,690 | 99.9% | 943 | 100.0% | string |
| `borderWidth_blocks` | 88,690 | 99.9% | 943 | 100.0% | string |
| `borderWidth_thumbnails` | 88,690 | 99.9% | 943 | 100.0% | string |
| `hasRadius_blocks` | 88,690 | 99.9% | 943 | 100.0% | boolean |
| `hasRadius_thumbnails` | 88,690 | 99.9% | 943 | 100.0% | boolean |
| `hasBackgroundBlocks` | 88,669 | 99.9% | 943 | 100.0% | boolean |
| `borderColor_thumbnails.blue` | 88,665 | 99.9% | 943 | 100.0% | integer |
| `borderColor_thumbnails.green` | 88,665 | 99.9% | 943 | 100.0% | integer |
| `borderColor_thumbnails.red` | 88,665 | 99.9% | 943 | 100.0% | integer |
| `hasBackgroundThumbnails` | 88,665 | 99.9% | 943 | 100.0% | boolean |
| `borderColor_blocks.blue` | 88,610 | 99.8% | 943 | 100.0% | integer |
| `borderColor_blocks.green` | 88,610 | 99.8% | 943 | 100.0% | integer |
| `borderColor_blocks.red` | 88,610 | 99.8% | 943 | 100.0% | integer |
| `backgroundColorBlocks.blue` | 88,485 | 99.7% | 942 | 99.9% | integer |
| `backgroundColorBlocks.green` | 88,485 | 99.7% | 942 | 99.9% | integer |
| `backgroundColorBlocks.red` | 88,485 | 99.7% | 942 | 99.9% | integer |
| `backgroundColorThumbnails.blue` | 88,476 | 99.7% | 943 | 100.0% | integer |
| `backgroundColorThumbnails.green` | 88,476 | 99.7% | 943 | 100.0% | integer |
| `backgroundColorThumbnails.red` | 88,476 | 99.7% | 943 | 100.0% | integer |
| `showThumbnails` | 88,432 | 99.6% | 943 | 100.0% | boolean |
| `showCount` | 88,427 | 99.6% | 943 | 100.0% | boolean |
| `assetCountColor` | 88,409 | 99.6% | 943 | 100.0% | string |
| `borderColor_thumbnails` | 85,165 | 95.9% | 926 | 98.2% | object |
| `borderColor_thumbnails.alpha` | 82,190 | 92.6% | 933 | 98.9% | integer 100.0%, number 0.0% |
| `backgroundColorBlocks` | 80,956 | 91.2% | 922 | 97.8% | object 100.0%, null 0.0% |
| `borderColor_blocks` | 80,783 | 91.0% | 912 | 96.7% | object |
| `backgroundColorThumbnails.alpha` | 80,270 | 90.4% | 931 | 98.7% | integer 100.0%, number 0.0% |
| `borderColor_blocks.alpha` | 77,212 | 87.0% | 931 | 98.7% | integer |
| `backgroundColorBlocks.alpha` | 72,978 | 82.2% | 913 | 96.8% | integer |
| `title` | 72,933 | 82.2% | 832 | 88.2% | string |
| `backgroundColorThumbnails` | 67,630 | 76.2% | 900 | 95.4% | object |
| `description` | 59,364 | 66.9% | 802 | 85.0% | string |
| `downloadUrlBlock` | 34,965 | 39.4% | 556 | 59.0% | string |
| `buttonText` | 20,635 | 23.2% | 336 | 35.6% | string |
| `backgroundColorBlocks.name` | 12,928 | 14.6% | 346 | 36.7% | string |
| `downloadExpiration` | 8,002 | 9.0% | 228 | 24.2% | integer |
| `backgroundColorThumbnails.name` | 5,438 | 6.1% | 239 | 25.3% | string |
| `radiusValue_blocks` | 4,909 | 5.5% | 179 | 19.0% | string |
| `borderColor_blocks.name` | 4,399 | 5.0% | 248 | 26.3% | string |
| `borderColor_thumbnails.name` | 3,712 | 4.2% | 141 | 15.0% | string |
| `countCustomColor` | 3,575 | 4.0% | 210 | 22.3% | null 56.3%, object 43.7% |
| `radiusValue_thumbnails` | 3,544 | 4.0% | 152 | 16.1% | string |
| `countCustomColor.blue` | 2,137 | 2.4% | 188 | 19.9% | integer |
| `countCustomColor.green` | 2,137 | 2.4% | 188 | 19.9% | integer |
| `countCustomColor.red` | 2,137 | 2.4% | 188 | 19.9% | integer |
| `countCustomColor.name` | 2,080 | 2.3% | 178 | 18.9% | string |
| `countCustomColor.alpha` | 1,884 | 2.1% | 187 | 19.8% | integer 98.8%, number 1.2% |
| `hasBackground_blocks` | 39 | 0.0% | 1 | 0.1% | boolean |
| `hasBackground_thumbnails` | 39 | 0.0% | 1 | 0.1% | boolean |
| `backgroundColor_thumbnails` | 14 | 0.0% | 1 | 0.1% | object |
| `backgroundColor_thumbnails.alpha` | 14 | 0.0% | 1 | 0.1% | integer |
| `backgroundColor_thumbnails.blue` | 14 | 0.0% | 1 | 0.1% | integer |
| `backgroundColor_thumbnails.green` | 14 | 0.0% | 1 | 0.1% | integer |
| `backgroundColor_thumbnails.red` | 14 | 0.0% | 1 | 0.1% | integer |
| `text` | 13 | 0.0% | 1 | 0.1% | string |
| `backgroundColor_thumbnails.name` | 10 | 0.0% | 1 | 0.1% | string |
| `backgroundColor_blocks` | 6 | 0.0% | 1 | 0.1% | object |
| `backgroundColor_blocks.alpha` | 6 | 0.0% | 1 | 0.1% | integer |
| `backgroundColor_blocks.blue` | 6 | 0.0% | 1 | 0.1% | integer |
| `backgroundColor_blocks.green` | 6 | 0.0% | 1 | 0.1% | integer |
| `backgroundColor_blocks.red` | 6 | 0.0% | 1 | 0.1% | integer |
| `backgroundColor_blocks.name` | 4 | 0.0% | 1 | 0.1% | string |
| `backgroundColorBlocks.id` | 4 | 0.0% | 1 | 0.1% | integer |
| `borderColor_blocks.id` | 4 | 0.0% | 1 | 0.1% | integer |
| `assetHeight` | 1 | 0.0% | 1 | 0.1% | string |
| `columns` | 1 | 0.0% | 1 | 0.1% | string |
| `customHeight` | 1 | 0.0% | 1 | 0.1% | boolean |
| `slide_type` | 1 | 0.0% | 1 | 0.1% | string |
| `slides` | 1 | 0.0% | 1 | 0.1% | array |

## Mixed types

Fields that do not resolve to a single type across the fleet.

| Field | Breakdown |
| --- | --- |
| `borderColor_thumbnails.alpha` | integer 82,189 (100.0%), number 1 (0.0%) |
| `backgroundColorBlocks` | object 80,951 (100.0%), null 5 (0.0%) |
| `backgroundColorThumbnails.alpha` | integer 80,269 (100.0%), number 1 (0.0%) |
| `countCustomColor` | null 2,013 (56.3%), object 1,562 (43.7%) |
| `countCustomColor.alpha` | integer 1,861 (98.8%), number 23 (1.2%) |

_Generated 2026-09-07T11:07:35.660Z from `rundeck.log`._
