### PR TITLE
feat(ThumbnailGridBlock): add settings schema

### DIFF
--- a/packages/thumbnail-grid-block/manifest.json
+++ b/packages/thumbnail-grid-block/manifest.json
@@ -1,14 +1,198 @@
 {
     "appId": "cle7bmsg70001c1w4wmz5c5j3",
-    "i18nFields": ["items"],
-    "searchFields": [
-        {
-            "settingId": "items.title",
-            "type": "fondueRte"
+    "settingsSchema": {
+        "type": "object",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "color": {
+                "type": ["null", "object"],
+                "required": ["red", "green", "blue"],
+                "additionalProperties": false,
+                "properties": {
+                    "red": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "green": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "blue": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "alpha": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "name": { "type": "string", "frontify-api-read": true, "frontify-api-write": true }
+                }
+            },
+            "borderStyle": {
+                "type": "string",
+                "enum": ["Solid", "Dotted", "Dashed"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "sizeChoice": {
+                "type": "string",
+                "enum": ["None", "Small", "Medium", "Large"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "gutterChoice": {
+                "type": "string",
+                "enum": ["Auto", "S", "M", "L"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "pixelValue": {
+                "type": "string",
+                "pattern": "^[0-9]+px$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "percentValue": {
+                "type": "string",
+                "pattern": "^([0-9]+%|auto)$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            }
         },
-        {
-            "settingId": "items.description",
-            "type": "fondueRte"
+        "required": [
+            "columnCount",
+            "hasCustomSpacing",
+            "spacingChoice",
+            "imagePosition",
+            "hasCustomImageWidth",
+            "imageWidthPreset",
+            "verticalImageAlignment",
+            "horizontalImageAlignment",
+            "hasBackground",
+            "hasBorder",
+            "borderStyle",
+            "borderWidth",
+            "hasRadius",
+            "radiusChoice",
+            "security",
+            "assetViewerEnabled",
+            "items"
+        ],
+        "additionalProperties": false,
+        "properties": {
+            "columnCount": {
+                "type": "string",
+                "enum": ["1", "2", "3", "4", "5"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+
+            "hasCustomSpacing": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "spacingCustom": { "$ref": "#/$defs/pixelValue" },
+            "spacingChoice": { "$ref": "#/$defs/gutterChoice" },
+
+            "imagePosition": {
+                "type": "string",
+                "enum": ["Below", "Above", "Right", "Left"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+
+            "hasCustomImageWidth": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "customImageWidth": { "$ref": "#/$defs/percentValue" },
+            "imageWidthPreset": {
+                "type": "string",
+                "enum": ["25%", "33%", "50%", "75%"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+
+            "verticalImageAlignment": {
+                "type": "string",
+                "enum": ["start", "center", "end"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "horizontalImageAlignment": {
+                "type": "string",
+                "enum": ["left", "center", "right"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+
+            "hasBackground": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "backgroundColor": { "$ref": "#/$defs/color" },
+
+            "hasBorder": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "borderStyle": { "$ref": "#/$defs/borderStyle" },
+            "borderWidth": { "$ref": "#/$defs/pixelValue" },
+            "borderColor": { "$ref": "#/$defs/color" },
+
+            "hasRadius": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "radiusChoice": { "$ref": "#/$defs/sizeChoice" },
+            "radiusValue": { "$ref": "#/$defs/pixelValue" },
+
+            "security": {
+                "type": "string",
+                "enum": ["Global", "Custom"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "assetViewerEnabled": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["id"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "frontify-api-read": true,
+                            "frontify-api-write": true,
+                            "frontify-translatable": true,
+                            "frontify-machine-translatable": false
+                        },
+                        "title": {
+                            "type": "string",
+                            "frontify-type": "fondueRte",
+                            "frontify-serializable": true,
+                            "frontify-serialization-index": 1,
+                            "frontify-translatable": true,
+                            "frontify-api-read": true,
+                            "frontify-api-write": true
+                        },
+                        "description": {
+                            "type": "string",
+                            "frontify-type": "fondueRte",
+                            "frontify-serializable": true,
+                            "frontify-serialization-index": 2,
+                            "frontify-translatable": true,
+                            "frontify-api-read": true,
+                            "frontify-api-write": true
+                        },
+                        "altText": {
+                            "type": "string",
+                            "frontify-translatable": true,
+                            "frontify-api-read": true,
+                            "frontify-api-write": true
+                        }
+                    }
+                }
+            }
         }
-    ]
+    }
 }


### PR DESCRIPTION
# Data fix PR for anomalies

https://github.com/Frontify/app-server/pull/33555

# Block settings usage

App: `cle7bmsg70001c1w4wmz5c5j3`

| Metric | Value |
| --- | ---: |
| Customers scanned | 1,860 |
| Customers with blocks | 959 |
| Total blocks | 34,057 |
| Distinct fields | 61 |

## Field usage

`% blocks` is share of all blocks carrying the field. `% customers` is share of tenants where it appears at least once.

| Field | Blocks | % blocks | Customers | % customers | Types |
| --- | ---: | ---: | ---: | ---: | --- |
| `items[]` | 134,720 | 395.6% | 949 | 99.0% | object |
| `items[].id` | 134,720 | 395.6% | 949 | 99.0% | string |
| `items[].title` | 92,306 | 271.0% | 806 | 84.0% | string |
| `items[].description` | 76,258 | 223.9% | 764 | 79.7% | string |
| `items[].altText` | 58,756 | 172.5% | 723 | 75.4% | string |
| `columnCount` | 34,055 | 100.0% | 959 | 100.0% | string |
| `imagePosition` | 34,054 | 100.0% | 959 | 100.0% | string |
| `imageWidthPreset` | 34,054 | 100.0% | 959 | 100.0% | string |
| `hasCustomImageWidth` | 34,053 | 100.0% | 959 | 100.0% | boolean |
| `horizontalImageAlignment` | 34,046 | 100.0% | 959 | 100.0% | string |
| `verticalImageAlignment` | 34,034 | 99.9% | 959 | 100.0% | string |
| `hasBorder` | 34,032 | 99.9% | 959 | 100.0% | boolean |
| `radiusChoice` | 34,021 | 99.9% | 959 | 100.0% | string |
| `hasBackground` | 34,020 | 99.9% | 959 | 100.0% | boolean |
| `spacingChoice` | 34,008 | 99.9% | 959 | 100.0% | string |
| `borderStyle` | 34,003 | 99.8% | 959 | 100.0% | string |
| `borderWidth` | 34,003 | 99.8% | 959 | 100.0% | string |
| `hasRadius` | 34,003 | 99.8% | 959 | 100.0% | boolean |
| `hasCustomSpacing` | 33,977 | 99.8% | 959 | 100.0% | boolean |
| `items` | 33,971 | 99.7% | 957 | 99.8% | array |
| `borderColor.blue` | 33,961 | 99.7% | 959 | 100.0% | integer |
| `borderColor.green` | 33,961 | 99.7% | 959 | 100.0% | integer |
| `borderColor.red` | 33,961 | 99.7% | 959 | 100.0% | integer |
| `borderColor` | 32,048 | 94.1% | 952 | 99.3% | object |
| `borderColor.alpha` | 30,978 | 91.0% | 954 | 99.5% | integer |
| `security` | 20,064 | 58.9% | 807 | 84.2% | string |
| `assetViewerEnabled` | 20,031 | 58.8% | 806 | 84.0% | boolean |
| `customImageWidth` | 18,877 | 55.4% | 649 | 67.7% | string |
| `items[].image` | 14,846 | 43.6% | 79 | 8.2% | string |
| `backgroundColor.blue` | 3,754 | 11.0% | 339 | 35.3% | integer |
| `backgroundColor.green` | 3,754 | 11.0% | 339 | 35.3% | integer |
| `backgroundColor.red` | 3,754 | 11.0% | 339 | 35.3% | integer |
| `backgroundColor.alpha` | 3,641 | 10.7% | 329 | 34.3% | integer 99.8%, number 0.2% |
| `spacingCustom` | 3,434 | 10.1% | 203 | 21.2% | string |
| `backgroundColor.name` | 2,830 | 8.3% | 323 | 33.7% | string |
| `radiusValue` | 2,521 | 7.4% | 345 | 36.0% | string |
| `borderColor.name` | 1,743 | 5.1% | 206 | 21.5% | string |
| `backgroundColor` | 1,496 | 4.4% | 302 | 31.5% | object 92.1%, null 7.9% |
| `gutterPreset` | 64 | 0.2% | 2 | 0.2% | string |
| `hasCustomGutter` | 64 | 0.2% | 2 | 0.2% | boolean |
| `items[].previewUrl` | 52 | 0.2% | 2 | 0.2% | string |
| `hasBackgroundColor` | 40 | 0.1% | 2 | 0.2% | boolean |
| `customGutter` | 30 | 0.1% | 2 | 0.2% | string |
| `borderLineStyle` | 24 | 0.1% | 2 | 0.2% | string |
| `borderLineWidth` | 24 | 0.1% | 2 | 0.2% | string |
| `borderRadiusPreset` | 24 | 0.1% | 2 | 0.2% | string |
| `customBorderRadius` | 24 | 0.1% | 2 | 0.2% | string |
| `hasCustomBorderRadius` | 24 | 0.1% | 2 | 0.2% | boolean |
| `downloadable` | 11 | 0.0% | 1 | 0.1% | boolean |
| `assetHeight` | 1 | 0.0% | 1 | 0.1% | string |
| `buttonText` | 1 | 0.0% | 1 | 0.1% | string |
| `columns` | 1 | 0.0% | 1 | 0.1% | string |
| `customHeight` | 1 | 0.0% | 1 | 0.1% | boolean |
| `description` | 1 | 0.0% | 1 | 0.1% | string |
| `hasBackgroundBlocks` | 1 | 0.0% | 1 | 0.1% | boolean |
| `hasBorder_blocks` | 1 | 0.0% | 1 | 0.1% | boolean |
| `showCount` | 1 | 0.0% | 1 | 0.1% | boolean |
| `showThumbnails` | 1 | 0.0% | 1 | 0.1% | boolean |
| `slide_type` | 1 | 0.0% | 1 | 0.1% | string |
| `slides` | 1 | 0.0% | 1 | 0.1% | array |
| `title` | 1 | 0.0% | 1 | 0.1% | string |

## Mixed types

Fields that do not resolve to a single type across the fleet.

| Field | Breakdown |
| --- | --- |
| `backgroundColor.alpha` | integer 3,633 (99.8%), number 8 (0.2%) |
| `backgroundColor` | object 1,378 (92.1%), null 118 (7.9%) |

_Generated 2026-09-07T13:39:24.776Z from `rundeck.log`._
