### PR TITLE
feat(CodeSandboxBlock): add settings schema

### DIFF
--- a/.releases/added-settings-schema-for-validation-77023f43.md
+++ b/.releases/added-settings-schema-for-validation-77023f43.md
@@ -1,0 +1,5 @@
+---
+blocks: [ui-pattern-block]
+---
+
+added settings schema for validation

--- a/packages/ui-pattern-block/manifest.json
+++ b/packages/ui-pattern-block/manifest.json
@@ -1,8 +1,325 @@
 {
     "appId": "clncxpkhl00014muq6fm3u7i0",
-    "i18nFields": ["title", "description"],
-    "searchFields": [
-        { "settingId": "title", "type": "fondueRte" },
-        { "settingId": "description", "type": "fondueRte" }
-    ]
+    "settingsSchema": {
+        "type": "object",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "color": {
+                "type": ["null", "object"],
+                "required": ["red", "green", "blue"],
+                "additionalProperties": false,
+                "properties": {
+                    "red": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "green": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "blue": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "alpha": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "name": {
+                        "type": "string",
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    }
+                }
+            },
+            "sizeChoice": {
+                "type": "string",
+                "enum": ["None", "Small", "Medium", "Large"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "heightChoice": {
+                "type": "string",
+                "enum": ["Auto", "Small", "Medium", "Large"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "pixelValue": {
+                "type": "string",
+                "pattern": "^[0-9]+px$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "switch": {
+                "type": "boolean",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "fileContent": {
+                "type": "string",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "templateDependencies": {
+                "type": "object",
+                "additionalProperties": false,
+                "frontify-api-read": true,
+                "frontify-api-write": true,
+                "properties": {
+                    "npm": {
+                        "type": "string",
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "external": {
+                        "type": "string",
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    }
+                }
+            }
+        },
+        "required": [
+            "sandpackTemplate",
+            "preprocessor",
+            "showResponsivePreview",
+            "showResetButton",
+            "showSandboxLink",
+            "showCode",
+            "isCodeEditable",
+            "shouldCollapseCodeByDefault",
+            "showNpmDependencies",
+            "showExternalDependencies",
+            "shouldCollapseDependenciesByDefault",
+            "labelPosition",
+            "alignment",
+            "hasCustomPadding",
+            "paddingChoice",
+            "isCustomHeight",
+            "customHeightValue",
+            "heightChoice",
+            "sandpackTheme",
+            "hasBackground",
+            "hasBorder",
+            "borderStyle",
+            "borderWidth",
+            "hasRadius",
+            "radiusChoice"
+        ],
+        "additionalProperties": false,
+        "properties": {
+            "title": {
+                "type": "string",
+                "frontify-type": "fondueRte",
+                "frontify-serializable": true,
+                "frontify-serialization-index": 1,
+                "frontify-translatable": true,
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "description": {
+                "type": "string",
+                "frontify-type": "fondueRte",
+                "frontify-serializable": true,
+                "frontify-serialization-index": 2,
+                "frontify-translatable": true,
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+
+            "sandpackTemplate": {
+                "type": "string",
+                "enum": [
+                    "vanilla",
+                    "static",
+                    "react",
+                    "angular",
+                    "svelte",
+                    "vue"
+                ],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "preprocessor": {
+                "type": "string",
+                "enum": ["None", "SCSS", "LESS"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+
+            "showResponsivePreview": { "$ref": "#/$defs/switch" },
+            "showResetButton": { "$ref": "#/$defs/switch" },
+            "showSandboxLink": { "$ref": "#/$defs/switch" },
+            "showCode": { "$ref": "#/$defs/switch" },
+            "isCodeEditable": { "$ref": "#/$defs/switch" },
+            "shouldCollapseCodeByDefault": { "$ref": "#/$defs/switch" },
+            "showNpmDependencies": { "$ref": "#/$defs/switch" },
+            "showExternalDependencies": { "$ref": "#/$defs/switch" },
+            "shouldCollapseDependenciesByDefault": { "$ref": "#/$defs/switch" },
+
+            "labelPosition": {
+                "type": "string",
+                "enum": ["Top", "Bottom"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "alignment": {
+                "type": "string",
+                "enum": ["Left", "Center"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+
+            "hasCustomPadding": { "$ref": "#/$defs/switch" },
+            "paddingCustom": { "$ref": "#/$defs/pixelValue" },
+            "paddingChoice": { "$ref": "#/$defs/sizeChoice" },
+
+            "isCustomHeight": { "$ref": "#/$defs/switch" },
+            "customHeightValue": {
+                "type": "string",
+                "pattern": "^([0-9]+px|auto)$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "heightChoice": { "$ref": "#/$defs/heightChoice" },
+
+            "sandpackTheme": {
+                "type": "string",
+                "enum": [
+                    "Dark",
+                    "Light",
+                    "Amethyst",
+                    "AquaBlue",
+                    "AtomDark",
+                    "Cobalt2",
+                    "Cyberpunk",
+                    "Dracula",
+                    "EcoLight",
+                    "FreeCodeCampDark",
+                    "GithubLight",
+                    "GruvboxDark",
+                    "GruvboxLight",
+                    "LevelUp",
+                    "MonokaiPro",
+                    "NeoCyan",
+                    "NightOwl",
+                    "SandpackDark"
+                ],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+
+            "hasBackground": { "$ref": "#/$defs/switch" },
+            "backgroundColor": { "$ref": "#/$defs/color" },
+
+            "hasBorder": { "$ref": "#/$defs/switch" },
+            "borderStyle": {
+                "type": "string",
+                "enum": ["Solid", "Dashed", "Dotted"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "borderWidth": { "$ref": "#/$defs/pixelValue" },
+            "borderColor": { "$ref": "#/$defs/color" },
+
+            "hasRadius": { "$ref": "#/$defs/switch" },
+            "radiusChoice": { "$ref": "#/$defs/sizeChoice" },
+            "radiusValue": { "$ref": "#/$defs/pixelValue" },
+
+            "files": {
+                "type": "object",
+                "additionalProperties": false,
+                "frontify-api-read": true,
+                "frontify-api-write": true,
+                "properties": {
+                    "vanilla": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "/index.html": { "$ref": "#/$defs/fileContent" },
+                            "/index.js": { "$ref": "#/$defs/fileContent" },
+                            "/app.js": { "$ref": "#/$defs/fileContent" },
+                            "/styles.css": { "$ref": "#/$defs/fileContent" },
+                            "/styles.scss": { "$ref": "#/$defs/fileContent" },
+                            "/styles.less": { "$ref": "#/$defs/fileContent" }
+                        }
+                    },
+                    "static": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "/index.html": { "$ref": "#/$defs/fileContent" },
+                            "/index.js": { "$ref": "#/$defs/fileContent" },
+                            "/style.css": { "$ref": "#/$defs/fileContent" }
+                        }
+                    },
+                    "react": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "/App.js": { "$ref": "#/$defs/fileContent" },
+                            "/styles.css": { "$ref": "#/$defs/fileContent" }
+                        }
+                    },
+                    "angular": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "/src/app/app.component.html": {
+                                "$ref": "#/$defs/fileContent"
+                            },
+                            "/src/app/app.component.css": {
+                                "$ref": "#/$defs/fileContent"
+                            },
+                            "/src/app/app.component.ts": {
+                                "$ref": "#/$defs/fileContent"
+                            }
+                        }
+                    },
+                    "svelte": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "/App.svelte": { "$ref": "#/$defs/fileContent" },
+                            "/styles.css": { "$ref": "#/$defs/fileContent" }
+                        }
+                    },
+                    "vue": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "/src/App.vue": { "$ref": "#/$defs/fileContent" },
+                            "/src/styles.css": { "$ref": "#/$defs/fileContent" }
+                        }
+                    }
+                }
+            },
+            "dependencies": {
+                "type": "object",
+                "additionalProperties": false,
+                "frontify-api-read": true,
+                "frontify-api-write": true,
+                "properties": {
+                    "vanilla": { "$ref": "#/$defs/templateDependencies" },
+                    "static": { "$ref": "#/$defs/templateDependencies" },
+                    "react": { "$ref": "#/$defs/templateDependencies" },
+                    "angular": { "$ref": "#/$defs/templateDependencies" },
+                    "svelte": { "$ref": "#/$defs/templateDependencies" },
+                    "vue": { "$ref": "#/$defs/templateDependencies" }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
[GCM-510](https://linear.app/frontify/issue/GCM-510/code-sandbox-block)

Replaces the `i18nFields` / `searchFields` entries with a `settingsSchema`, following the Audio and Template blocks. Translation and search metadata move into per-property `frontify-*` annotations.

## What the schema covers

- `title` and `description` as translatable, serializable `fondueRte`
- the 25 keys the block always writes are `required`, everything else optional
- `additionalProperties: false` everywhere, colors as the shared `$defs/color`, pixel values as `^[0-9]+px$`

## `files` and `dependencies`

Both are per-template maps. The schema enumerates their keys rather than allowing free-form ones:

- the templates are the six Sandpack templates the block offers
- each template lists exactly the files its editor can open — which is also the exact set the usage scan found in production

Enumerating them is what keeps the `frontify-*` annotations reachable: `SchemaWalker` only descends into `properties`, so anything under `additionalProperties` would be invisible to `BlockSettingsMapper` and `files` / `dependencies` would be served as empty objects through the API. Verified against `BlockSettingsMapper` — `api-read`, `api-write`, `translatable` and the search serialization all resolve as before.

It also rejects the numeric-key `files.vanilla` artifact below without a bespoke rule.

## Data fix PR

app-server: https://github.com/Frontify/app-server/pull/33635

# Block settings usage

App: `clncxpkhl00014muq6fm3u7i0`

| Metric | Value |
| --- | ---: |
| Customers scanned | 1,873 |
| Customers with blocks | 696 |
| Total blocks | 72,933 |
| Distinct fields | 80 |

## Field usage

`% blocks` is share of all blocks carrying the field. `% customers` is share of tenants where it appears at least once.

| Field | Blocks | % blocks | Customers | % customers | Types |
| --- | ---: | ---: | ---: | ---: | --- |
| `sandpackTemplate` | 72,916 | 100.0% | 696 | 100.0% | string |
| `alignment` | 72,915 | 100.0% | 696 | 100.0% | string |
| `borderStyle` | 72,915 | 100.0% | 696 | 100.0% | string |
| `borderWidth` | 72,915 | 100.0% | 696 | 100.0% | string |
| `customHeightValue` | 72,915 | 100.0% | 696 | 100.0% | string |
| `hasBackground` | 72,915 | 100.0% | 696 | 100.0% | boolean |
| `hasBorder` | 72,915 | 100.0% | 696 | 100.0% | boolean |
| `hasCustomPadding` | 72,915 | 100.0% | 696 | 100.0% | boolean |
| `hasRadius` | 72,915 | 100.0% | 696 | 100.0% | boolean |
| `heightChoice` | 72,915 | 100.0% | 696 | 100.0% | string |
| `isCustomHeight` | 72,915 | 100.0% | 696 | 100.0% | boolean |
| `paddingChoice` | 72,915 | 100.0% | 696 | 100.0% | string |
| `radiusChoice` | 72,915 | 100.0% | 696 | 100.0% | string |
| `sandpackTheme` | 72,915 | 100.0% | 696 | 100.0% | string |
| `shouldCollapseCodeByDefault` | 72,915 | 100.0% | 696 | 100.0% | boolean |
| `showCode` | 72,915 | 100.0% | 696 | 100.0% | boolean |
| `showResetButton` | 72,915 | 100.0% | 696 | 100.0% | boolean |
| `showResponsivePreview` | 72,915 | 100.0% | 696 | 100.0% | boolean |
| `showSandboxLink` | 72,915 | 100.0% | 696 | 100.0% | boolean |
| `backgroundColor.alpha` | 72,910 | 100.0% | 696 | 100.0% | integer |
| `backgroundColor.blue` | 72,910 | 100.0% | 696 | 100.0% | integer |
| `backgroundColor.green` | 72,910 | 100.0% | 696 | 100.0% | integer |
| `backgroundColor.red` | 72,910 | 100.0% | 696 | 100.0% | integer |
| `borderColor.blue` | 72,885 | 99.9% | 696 | 100.0% | integer |
| `borderColor.green` | 72,885 | 99.9% | 696 | 100.0% | integer |
| `borderColor.red` | 72,885 | 99.9% | 696 | 100.0% | integer |
| `shouldCollapseDependenciesByDefault` | 72,821 | 99.8% | 696 | 100.0% | boolean |
| `showExternalDependencies` | 72,814 | 99.8% | 696 | 100.0% | boolean |
| `showNpmDependencies` | 72,814 | 99.8% | 696 | 100.0% | boolean |
| `isCodeEditable` | 72,813 | 99.8% | 696 | 100.0% | boolean |
| `labelPosition` | 72,744 | 99.7% | 696 | 100.0% | string |
| `borderColor` | 72,214 | 99.0% | 693 | 99.6% | object |
| `backgroundColor` | 72,210 | 99.0% | 694 | 99.7% | object |
| `preprocessor` | 71,990 | 98.7% | 695 | 99.9% | string |
| `files` | 62,932 | 86.3% | 643 | 92.4% | object |
| `files.vanilla./index.html` | 59,376 | 81.4% | 641 | 92.1% | string |
| `files.vanilla` | 58,953 | 80.8% | 640 | 92.0% | object |
| `title` | 58,452 | 80.1% | 511 | 73.4% | string |
| `dependencies` | 55,735 | 76.4% | 530 | 76.1% | object |
| `dependencies.vanilla` | 55,056 | 75.5% | 530 | 76.1% | object |
| `dependencies.vanilla.external` | 54,238 | 74.4% | 496 | 71.3% | string |
| `files.vanilla./app.js` | 54,180 | 74.3% | 504 | 72.4% | string |
| `files.vanilla./styles.css` | 51,789 | 71.0% | 557 | 80.0% | string |
| `borderColor.alpha` | 45,181 | 61.9% | 683 | 98.1% | number |
| `files.vanilla./styles.scss` | 3,907 | 5.4% | 58 | 8.3% | string |
| `files.static` | 3,895 | 5.3% | 167 | 24.0% | object |
| `files.static./index.html` | 3,894 | 5.3% | 167 | 24.0% | string |
| `files.static./style.css` | 3,649 | 5.0% | 140 | 20.1% | string |
| `files.static./index.js` | 3,644 | 5.0% | 138 | 19.8% | string |
| `description` | 2,631 | 3.6% | 75 | 10.8% | string |
| `dependencies.vanilla.npm` | 2,151 | 2.9% | 157 | 22.6% | string |
| `files.react` | 993 | 1.4% | 67 | 9.6% | object |
| `files.react./App.js` | 993 | 1.4% | 67 | 9.6% | string |
| `files.angular` | 766 | 1.1% | 41 | 5.9% | object |
| `files.angular./src/app/app.component.html` | 766 | 1.1% | 41 | 5.9% | string |
| `files.react./styles.css` | 668 | 0.9% | 28 | 4.0% | string |
| `dependencies.react` | 663 | 0.9% | 8 | 1.1% | object |
| `dependencies.react.npm` | 663 | 0.9% | 8 | 1.1% | string |
| `files.angular./src/app/app.component.css` | 622 | 0.9% | 15 | 2.2% | string |
| `files.vanilla./styles.less` | 507 | 0.7% | 14 | 2.0% | string |
| `files.vanilla./index.js` | 196 | 0.3% | 1 | 0.1% | string |
| `files.vue` | 169 | 0.2% | 38 | 5.5% | object |
| `files.vue./src/App.vue` | 168 | 0.2% | 37 | 5.3% | string |
| `files.svelte` | 130 | 0.2% | 30 | 4.3% | object |
| `files.svelte./App.svelte` | 130 | 0.2% | 30 | 4.3% | string |
| `backgroundColor.name` | 119 | 0.2% | 14 | 2.0% | string |
| `files.angular./src/app/app.component.ts` | 65 | 0.1% | 13 | 1.9% | string |
| `borderColor.name` | 58 | 0.1% | 13 | 1.9% | string |
| `radiusValue` | 53 | 0.1% | 8 | 1.1% | string |
| `dependencies.react.external` | 43 | 0.1% | 4 | 0.6% | string |
| `paddingCustom` | 33 | 0.0% | 13 | 1.9% | string |
| `files.vue./src/styles.css` | 24 | 0.0% | 6 | 0.9% | string |
| `dependencies.angular` | 20 | 0.0% | 6 | 0.9% | object |
| `dependencies.vue` | 20 | 0.0% | 2 | 0.3% | object |
| `dependencies.vue.npm` | 20 | 0.0% | 2 | 0.3% | string |
| `files.svelte./styles.css` | 16 | 0.0% | 4 | 0.6% | string |
| `dependencies.angular.npm` | 13 | 0.0% | 5 | 0.7% | string |
| `dependencies.angular.external` | 8 | 0.0% | 5 | 0.7% | string |
| `dependencies.svelte` | 1 | 0.0% | 1 | 0.1% | object |
| `dependencies.svelte.npm` | 1 | 0.0% | 1 | 0.1% | string |

## Collapsed numeric-key artifacts

Keys like `files.vanilla.12345` (a purely-numeric leaf segment) are collapsed into one row per prefix rather than one row per index. A contiguous run of indices from 0 with single-character string values is a known artifact of a string being spread into an object (`{...someString}`) instead of stored as a single value, not real per-field usage.

| Prefix | Distinct keys | Max index | Rows | Customers | Types |
| --- | ---: | ---: | ---: | ---: | --- |
| `files.vanilla.<digit>` | 344,388 | 344,387 | 344,388 | 1 | string |
