### PR TITLE
feat(GradientBlock): add settings schema [GCM-508]

### DIFF
--- a/.releases/added-settings-schema-for-validation-c9b32e83.md
+++ b/.releases/added-settings-schema-for-validation-c9b32e83.md
@@ -1,0 +1,5 @@
+---
+blocks: [gradient-block]
+---
+
+added settings schema for validation

--- a/packages/gradient-block/manifest.json
+++ b/packages/gradient-block/manifest.json
@@ -1,3 +1,101 @@
 {
-    "appId": "clexy16s300010pw1gf0c4bne"
+    "appId": "clexy16s300010pw1gf0c4bne",
+    "settingsSchema": {
+        "type": "object",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "color": {
+                "type": "object",
+                "required": ["red", "green", "blue"],
+                "additionalProperties": false,
+                "properties": {
+                    "red": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "green": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "blue": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "alpha": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "name": { "type": "string", "frontify-api-read": true, "frontify-api-write": true }
+                }
+            }
+        },
+        "required": [
+            "displayCss",
+            "gradientColors",
+            "isHeightCustom",
+            "heightSimple",
+            "isOrientationCustom",
+            "orientationSimple"
+        ],
+        "additionalProperties": false,
+        "properties": {
+            "displayCss": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "gradientColors": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["color", "position"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "color": { "$ref": "#/$defs/color" },
+                        "position": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 100,
+                            "frontify-api-read": true,
+                            "frontify-api-write": true
+                        }
+                    }
+                }
+            },
+            "isHeightCustom": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "heightCustom": {
+                "type": "string",
+                "pattern": "^([0-9]+px|auto)$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "heightSimple": {
+                "type": "string",
+                "enum": ["s", "m", "l"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "isOrientationCustom": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "orientationCustom": {
+                "type": "string",
+                "pattern": "^([0-9]|[1-8][0-9]|90)$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "orientationSimple": {
+                "type": "string",
+                "enum": ["0", "90"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            }
+        }
+    }
 }


### PR DESCRIPTION
## GCM-508

Adds a `settingsSchema` to the Gradient block manifest, following the Divider and Do & Dont blocks.

Unlike the Audio block (#1452) there are no `i18nFields` / `searchFields` to replace — none of the Gradient block's settings is translatable or searchable.

## What the schema covers

Every field the block actually writes:

| Field | Shape | Notes |
| --- | --- | --- |
| `gradientColors` | array of `{ color, position }` | `color` is the shared `$defs/color`, `position` an integer `0..100` |
| `displayCss` | boolean | Inspect → *Display CSS Code* |
| `isHeightCustom` / `heightSimple` / `heightCustom` | boolean / `s\|m\|l` / `^([0-9]+px\|auto)$` | matches `maximumNumericalOrPixelOrAutoRule(800)` in the sidebar |
| `isOrientationCustom` / `orientationSimple` / `orientationCustom` | boolean / `0\|90` / `^([0-9]\|[1-8][0-9]\|90)$` | matches `maximumNumericalRule(90)` in the sidebar |

The six fields present on ~100% of blocks in the fleet are `required`; the two custom values stay optional because they only exist when the matching switch is on.

## Left out on purpose

`gradientColors[].level` and `gradientColors[].isReverse` (38.6% of blocks). They are not settings — `prepareGradientColors()` recomputes both from the stop position and the block width on every render of `SquareBadgesRow`, and an earlier block revision persisted them along with the settings bundle. The accompanying app-server alignment command drops them.

## Alignment

https://github.com/Frontify/app-server/pull/33641

# Block settings usage

App: `clexy16s300010pw1gf0c4bne`

| Metric | Value |
| --- | ---: |
| Customers scanned | 1,877 |
| Customers with blocks | 727 |
| Total blocks | 6,079 |
| Distinct fields | 18 |

## Field usage

`% blocks` is share of all blocks carrying the field. `% customers` is share of tenants where it appears at least once.

| Field | Blocks | % blocks | Customers | % customers | Types |
| --- | ---: | ---: | ---: | ---: | --- |
| `gradientColors[]` | 16,244 | 267.2% | 727 | 100.0% | object |
| `gradientColors[].color` | 16,244 | 267.2% | 727 | 100.0% | object |
| `gradientColors[].color.blue` | 16,244 | 267.2% | 727 | 100.0% | integer |
| `gradientColors[].color.green` | 16,244 | 267.2% | 727 | 100.0% | integer |
| `gradientColors[].color.red` | 16,244 | 267.2% | 727 | 100.0% | integer |
| `gradientColors[].position` | 14,043 | 231.0% | 724 | 99.6% | integer |
| `gradientColors[].color.name` | 11,521 | 189.5% | 714 | 98.2% | string |
| `gradientColors[].color.alpha` | 11,220 | 184.6% | 683 | 93.9% | integer 99.9%, number 0.1% |
| `gradientColors` | 6,079 | 100.0% | 727 | 100.0% | array |
| `displayCss` | 6,077 | 100.0% | 727 | 100.0% | boolean |
| `heightSimple` | 6,077 | 100.0% | 727 | 100.0% | string |
| `isHeightCustom` | 6,077 | 100.0% | 727 | 100.0% | boolean |
| `isOrientationCustom` | 6,077 | 100.0% | 727 | 100.0% | boolean |
| `orientationSimple` | 6,077 | 100.0% | 727 | 100.0% | string |
| `gradientColors[].isReverse` | 2,347 | 38.6% | 267 | 36.7% | boolean |
| `gradientColors[].level` | 2,347 | 38.6% | 267 | 36.7% | integer |
| `heightCustom` | 542 | 8.9% | 74 | 10.2% | string |
| `orientationCustom` | 375 | 6.2% | 51 | 7.0% | string |

## Mixed types

| Field | Breakdown |
| --- | --- |
| `gradientColors[].color.alpha` | integer 11,208 (99.9%), number 12 (0.1%) |

_Generated 2026-09-09T12:14:33.581Z from `rundeck.log`._


---

Schema validation script ran here: [https://rundeck-engineering.frontify.io/execution/show/277437#nodes](https://rundeck-engineering.frontify.io/execution/show/277437#nodes)