### PR TITLE
feat(CodeSnippetBlock): add settings schema

### DIFF
--- a/.releases/added-settings-schema-for-validation-1af0fc90.md
+++ b/.releases/added-settings-schema-for-validation-1af0fc90.md
@@ -1,0 +1,5 @@
+---
+blocks: [code-snippet-block]
+---
+
+added settings schema for validation

--- a/packages/code-snippet-block/manifest.json
+++ b/packages/code-snippet-block/manifest.json
@@ -1,5 +1,172 @@
 {
     "appId": "cl7gar8ts00013muqwzjp8j9c",
-    "i18nFields": ["content"],
-    "searchFields": [{ "settingId": "content", "type": "string" }]
+    "settingsSchema": {
+        "type": "object",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "color": {
+                "type": ["null", "object"],
+                "required": ["red", "green", "blue"],
+                "additionalProperties": false,
+                "properties": {
+                    "red": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "green": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "blue": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "alpha": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "name": { "type": "string", "frontify-api-read": true, "frontify-api-write": true }
+                }
+            }
+        },
+        "required": [
+            "language",
+            "theme",
+            "withHeading",
+            "withRowNumbers",
+            "hasBorder",
+            "borderStyle",
+            "borderWidth",
+            "borderColor",
+            "hasExtendedCustomRadius",
+            "extendedRadiusChoice"
+        ],
+        "additionalProperties": false,
+        "properties": {
+            "content": {
+                "type": "string",
+                "frontify-serializable": true,
+                "frontify-serialization-index": 1,
+                "frontify-translatable": true,
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "language": {
+                "type": "string",
+                "enum": [
+                    "c",
+                    "coffeescript",
+                    "cpp",
+                    "csharp",
+                    "css",
+                    "go",
+                    "html",
+                    "java",
+                    "javascript",
+                    "json",
+                    "jsx",
+                    "kotlin",
+                    "livescript",
+                    "markdown",
+                    "php",
+                    "plain",
+                    "python",
+                    "sass",
+                    "shell",
+                    "sql",
+                    "swift",
+                    "tsx",
+                    "typescript",
+                    "xml",
+                    "yaml"
+                ],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "theme": {
+                "type": "string",
+                "enum": [
+                    "abcdef",
+                    "androidstudio",
+                    "atomone",
+                    "bbedit",
+                    "bespin",
+                    "darcula",
+                    "default",
+                    "dracula",
+                    "duotoneDark",
+                    "duotoneLight",
+                    "eclipse",
+                    "githubDark",
+                    "githubLight",
+                    "gruvboxDark",
+                    "okaidia",
+                    "sublime",
+                    "xcodeDark",
+                    "xcodeLight"
+                ],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "withHeading": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "withRowNumbers": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "hasBorder": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "borderStyle": {
+                "type": "string",
+                "enum": ["Solid", "Dashed", "Dotted"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "borderWidth": {
+                "type": "string",
+                "pattern": "^[0-9]+px$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "borderColor": { "$ref": "#/$defs/color" },
+            "hasExtendedCustomRadius": { "type": "boolean", "frontify-api-read": true, "frontify-api-write": true },
+            "extendedRadiusChoice": {
+                "type": "string",
+                "enum": ["None", "Small", "Medium", "Large"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "extendedRadiusTopLeft": {
+                "type": "string",
+                "pattern": "^([0-9]+px)?$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "extendedRadiusTopRight": {
+                "type": "string",
+                "pattern": "^([0-9]+px)?$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "extendedRadiusBottomLeft": {
+                "type": "string",
+                "pattern": "^([0-9]+px)?$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "extendedRadiusBottomRight": {
+                "type": "string",
+                "pattern": "^([0-9]+px)?$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            }
+        }
+    }
 }


### PR DESCRIPTION
# Data fix PR for anomalies

https://github.com/Frontify/app-server/pull/33660

## Schema notes

- `borderStyle` keeps the capitalised sidebar values (`Solid` / `Dashed` / `Dotted`) that `getBorderSettings` writes, not the lowercase CSS keywords.
- `borderColor` is nullable: the block renders `borderColor || DEFAULT_BORDER_COLOR`, and 16 blocks already store `null`.
- `language` and `theme` list every sidebar choice, including the ones no tenant uses yet (`csharp`, `eclipse`, `yaml`).
- `content` is the only translatable setting, and stays serializable so it remains searchable (it replaces the previous `i18nFields` / `searchFields` entries).
- The extended corner radii are optional and only meaningful while `hasExtendedCustomRadius` is on, matching the callout block.

Everything the block never reads (`radiusValue`, `project`, `lineStyle`, `lineWidth`, `withBorder`, `extendedMargin*`, `hasExtendedCustomMargin`) is left out of the schema and removed by the data fix.

# Block settings usage

App: `cl7gar8ts00013muqwzjp8j9c`

| Metric | Value |
| --- | ---: |
| Customers scanned | 1,879 |
| Customers with blocks | 622 |
| Total blocks | 24,994 |
| Distinct fields | 31 |

## Field usage

`% blocks` is share of all blocks carrying the field. `% customers` is share of tenants where it appears at least once.

| Field | Blocks | % blocks | Customers | % customers | Types |
| --- | ---: | ---: | ---: | ---: | --- |
| `extendedRadiusChoice` | 24,988 | 100.0% | 622 | 100.0% | string |
| `hasExtendedCustomRadius` | 24,988 | 100.0% | 622 | 100.0% | boolean |
| `language` | 24,988 | 100.0% | 622 | 100.0% | string |
| `theme` | 24,988 | 100.0% | 622 | 100.0% | string |
| `withHeading` | 24,988 | 100.0% | 622 | 100.0% | boolean |
| `withRowNumbers` | 24,988 | 100.0% | 622 | 100.0% | boolean |
| `borderColor` | 24,988 | 100.0% | 622 | 100.0% | object (24,972), null (16) |
| `borderStyle` | 24,985 | 100.0% | 622 | 100.0% | string |
| `hasBorder` | 24,984 | 100.0% | 622 | 100.0% | boolean |
| `borderWidth` | 24,983 | 100.0% | 622 | 100.0% | string |
| `borderColor.alpha` | 24,972 | 99.9% | 622 | 100.0% | integer (24,967), number (5) |
| `borderColor.blue` | 24,972 | 99.9% | 622 | 100.0% | integer |
| `borderColor.green` | 24,972 | 99.9% | 622 | 100.0% | integer |
| `borderColor.red` | 24,972 | 99.9% | 622 | 100.0% | integer |
| `content` | 23,391 | 93.6% | 502 | 80.7% | string |
| `borderColor.name` | 10,921 | 43.7% | 163 | 26.2% | string |
| `radiusValue` | 10,787 | 43.2% | 151 | 24.3% | string |
| `project` | 429 | 1.7% | 28 | 4.5% | integer |
| `extendedRadiusBottomLeft` | 127 | 0.5% | 16 | 2.6% | string |
| `extendedRadiusTopLeft` | 76 | 0.3% | 17 | 2.7% | string |
| `extendedRadiusBottomRight` | 65 | 0.3% | 16 | 2.6% | string |
| `extendedRadiusTopRight` | 64 | 0.3% | 15 | 2.4% | string |
| `lineStyle` | 5 | 0.0% | 1 | 0.2% | string |
| `lineWidth` | 5 | 0.0% | 1 | 0.2% | string |
| `withBorder` | 5 | 0.0% | 1 | 0.2% | boolean |
| `extendedMarginChoice` | 4 | 0.0% | 1 | 0.2% | string |
| `hasExtendedCustomMargin` | 4 | 0.0% | 1 | 0.2% | boolean |
| `extendedMarginBottom` | 2 | 0.0% | 1 | 0.2% | string |
| `extendedMarginLeft` | 2 | 0.0% | 1 | 0.2% | string |
| `extendedMarginRight` | 2 | 0.0% | 1 | 0.2% | string |
| `extendedMarginTop` | 2 | 0.0% | 1 | 0.2% | string |

The `borderColor` rows differ from the generated report: that one splits the 24,988 blocks carrying the key into an `object` row of 24,020 and drops the `null` occurrences, which made the child channels look more frequent than their parent. Re-aggregated straight from `rundeck.log`, the key is present on every block that has settings at all.

---

Anomalies the data fix has to repair, all found in `rundeck.log`:

- `language`: `ts` (not a sidebar choice) → `typescript`
- `theme`: `evaLight` (a theme the block dropped) → `default`
- `borderWidth`: `""`, `0`, `1` → `1px` / `0px` / `1px`
- `hasExtendedCustomRadius` is on for blocks that carry only some of the four corners


---

Schema validation script here: https://rundeck-engineering.frontify.io/execution/show/256245#nodes