### PR TITLE
feat(GlyphsBlock): add settings schema

### DIFF
--- a/.releases/added-settings-schema-for-validation-bbbdfebe.md
+++ b/.releases/added-settings-schema-for-validation-bbbdfebe.md
@@ -1,0 +1,5 @@
+---
+blocks: [glyphs-block]
+---
+
+added settings schema for validation

--- a/packages/glyphs-block/manifest.json
+++ b/packages/glyphs-block/manifest.json
@@ -1,3 +1,127 @@
 {
-    "appId": "cld03deen00010qw4mgotfcgd"
+    "appId": "cld03deen00010qw4mgotfcgd",
+    "settingsSchema": {
+        "type": "object",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "color": {
+                "type": ["null", "object"],
+                "required": ["red", "green", "blue"],
+                "additionalProperties": false,
+                "properties": {
+                    "red": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "green": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "blue": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "alpha": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "name": {
+                        "type": "string",
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    }
+                }
+            }
+        },
+        "required": [
+            "chars",
+            "fontFamily",
+            "fontWeight",
+            "fontSize",
+            "hasBackground",
+            "hasBorder",
+            "borderStyle",
+            "borderWidth",
+            "hasRadius",
+            "radiusChoice"
+        ],
+        "additionalProperties": false,
+        "properties": {
+            "chars": {
+                "type": "string",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "fontFamily": {
+                "type": "string",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "fontWeight": {
+                "type": "string",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "fontSize": {
+                "type": "string",
+                "pattern": "^[0-9]+px$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "fontColor": { "$ref": "#/$defs/color" },
+            "hasBackground": {
+                "type": "boolean",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "backgroundColor": { "$ref": "#/$defs/color" },
+            "hasBorder": {
+                "type": "boolean",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "borderStyle": {
+                "type": "string",
+                "enum": ["Solid", "Dotted", "Dashed"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "borderWidth": {
+                "type": "string",
+                "pattern": "^[0-9]+px$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "borderColor": { "$ref": "#/$defs/color" },
+            "hasRadius": {
+                "type": "boolean",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "radiusChoice": {
+                "type": "string",
+                "enum": ["None", "Small", "Medium", "Large"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "radiusValue": {
+                "type": "string",
+                "pattern": "^[0-9]+px$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            }
+        }
+    }
 }


### PR DESCRIPTION
# Data fix PR for anomalies

https://github.com/Frontify/app-server/pull/33619

# Block settings usage

App: `cld03deen00010qw4mgotfcgd`

| Metric | Value |
| --- | ---: |
| Customers scanned | 1,875 |
| Customers with blocks | 226 |
| Total blocks | 915 |
| Distinct fields | 36 |

## Field usage

`% blocks` is share of all blocks carrying the field. `% customers` is share of tenants where it appears at least once.

| Field | Blocks | % blocks | Customers | % customers | Types |
| --- | ---: | ---: | ---: | ---: | --- |
| `borderStyle` | 915 | 100.0% | 226 | 100.0% | string |
| `borderWidth` | 915 | 100.0% | 226 | 100.0% | string |
| `chars` | 915 | 100.0% | 226 | 100.0% | string |
| `fontFamily` | 915 | 100.0% | 226 | 100.0% | string |
| `fontSize` | 915 | 100.0% | 226 | 100.0% | string |
| `fontWeight` | 915 | 100.0% | 226 | 100.0% | string |
| `borderColor.blue` | 914 | 99.9% | 226 | 100.0% | integer |
| `borderColor.green` | 914 | 99.9% | 226 | 100.0% | integer |
| `borderColor.red` | 914 | 99.9% | 226 | 100.0% | integer |
| `backgroundColor.blue` | 913 | 99.8% | 226 | 100.0% | integer |
| `backgroundColor.green` | 913 | 99.8% | 226 | 100.0% | integer |
| `backgroundColor.red` | 913 | 99.8% | 226 | 100.0% | integer |
| `borderColor` | 913 | 99.8% | 225 | 99.6% | object |
| `backgroundColor.name` | 911 | 99.6% | 226 | 100.0% | string |
| `backgroundColor` | 906 | 99.0% | 224 | 99.1% | object |
| `borderColor.name` | 906 | 99.0% | 226 | 100.0% | string |
| `hasBorder` | 899 | 98.3% | 226 | 100.0% | boolean |
| `radiusChoice` | 893 | 97.6% | 226 | 100.0% | string |
| `hasBackground` | 887 | 96.9% | 226 | 100.0% | boolean |
| `fontColor.alpha` | 885 | 96.7% | 226 | 100.0% | integer |
| `fontColor.blue` | 885 | 96.7% | 226 | 100.0% | integer |
| `fontColor.green` | 885 | 96.7% | 226 | 100.0% | integer |
| `fontColor.red` | 885 | 96.7% | 226 | 100.0% | integer |
| `fontColor.name` | 883 | 96.5% | 226 | 100.0% | string |
| `hasRadius` | 879 | 96.1% | 226 | 100.0% | boolean |
| `backgroundColor.alpha` | 835 | 91.3% | 224 | 99.1% | integer |
| `borderColor.alpha` | 832 | 90.9% | 224 | 99.1% | integer |
| `fontColor` | 791 | 86.4% | 225 | 99.6% | object |
| `radiusValue` | 133 | 14.5% | 26 | 11.5% | string |
| `color` | 42 | 4.6% | 1 | 0.4% | object |
| `color.alpha` | 42 | 4.6% | 1 | 0.4% | integer |
| `color.blue` | 42 | 4.6% | 1 | 0.4% | integer |
| `color.green` | 42 | 4.6% | 1 | 0.4% | integer |
| `color.red` | 42 | 4.6% | 1 | 0.4% | integer |
| `type` | 42 | 4.6% | 1 | 0.4% | string |
| `color.name` | 41 | 4.5% | 1 | 0.4% | string |

_Generated 2026-09-09T07:26:10.107Z from `rundeck.log`._

---

Schema validation run: [https://rundeck-engineering.frontify.io/execution/show/238442#output](https://rundeck-engineering.frontify.io/execution/show/238442#output)
