### PR TITLE
feat(StorybookBlock): add settings schema

### DIFF
--- a/packages/storybook-block/manifest.json
+++ b/packages/storybook-block/manifest.json
@@ -1,3 +1,135 @@
 {
-    "appId": "cl5wd1za500010sw8g3onl5ly"
+    "appId": "cl5wd1za500010sw8g3onl5ly",
+    "settingsSchema": {
+        "type": "object",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "color": {
+                "type": ["null", "object"],
+                "required": ["red", "green", "blue"],
+                "additionalProperties": false,
+                "properties": {
+                    "red": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "green": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "blue": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "alpha": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1,
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    },
+                    "name": {
+                        "type": "string",
+                        "frontify-api-read": true,
+                        "frontify-api-write": true
+                    }
+                }
+            }
+        },
+        "required": [
+            "style",
+            "isCustomHeight",
+            "heightChoice",
+            "positioning",
+            "hasBorder",
+            "borderColor",
+            "borderStyle",
+            "borderWidth",
+            "hasRadius",
+            "radiusChoice"
+        ],
+        "additionalProperties": false,
+        "properties": {
+            "style": {
+                "type": "string",
+                "enum": ["Default", "WithAddons"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "url": {
+                "type": "string",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "isCustomHeight": {
+                "type": "boolean",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "heightChoice": {
+                "type": "string",
+                "enum": ["Small", "Medium", "Large"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "heightValue": {
+                "type": "string",
+                "pattern": "^(auto|[0-9]+px)$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "positioning": {
+                "type": "string",
+                "enum": ["Vertical", "Horizontal"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "hasBorder": {
+                "type": "boolean",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "borderColor": {
+                "$ref": "#/$defs/color"
+            },
+            "borderStyle": {
+                "type": "string",
+                "enum": ["Solid", "Dotted", "Dashed"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "borderWidth": {
+                "type": "string",
+                "pattern": "^[0-9]+px$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "hasRadius": {
+                "type": "boolean",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "radiusChoice": {
+                "type": "string",
+                "enum": ["None", "Small", "Medium", "Large"],
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            },
+            "radiusValue": {
+                "type": "string",
+                "pattern": "^[0-9]+px$",
+                "frontify-api-read": true,
+                "frontify-api-write": true
+            }
+        }
+    }
 }

--- a/packages/storybook-block/src/settings.ts
+++ b/packages/storybook-block/src/settings.ts
@@ -74,7 +74,7 @@ export const settings = defineSettings({
                     id: HEIGHT_VALUE_ID,
                     type: 'input',
                     placeholder: 'e.g. 500px',
-                    defaultValue: StorybookHeight.Medium,
+                    defaultValue: heights[StorybookHeight.Medium],
                     rules: [numericalOrPixelRule, minimumNumericalOrPixelOrAutoRule(MIN_HEIGHT_VALUE)],
                     onChange: (bundle) => appendUnit(bundle, HEIGHT_VALUE_ID),
                 },


### PR DESCRIPTION
[GCM-505](https://linear.app/frontify/issue/GCM-505/storybook-block)

# Data fix PR for anomalies

https://github.com/Frontify/app-server/pull/33668

## Notes

- The 10 settings that are present on 100% of the blocks are `required`, everything else is optional.
- `borderColor` is modelled with the shared nullable `color` `$defs`; the 73 blocks carrying the legacy short keys (`r`/`g`/`b`/`a`) are normalized by the data fix.
- The legacy `project`, `target-type` and `target-choices` settings are not part of the schema and are removed by the data fix.
- `heightValue` allows `auto` next to pixel values, because `minimumNumericalOrPixelOrAutoRule` accepts it.
- Drive-by: the `heightValue` default was `StorybookHeight.Medium` (the literal `Medium`) instead of `heights[StorybookHeight.Medium]` (`400px`), so newly created blocks would have written a value the schema rejects.

# Block settings usage

App: `cl5wd1za500010sw8g3onl5ly`

| Metric | Value |
| --- | ---: |
| Customers scanned | 1,879 |
| Customers with blocks | 824 |
| Total blocks | 30,642 |
| Distinct fields | 25 |

## Field usage

`% blocks` is share of all blocks carrying the field. `% customers` is share of tenants where it appears at least once.

| Field | Blocks | % blocks | Customers | % customers | Types |
| --- | ---: | ---: | ---: | ---: | --- |
| `borderColor` | 30,642 | 100.0% | 824 | 100.0% | object |
| `borderStyle` | 30,642 | 100.0% | 824 | 100.0% | string |
| `borderWidth` | 30,642 | 100.0% | 824 | 100.0% | string |
| `hasBorder` | 30,642 | 100.0% | 824 | 100.0% | boolean |
| `hasRadius` | 30,642 | 100.0% | 824 | 100.0% | boolean |
| `heightChoice` | 30,642 | 100.0% | 824 | 100.0% | string |
| `isCustomHeight` | 30,642 | 100.0% | 824 | 100.0% | boolean |
| `positioning` | 30,642 | 100.0% | 824 | 100.0% | string |
| `radiusChoice` | 30,642 | 100.0% | 824 | 100.0% | string |
| `style` | 30,642 | 100.0% | 824 | 100.0% | string |
| `borderColor.blue` | 30,569 | 99.8% | 824 | 100.0% | integer |
| `borderColor.green` | 30,569 | 99.8% | 824 | 100.0% | integer |
| `borderColor.red` | 30,569 | 99.8% | 824 | 100.0% | integer |
| `borderColor.alpha` | 30,440 | 99.3% | 822 | 99.8% | integer |
| `heightValue` | 30,368 | 99.1% | 821 | 99.6% | string |
| `url` | 28,414 | 92.7% | 527 | 64.0% | string |
| `borderColor.name` | 9,357 | 30.5% | 384 | 46.6% | string |
| `radiusValue` | 6,665 | 21.8% | 149 | 18.1% | string |
| `project` | 2,036 | 6.6% | 133 | 16.1% | integer |
| `borderColor.a` | 73 | 0.2% | 16 | 1.9% | integer |
| `borderColor.b` | 73 | 0.2% | 16 | 1.9% | integer |
| `borderColor.g` | 73 | 0.2% | 16 | 1.9% | integer |
| `borderColor.r` | 73 | 0.2% | 16 | 1.9% | integer |
| `target-choices` | 26 | 0.1% | 2 | 0.2% | array |
| `target-type` | 26 | 0.1% | 2 | 0.2% | string |

---

Schema validation script: _not run yet_
